### PR TITLE
ANDROID-9679 Fix translations

### DIFF
--- a/library/src/main/res/values-en/strings_load_error_feedback.xml
+++ b/library/src/main/res/values-en/strings_load_error_feedback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="generic_retry" comment="Retry">Retry</string>
-    <string name="error_generic" comment="Oops! Something went wrong.">
-Algo deu errado.</string>
+    <string name="error_generic" comment="Oops! Something went wrong.">Oops! Something went wrong.</string>
 </resources>

--- a/library/src/main/res/values-pt/strings_load_error_feedback.xml
+++ b/library/src/main/res/values-pt/strings_load_error_feedback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="generic_retry" comment="Retry">Reintentar</string>
-    <string name="error_generic" comment="Oops! Something went wrong.">Algo no ha funcionado.</string>
+    <string name="generic_retry" comment="Retry">Tentar novamente</string>
+    <string name="error_generic" comment="Oops! Something went wrong.">Algo deu errado.</string>
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix https://jira.tid.es/browse/ANDROID-9679, where a copy is not properly translated to pt-BR

### :construction: How do we do it?
* Just fix the translations

### ☑️ Checks
- No need to update docs
- No need to test with dark mode or API 21

### :test_tube: How can I test this?
- [X] 🖼️ Screenshots/Videos

Before | After
--- | ---
![Screenshot_2021-07-09-13-32-16-989_br com vivo enterprise](https://user-images.githubusercontent.com/1579029/126137725-e6fd5d68-5ac8-48a6-90c9-d0d61f71a982.jpg) | ![android9679_fix](https://user-images.githubusercontent.com/1579029/126137598-a13eac0a-d442-4eba-8d19-876aa9f33f4b.png)
