### PR TITLE
ANDROID-9827 add max lines attr to title, subtitle and description in…

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/ListsCatalogFragment.kt
@@ -193,7 +193,16 @@ class ListsCatalogFragment : Fragment() {
             {
                 it.configureView(
                     withLongTitle = true,
+                    withTitleMaxLines = 1,
                     withLongDescription = true,
+                    withInverseBackground = withInverseBackground,
+                )
+            },
+            {
+                it.configureView(
+                    withLongTitle = true,
+                    withLongDescription = true,
+                    withDescriptionMaxLines = 2,
                     withInverseBackground = withInverseBackground,
                 )
             },
@@ -300,7 +309,9 @@ class ListsCatalogFragment : Fragment() {
         @SuppressLint("SetTextI18n")
         private fun ListRowView.configureView(
             withLongTitle: Boolean = false,
+            withTitleMaxLines: Int? = null,
             withLongDescription: Boolean? = null,
+            withDescriptionMaxLines: Int? = null,
             withAsset: Boolean = false,
             @AssetType withAssetType: Int = TYPE_SMALL_ICON,
             withAction: Boolean = false,
@@ -308,6 +319,7 @@ class ListsCatalogFragment : Fragment() {
             withBadgeNumeric: Int = 0,
             withHeadline: Boolean = false,
             withSubtitle: Boolean = false,
+            withSubtitleMaxLines: Int? = null,
             withBadgeDescription: String? = null,
             withInverseBackground: Boolean,
         ) {
@@ -324,12 +336,17 @@ class ListsCatalogFragment : Fragment() {
                 setHeadlineLayout(ListRowView.HEADLINE_NONE)
             }
 
-            setTitle(if (withLongTitle) "Title long enough to need 2 lines to show it, just for testing purposes." else "Title")
+            withTitleMaxLines?.let { setTitleMaxLines(it) }
+            setTitle(if (withLongTitle) "Title long enough to need more than 2 lines to show it, just for testing purposes." +
+                    "More sample text just for testing purposes." else "Title")
+            withSubtitleMaxLines?.let { setSubtitleMaxLines(it) }
             setSubtitle(if (withSubtitle) "Any Subtitle" else null)
+            withDescriptionMaxLines?.let { setDescriptionMaxLines(it) }
             setDescription(
                 withLongDescription?.let { long ->
                     if (long) {
-                        "Description long enough to need 2 lines to show it, just for testing purposes."
+                        "Description long enough to need more than 2 lines to show it, just for testing purposes." +
+                                "Description long enough to need more than 2 lines to show it, just for testing purposes."
                     } else {
                         "Description"
                     }

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.TypedArray
 import android.graphics.drawable.Drawable
+import android.text.TextUtils
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -45,13 +46,28 @@ import com.telefonica.mistica.util.getThemeColor
     ),
     BindingMethod(
         type = ListRowView::class,
+        attribute = "listRowTitleMaxLines",
+        method = "setTitleMaxLines"
+    ),
+    BindingMethod(
+        type = ListRowView::class,
         attribute = "listRowSubtitle",
         method = "setSubtitle"
     ),
     BindingMethod(
         type = ListRowView::class,
+        attribute = "listRowSubtitleMaxLines",
+        method = "setSubtitleMaxLines"
+    ),
+    BindingMethod(
+        type = ListRowView::class,
         attribute = "listRowDescription",
         method = "setDescription"
+    ),
+    BindingMethod(
+        type = ListRowView::class,
+        attribute = "listRowDescriptionMaxLines",
+        method = "setDescriptionMaxLines"
     ),
     BindingMethod(
         type = ListRowView::class,
@@ -147,6 +163,7 @@ class ListRowView @JvmOverloads constructor(
                 defStyleAttr,
                 0
             )
+            setTitleMaxLines(styledAttrs.getInteger(R.styleable.ListRowView_listRowTitleMaxLines, -1))
             styledAttrs.getText(R.styleable.ListRowView_listRowTitle)?.let { setTitle(it) }
             styledAttrs.getResourceId(
                 R.styleable.ListRowView_listRowHeadlineLayout,
@@ -160,7 +177,9 @@ class ListRowView @JvmOverloads constructor(
                     currentHeadlineLayoutRes != HEADLINE_NONE
                 )
             )
+            setSubtitleMaxLines(styledAttrs.getInteger(R.styleable.ListRowView_listRowSubtitleMaxLines, -1))
             setSubtitle(styledAttrs.getText(R.styleable.ListRowView_listRowSubtitle))
+            setDescriptionMaxLines(styledAttrs.getInteger(R.styleable.ListRowView_listRowDescriptionMaxLines, -1))
             setDescription(styledAttrs.getText(R.styleable.ListRowView_listRowDescription))
             val isBoxed = styledAttrs.getBoolean(R.styleable.ListRowView_listRowIsBoxed, false)
             val backgroundTypeDefaultValue = if (isBoxed) {
@@ -239,6 +258,13 @@ class ListRowView @JvmOverloads constructor(
     fun setTitle(text: CharSequence?) {
         titleTextView.text = text
         recalculateTitleBottomConstraints()
+    }
+
+    fun setTitleMaxLines(maxLines: Int) {
+        if (maxLines > 0) {
+            titleTextView.maxLines = maxLines
+            titleTextView.ellipsize = TextUtils.TruncateAt.END
+        }
     }
 
     @Deprecated(
@@ -341,10 +367,24 @@ class ListRowView @JvmOverloads constructor(
         recalculateAssetPosition()
     }
 
+    fun setSubtitleMaxLines(maxLines: Int) {
+        if (maxLines > 0) {
+            subtitleTextView.maxLines = maxLines
+            subtitleTextView.ellipsize = TextUtils.TruncateAt.END
+        }
+    }
+
     fun setDescription(text: CharSequence?) {
         descriptionTextView.setTextAndVisibility(text)
         recalculateTitleBottomConstraints()
         recalculateAssetPosition()
+    }
+
+    fun setDescriptionMaxLines(maxLines: Int) {
+        if (maxLines > 0) {
+            descriptionTextView.maxLines = maxLines
+            descriptionTextView.ellipsize = TextUtils.TruncateAt.END
+        }
     }
 
     fun setActionLayout(@LayoutRes layoutRes: Int = ACTION_NONE) {

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -16,8 +16,11 @@ Implemented as a custom view, `com.telefonica.mistica.ListRowView` can be used i
 	</attr>
 	<attr name="listRowHeadlineVisible" format="boolean" />
 	<attr name="listRowTitle" format="string" />
+	<attr name="listRowTitleMaxLines" format="integer" />
 	<attr name="listRowSubtitle" format="string" />
+	<attr name="listRowSubtitleMaxLines" format="integer" />
 	<attr name="listRowDescription" format="string" />
+	<attr name="listRowDescriptionMaxLines" format="integer" />
 	<attr name="listRowAssetDrawable" format="reference" />
 	<attr name="listRowAssetType" format="enum">
 		<enum name="image" value="0" />

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -44,8 +44,11 @@
         </attr>
         <attr name="listRowHeadlineVisible" format="boolean" />
         <attr name="listRowTitle" format="string" />
+        <attr name="listRowTitleMaxLines" format="integer" />
         <attr name="listRowSubtitle" format="string" />
+        <attr name="listRowSubtitleMaxLines" format="integer" />
         <attr name="listRowDescription" format="string" />
+        <attr name="listRowDescriptionMaxLines" format="integer" />
         <attr name="listRowAssetDrawable" format="reference" />
         <attr name="listRowAssetType" format="enum">
             <enum name="image" value="0" />


### PR DESCRIPTION
### :goal_net: What's the goal?
Add max lines attr to title, subtitle and description in listRowView component

### :construction: How do we do it?
Three new attributes to support max lines in title, subtitle and description in `ListRowView` component are added. The attributes are `listRowTitleMaxLines`, `listRowSubtitleMaxLines` and `listRowDescriptionMaxLines`.
The catalog is updated to show how is the impact in the current behavior.
This is not a breaking change neither a bugfix, so the new version should be 2.5.0

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
(Checking with UI team if they need a beta version of the catalog or the verification by screenshots is enough)
- [x] 🖼️ Screenshots/Videos
![image](https://user-images.githubusercontent.com/944814/131672515-55737da4-776f-46b1-b780-c07a6458f127.png)
![image](https://user-images.githubusercontent.com/944814/131672570-0d26ac4e-7141-4fd0-b9e3-62512f0a76c2.png)

- [x] Reviewed by Mistica design team
