### PR TITLE
ANDROID-9581 fix tab indicator color

### DIFF
--- a/library/src/main/res/values/styles_tab_layout.xml
+++ b/library/src/main/res/values/styles_tab_layout.xml
@@ -12,6 +12,6 @@
 		<item name="tabPadding">16dp</item>
 		<item name="iconEndPadding">8dp</item>
 		<item name="tabIndicatorAnimationDuration">300</item>
-		<item name="tabIndicatorColor">?attr/colorControlActivated</item>
+		<item name="tabIndicatorColor">?attr/colorControlActive</item>
 	</style>
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Current tab indicator color is colorControlActivated, it should be colorControlActive

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [x] 🖼️ Screenshots/Videos
![image](https://user-images.githubusercontent.com/944814/123134179-d28f2200-d450-11eb-8444-10337a5bf52c.png)
![image](https://user-images.githubusercontent.com/944814/123134298-f05c8700-d450-11eb-830d-9b95aa2b08a0.png)

- [x] Reviewed by Mistica design team
