### PR TITLE
Publish in MavenCentral

### DIFF
--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -11,6 +11,9 @@ jobs:
 
       - name: Close and promote staging repository
         uses: docker://docker.tuenti.io/android/mistica_builder:2
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
         with:
           args: './gradlew closeAndReleaseRepository -DSTAGING_PROFILE_ID="$(./gradlew getStagingProfile  | sed -n -e "s/^Received staging profile id: //p")"'
 

--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -6,5 +6,11 @@ jobs:
   promote:
     runs-on: self-hosted-novum
     steps:
-      - run: 'echo TODO Promote'
-        shell: bash
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Close and promote staging repository
+        uses: docker://docker.tuenti.io/android/mistica_builder:2
+        with:
+          args: './gradlew closeAndReleaseRepository -DSTAGING_PROFILE_ID="$(./gradlew getStagingProfile  | sed -n -e "s/^Received staging profile id: //p")"'
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "Release library"
+name: "Release library to MavenCentral"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,50 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - run: 'echo TODO Autotest'
-        shell: bash
+      - name: Check permissions
+          id: check
+          uses: scherermichael-oss/action-has-permission@master
+          with:
+            required-permission: admin
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check permissions
+          if: "! steps.check.outputs.has-permission"
+          run: exit 1
+
+      - name: Build library
+        if: steps.check.outputs.has-permission
+        uses: docker://docker.tuenti.io/android/mistica_builder:2
+        with:
+          args: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
+
+      - name: Release library
+        if: steps.check.outputs.has-permission
+        uses: docker://docker.tuenti.io/android/mistica_builder:2
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+        with:
+          args: 'bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.inputs.libraryVersion }}'
+
+      - name: Release catalog
+        if: steps.check.outputs.has-permission
+        uses: docker://docker.tuenti.io/android/mistica_builder:2
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+        with:
+          args: 'bash ./gradlew :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.inputs.libraryVersion }}'
+
+      - name: Create Release in github
+        if: steps.check.outputs.has-permission
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.libraryVersion }}
+          release_name: ${{ github.event.inputs.libraryVersion }}
+          body: ${{ github.event.inputs.releaseDescription }}
+          draft: true
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check permissions
-          id: check
-          uses: scherermichael-oss/action-has-permission@master
-          with:
-            required-permission: admin
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: check
+        uses: scherermichael-oss/action-has-permission@master
+        with:
+          required-permission: admin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check permissions
-          if: "! steps.check.outputs.has-permission"
-          run: exit 1
+        if: "! steps.check.outputs.has-permission"
+        run: exit 1
 
       - name: Build library
         if: steps.check.outputs.has-permission

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
         env:
           MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
           MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
-            ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-            ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-            ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         with:
           args: 'bash ./gradlew :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.inputs.libraryVersion }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
         env:
           MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
           MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         with:
           args: 'bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.inputs.libraryVersion }}'
 
@@ -48,6 +51,9 @@ jobs:
         env:
           MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
           MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+            ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+            ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+            ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         with:
           args: 'bash ./gradlew :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.inputs.libraryVersion }}'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,17 +13,13 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.2.1"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 
 apply plugin: 'io.codearte.nexus-staging'
 nexusStaging {
-    //serverUrl = "https://s01.oss.sonatype.org/service/local/" //required only for projects registered in Sonatype after 2021-02-24
-    packageGroup = "com.telefonica" //optional if packageGroup == project.getGroup()
-    stagingProfileId = "com.telefonica" //when not defined will be got from server using "packageGroup"
+    packageGroup = "com.telefonica"
+    stagingProfileId = "com.telefonica"
     stagingProfileId = System.getProperty("STAGING_PROFILE_ID")
     username = System.getenv("MOBILE_MAVENCENTRAL_USER")
     password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ nexusStaging {
     //serverUrl = "https://s01.oss.sonatype.org/service/local/" //required only for projects registered in Sonatype after 2021-02-24
     packageGroup = "com.telefonica" //optional if packageGroup == project.getGroup()
     stagingProfileId = "com.telefonica" //when not defined will be got from server using "packageGroup"
-    stagingRepositoryId = "comtelefonica-1014"
+    stagingProfileId = System.getProperty("STAGING_PROFILE_ID")
     username = System.getenv("MOBILE_MAVENCENTRAL_USER")
     password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,21 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.2.1"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+apply plugin: 'io.codearte.nexus-staging'
+nexusStaging {
+    //serverUrl = "https://s01.oss.sonatype.org/service/local/" //required only for projects registered in Sonatype after 2021-02-24
+    packageGroup = "com.telefonica" //optional if packageGroup == project.getGroup()
+    stagingProfileId = "com.telefonica" //when not defined will be got from server using "packageGroup"
+    stagingRepositoryId = "comtelefonica-1014"
+    username = System.getenv("MOBILE_MAVENCENTRAL_USER")
+    password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
 }
 
 allprojects {

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -31,34 +31,4 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 }
 
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username System.env.NEXUS_USER
-                password System.env.NEXUS_PASS
-            }
-            url "https://nexusng.tuenti.io/repository/maven-release-private/"
-        }
-    }
-    publications {
-        impl(MavenPublication) {
-            artifact 'build/outputs/aar/catalog-release.aar'
-            artifact(sourceJar)
-            groupId 'com.telefonica.mistica'
-            artifactId 'mistica-catalog'
-            version version
-
-            pom.withXml {
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                configurations.implementation.allDependencies.each {
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.group)
-                    dependencyNode.appendNode('artifactId', it.name)
-                    dependencyNode.appendNode('version', it.version)
-                }
-            }
-        }
-    }
-}
+apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -38,34 +38,4 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 }
 
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username System.env.NEXUS_USER
-                password System.env.NEXUS_PASS
-            }
-            url "https://nexusng.tuenti.io/repository/maven-release-private/"
-        }
-    }
-    publications {
-        impl(MavenPublication) {
-            artifact 'build/outputs/aar/library-release.aar'
-            artifact(sourceJar)
-            groupId 'com.telefonica.mistica'
-            artifactId 'mistica'
-            version version
-
-            pom.withXml {
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                configurations.implementation.allDependencies.each {
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.group)
-                    dependencyNode.appendNode('artifactId', it.name)
-                    dependencyNode.appendNode('version', it.version)
-                }
-            }
-        }
-    }
-}
+apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -116,8 +116,8 @@ publishing {
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
             credentials {
-                username System.getProperty("MOBILE_MAVENCENTRAL_USER")
-                password System.getProperty("MOBILE_MAVENCENTRAL_PASSWORD")
+                username System.getenv("MOBILE_MAVENCENTRAL_USER")
+                password System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
             }
         }
     }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -132,12 +132,15 @@ publishing {
 }
 
 println(System.getenv("ORG_GRADLE_PROJECT_signingKeyId"))
-println(System.getenv("signingKeyId"))
+println(findProperty("signingKeyId"))
 
 signing {
-    def signingKeyId = findProperty("signingKeyId")
-    def signingKey = findProperty("signingKey")
-    def signingPassword = findProperty("signingPassword")
+//    def signingKeyId = findProperty("signingKeyId")
+//    def signingKey = findProperty("signingKey")
+//    def signingPassword = findProperty("signingPassword")
+    def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_signingKeyId")
+    def signingKey = System.getenv("ORG_GRADLE_PROJECT_signingKey")
+    def signingPassword = System.getenv("ORG_GRADLE_PROJECT_signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -124,5 +124,9 @@ publishing {
 }
 
 signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -131,8 +131,8 @@ publishing {
     }
 }
 
-println(System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY"))
-println(System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID"))
+println(System.getenv("ORG_GRADLE_PROJECT_signingKeyId"))
+println(System.getenv("signingKeyId"))
 
 signing {
     def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID")

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -132,9 +132,9 @@ publishing {
 }
 
 signing {
-    def signingKeyId = findProperty("signingKeyId")
-    def signingKey = findProperty("signingKey")
-    def signingPassword = findProperty("signingPassword")
+    def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID")
+    def signingKey = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
+    def signingPassword = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -131,7 +131,8 @@ publishing {
     }
 }
 
-println("ORG_GRADLE_PROJECT_SIGNINGKEYID")
+println(System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY"))
+println(System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID"))
 
 signing {
     def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID")

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -8,6 +8,7 @@ artifacts {
 }
 
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 ext {
     PUBLISH_GROUP_ID = 'com.telefonica'
@@ -114,11 +115,14 @@ publishing {
             def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
             credentials {
                 username System.getenv("MOBILE_MAVENCENTRAL_USER")
                 password System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -99,11 +99,19 @@ publishing {
                     def dependenciesNode = asNode().appendNode('dependencies')
 
                     project.configurations.getByName("implementation").allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+                        if (it.group != "com.telefonica.mistica" && it.name != "library") {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
                     }
+
+                    //Add a dependency with the library
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', PUBLISH_GROUP_ID)
+                    dependencyNode.appendNode('artifactId', PUBLISH_ARTIFACT_ID)
+                    dependencyNode.appendNode('version', PUBLISH_VERSION)
                 }
             }
         }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -1,0 +1,129 @@
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+ext {
+    PUBLISH_GROUP_ID = 'com.telefonica'
+    PUBLISH_ARTIFACT_ID = 'mistica'
+    PUBLISH_VERSION = version
+
+    PUBLISH_RELEASE_NAME = 'Mistica Android'
+    PUBLISH_CATALOG_NAME = 'Mistica Catalog Android'
+    PUBLISH_DESCRIPTION = 'Mistica is a framework that contains reusable UI components and utilities.'
+    PUBLISH_REPO_URL = 'https://github.com/Telefonica/mistica-android'
+}
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId PUBLISH_GROUP_ID
+            artifactId PUBLISH_ARTIFACT_ID
+            version PUBLISH_VERSION
+
+            artifact("$buildDir/outputs/aar/library-release.aar")
+            artifact androidSourcesJar
+
+            pom {
+                name = PUBLISH_RELEASE_NAME
+                description = PUBLISH_DESCRIPTION
+                url = PUBLISH_REPO_URL
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'android-team-telefonica'
+                        name = 'Android Team'
+                        email = 'cto-android@telefonica.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:github.com/Telefonica/mistica-android.git'
+                    developerConnection = 'scm:git:ssh://github.com/Telefonica/mistica-android.git'
+                    url = 'https://github.com/Telefonica/mistica-android/tree/master'
+                }
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.getByName("implementation").allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+        catalog(MavenPublication) {
+            groupId PUBLISH_GROUP_ID
+            artifactId "$PUBLISH_ARTIFACT_ID-catalog"
+            version PUBLISH_VERSION
+
+            artifact("$buildDir/outputs/aar/catalog-release.aar")
+            artifact androidSourcesJar
+
+            pom {
+                name = PUBLISH_CATALOG_NAME
+                description = PUBLISH_DESCRIPTION
+                url = PUBLISH_REPO_URL
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'android-team-telefonica'
+                        name = 'Android Team'
+                        email = 'cto-android@telefonica.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:github.com/Telefonica/mistica-android.git'
+                    developerConnection = 'scm:git:ssh://github.com/Telefonica/mistica-android.git'
+                    url = 'https://github.com/Telefonica/mistica-android/tree/master'
+                }
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.getByName("implementation").allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "sonatype"
+
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+            credentials {
+                username System.getProperty("MOBILE_MAVENCENTRAL_USER")
+                password System.getProperty("MOBILE_MAVENCENTRAL_PASSWORD")
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -131,16 +131,10 @@ publishing {
     }
 }
 
-println(System.getenv("ORG_GRADLE_PROJECT_signingKeyId"))
-println(findProperty("signingKeyId"))
-
 signing {
-//    def signingKeyId = findProperty("signingKeyId")
-//    def signingKey = findProperty("signingKey")
-//    def signingPassword = findProperty("signingPassword")
-    def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_signingKeyId")
-    def signingKey = System.getenv("ORG_GRADLE_PROJECT_signingKey")
-    def signingPassword = System.getenv("ORG_GRADLE_PROJECT_signingPassword")
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -131,6 +131,8 @@ publishing {
     }
 }
 
+println("ORG_GRADLE_PROJECT_SIGNINGKEYID")
+
 signing {
     def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID")
     def signingKey = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -8,7 +8,6 @@ artifacts {
 }
 
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 ext {
     PUBLISH_GROUP_ID = 'com.telefonica'
@@ -122,8 +121,4 @@ publishing {
             }
         }
     }
-}
-
-signing {
-    sign publishing.publications
 }

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -135,9 +135,9 @@ println(System.getenv("ORG_GRADLE_PROJECT_signingKeyId"))
 println(System.getenv("signingKeyId"))
 
 signing {
-    def signingKeyId = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEYID")
-    def signingKey = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
-    def signingPassword = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Publish releases in MavenCentral.

The steps to publish are going to be:
1. Generate a release with the github action.
2. The result will be a release draft, the user will need to go there and publish the draft.
3. At that moment, the artifact, which is in a staging state in mavenCentral will be published.


### :construction: How do we do it?
There are two github actions, one to publish to staging and the second one to promote the staging repository.

The first one: release.yml sends the library and the catalog to mavenCentral.
And then the second one, closes & promotes the currently opened staging repository

### :test_tube: How can I test this?
- [x] [The publishing](https://github.com/Telefonica/mistica-android/actions/runs/943082573) 
- [ ] The promoting can't be tested now. I've tested it locally and will do a final test when this is integrated.

