### PR TITLE
ANDROID-9847 Fix colors in dialogs

### DIFF
--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -5,7 +5,7 @@
 
     <style name="MisticaTheme_Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
 
-        <item name="colorPrimary">?colorNavigationBarBackground</item>
+        <item name="colorPrimary">?colorBrand</item>
         <item name="colorPrimaryDark">?colorBrandDark</item>
         <item name="android:windowBackground">?colorBackground</item>
         <item name="android:textColorPrimary">@color/text_primary_selector</item>


### PR DESCRIPTION
### :goal_net: What's the goal?
Color primary was set to a color background (that was almost black). I'm setting the color primary in dark mode themes to the colorBrand.

### :construction: How do we do it?


### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?

Before:
![image](https://user-images.githubusercontent.com/4595241/132716851-79067e8c-628c-4a53-b381-3fdb61a97f29.png)

After:
![image](https://user-images.githubusercontent.com/4595241/132716935-73149d38-31ea-4b51-a510-282f7ed1c6db.png)
