### PR TITLE
ANDROID-9856 Make mistica drawable loads to use AppCompatResources

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/TabsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/TabsCatalogFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
@@ -75,7 +76,7 @@ class TabsCatalogFragment : Fragment() {
     private fun addTab(text: String?, checked: Boolean) {
         if (text.isNullOrEmpty()) return
         val tab = tabs.newTab().setText(text)
-        if (checked) tab.icon = context?.getDrawable(R.drawable.ic_tab)
+        if (checked) tab.icon = context?.let { AppCompatResources.getDrawable(it, R.drawable.ic_tab) }
         tabs.addTab(tab)
         pagerAdapter.addTab(text)
     }

--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -20,7 +20,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.ColorUtils
 import com.google.android.material.button.MaterialButton
 import com.telefonica.mistica.R
@@ -96,7 +96,7 @@ class ProgressButton : FrameLayout {
                 ViewGroup.LayoutParams.MATCH_PARENT
             )
             showTextOnly()
-            icon = ContextCompat.getDrawable(context, R.drawable.empty_material_button_icon)
+            icon = AppCompatResources.getDrawable(context, R.drawable.empty_material_button_icon)
             text = ""
         }
 

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -16,7 +16,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -132,7 +132,10 @@ class CalloutView @JvmOverloads constructor(
         if (attrs != null) {
             val styledAttrs = context.theme.obtainStyledAttributes(attrs, R.styleable.CalloutView, defStyleAttr, 0)
 
-            styledAttrs.getDrawable(R.styleable.CalloutView_calloutIcon)?.let { setIconDrawable(it) }
+            styledAttrs.getResourceId(R.styleable.CalloutView_calloutIcon, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
+                ?.let { setIconDrawable(it) }
 
             styledAttrs.getString(R.styleable.CalloutView_calloutTitle)?.let { setTitle(it) }
             styledAttrs.getString(R.styleable.CalloutView_calloutDescription)?.let { setDescription(it) }
@@ -160,7 +163,7 @@ class CalloutView @JvmOverloads constructor(
 
     fun setInverse(inverse: Boolean) {
         val backgroundDrawable = if (inverse) R.drawable.bg_callout_inverse else R.drawable.bg_callout
-        background = ContextCompat.getDrawable(context, backgroundDrawable)
+        background = AppCompatResources.getDrawable(context, backgroundDrawable)
     }
 
     private fun initCloseButton() {

--- a/library/src/main/java/com/telefonica/mistica/card/CardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/card/CardView.kt
@@ -8,8 +8,8 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.cardview.widget.CardView
-import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
@@ -76,7 +76,7 @@ abstract class CardView @JvmOverloads constructor(
         cardElevation = 0F
         radius = resources.getDimension(R.dimen.card_corner_radius)
         minimumWidth = resources.getDimension(R.dimen.card_min_width).toInt()
-        background = ContextCompat.getDrawable(context, R.drawable.card_view_background)
+        background = AppCompatResources.getDrawable(context, R.drawable.card_view_background)
 
         cardContentView = rootView.findViewById(R.id.card_content)
         cardCustomContentLayout = rootView.findViewById(R.id.card_custom_content_layout)

--- a/library/src/main/java/com/telefonica/mistica/card/datacard/DataCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/card/datacard/DataCardView.kt
@@ -3,11 +3,13 @@ package com.telefonica.mistica.card.datacard
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -51,7 +53,10 @@ class DataCardView @JvmOverloads constructor(
                     0
                 )
             setSubtitle(styledAttrs.getText(R.styleable.DataCardView_cardSubtitle))
-            styledAttrs.getDrawable(R.styleable.DataCardView_cardIcon)?.let { setIcon(it) }
+            styledAttrs.getResourceId(R.styleable.DataCardView_cardIcon, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
+                ?.let { setIcon(it) }
             styledAttrs.recycle()
         }
         return rootView

--- a/library/src/main/java/com/telefonica/mistica/card/mediacard/MediaCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/card/mediacard/MediaCardView.kt
@@ -3,12 +3,14 @@ package com.telefonica.mistica.card.mediacard
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -63,7 +65,9 @@ class MediaCardView @JvmOverloads constructor(
                 )
             setPretitle(styledAttrs.getText(R.styleable.MediaCardView_cardPretitle))
             setCardImageContentDescription(styledAttrs.getText(R.styleable.MediaCardView_cardImageContentDescription))
-            styledAttrs.getDrawable(R.styleable.MediaCardView_cardImage)
+            styledAttrs.getResourceId(R.styleable.MediaCardView_cardImage, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
                 ?.let { setCardImage(it) }
             styledAttrs.recycle()
         }

--- a/library/src/main/java/com/telefonica/mistica/contentindicator/ScrollContentIndicator.kt
+++ b/library/src/main/java/com/telefonica/mistica/contentindicator/ScrollContentIndicator.kt
@@ -8,8 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewOutlineProvider
 import android.view.animation.*
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import com.telefonica.mistica.R
 import com.telefonica.mistica.util.getThemeColor
 
@@ -46,7 +46,7 @@ class ScrollContentIndicator @JvmOverloads constructor(
 
         isClickable = true
         isFocusable = true
-        background = ContextCompat.getDrawable(
+        background = AppCompatResources.getDrawable(
             context,
             R.drawable.scroll_content_indicator_clickable_background
         )

--- a/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.emptystate.card
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
@@ -145,7 +147,11 @@ class EmptyStateCardView @JvmOverloads constructor(
             val styledAttrs =
                 theme.obtainStyledAttributes(attrs, R.styleable.EmptyStateCardView, defStyleAttr, 0)
 
-            styledAttrs.getDrawable(R.styleable.EmptyStateCardView_emptyStateCardImage)?.let { setImageDrawable(it) }
+            styledAttrs.getResourceId(R.styleable.EmptyStateCardView_emptyStateCardImage, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
+                ?.let { setImageDrawable(it) }
+
             styledAttrs.getString(R.styleable.EmptyStateCardView_emptyStateCardImageContentDescription)?.let { setImageContentDescription(it) }
             imageSize = styledAttrs.getInteger(R.styleable.EmptyStateCardView_emptyStateCardImageSize, imageSize)
 

--- a/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
@@ -14,7 +14,6 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.content.ContextCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -118,7 +117,7 @@ class EmptyStateCardView @JvmOverloads constructor(
     init {
         LayoutInflater.from(context).inflate(R.layout.empty_state_card_view, this, true)
 
-        background = ContextCompat.getDrawable(context, R.drawable.empty_state_card_view_background)
+        background = AppCompatResources.getDrawable(context, R.drawable.empty_state_card_view_background)
         isFocusable = true
         orientation = VERTICAL
         setPadding(

--- a/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.emptystate.screen
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +14,8 @@ import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -134,7 +137,11 @@ class EmptyStateScreenView @JvmOverloads constructor(
             val styledAttrs =
                 theme.obtainStyledAttributes(attrs, R.styleable.EmptyStateScreenView, defStyleAttr, 0)
 
-            styledAttrs.getDrawable(R.styleable.EmptyStateScreenView_emptyStateScreenImage)?.let { setImageDrawable(it) }
+            styledAttrs.getResourceId(R.styleable.EmptyStateScreenView_emptyStateScreenImage, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
+                ?.let { setImageDrawable(it) }
+
             styledAttrs.getString(R.styleable.EmptyStateScreenView_emptyStateScreenImageContentDescription)?.let { setImageContentDescription(it) }
             imageSize = styledAttrs.getInteger(R.styleable.EmptyStateScreenView_emptyStateScreenImageSize, imageSize)
 

--- a/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
@@ -15,7 +15,6 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R

--- a/library/src/main/java/com/telefonica/mistica/highlightedcard/HighlightedCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/highlightedcard/HighlightedCardView.kt
@@ -5,6 +5,7 @@ import android.graphics.*
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
@@ -14,8 +15,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -151,7 +152,9 @@ class HighlightedCardView @JvmOverloads constructor(
                     0
                 )
 
-            styledAttrs.getDrawable(R.styleable.HighlightedCardView_highlightedCardBackground)
+            styledAttrs.getResourceId(R.styleable.HighlightedCardView_highlightedCardBackground, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
                 ?.let { setCustomBackground(it) }
 
             isInverse = styledAttrs.getBoolean(
@@ -178,7 +181,9 @@ class HighlightedCardView @JvmOverloads constructor(
             )
             styledAttrs.getText(R.styleable.HighlightedCardView_highlightedCardCloseButton)
                 ?.let { setCloseButton(it) }
-            styledAttrs.getDrawable(R.styleable.HighlightedCardView_highlightedCardImage)
+            styledAttrs.getResourceId(R.styleable.HighlightedCardView_highlightedCardImage, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
                 ?.let { setImage(it) }
 
             styledAttrs.recycle()
@@ -242,7 +247,7 @@ class HighlightedCardView @JvmOverloads constructor(
     }
 
     fun setCustomBackground(@DrawableRes imageRes: Int) {
-        setCustomBackground(ContextCompat.getDrawable(context, imageRes)!!)
+        setCustomBackground(AppCompatResources.getDrawable(context, imageRes)!!)
     }
 
     fun setCustomBackground(drawable: Drawable) {
@@ -298,7 +303,7 @@ class HighlightedCardView @JvmOverloads constructor(
             } else {
                 R.drawable.highlighted_card_background
             }
-            container.background = ContextCompat.getDrawable(context, backgroundDrawable)
+            container.background = AppCompatResources.getDrawable(context, backgroundDrawable)
         }
     }
 

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -17,9 +17,9 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.annotation.LayoutRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
@@ -199,7 +199,10 @@ class ListRowView @JvmOverloads constructor(
                     TYPE_SMALL_ICON
                 )
             )
-            setAssetDrawable(styledAttrs.getDrawable(R.styleable.ListRowView_listRowAssetDrawable))
+            val assetDrawable: Drawable? = styledAttrs.getResourceId(R.styleable.ListRowView_listRowAssetDrawable, TypedValue.TYPE_NULL)
+                .takeIf { it != TypedValue.TYPE_NULL }
+                ?.let { AppCompatResources.getDrawable(context, it) }
+            setAssetDrawable(assetDrawable)
             setBadgeInitialState(styledAttrs)
 
             styledAttrs.getResourceId(
@@ -213,7 +216,7 @@ class ListRowView @JvmOverloads constructor(
     }
 
     fun setAssetResource(@DrawableRes resource: Int? = null) {
-        setAssetDrawable(resource?.let { ContextCompat.getDrawable(context, it) })
+        setAssetDrawable(resource?.let { AppCompatResources.getDrawable(context, it) })
     }
 
     fun setAssetDrawable(drawable: Drawable? = null) {
@@ -289,7 +292,7 @@ class ListRowView @JvmOverloads constructor(
             BackgroundType.TYPE_NORMAL -> R.drawable.list_row_background
             else -> R.drawable.list_row_background
         }
-        background = ContextCompat.getDrawable(context, backgroundDrawable)
+        background = AppCompatResources.getDrawable(context, backgroundDrawable)
         configureTextViewsColor(type)
     }
 

--- a/library/src/main/java/com/telefonica/mistica/list/decoration/divider/DividerItemDecoration.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/decoration/divider/DividerItemDecoration.kt
@@ -6,7 +6,7 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.view.View
 import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.RecyclerView
 import com.telefonica.mistica.R
 
@@ -16,7 +16,7 @@ open class DividerItemDecoration @JvmOverloads constructor(
     @DrawableRes drawableRes: Int = R.drawable.generic_divider,
 ) : RecyclerView.ItemDecoration() {
 
-    private val divider: Drawable? = ContextCompat.getDrawable(context, drawableRes)
+    private val divider: Drawable? = AppCompatResources.getDrawable(context, drawableRes)
     private val bounds = Rect()
 
     private var drawableState: IntArray = IntArray(0)


### PR DESCRIPTION
### :goal_net: What's the goal?
Programatic drawable load should be done with `AppCompatResources`, in order to support new vector drawables attributes on old android api versions. This avoids possible crashes on older api versions.
For example, Empty states illustrations loads are crashing without this.

From [link](https://stackoverflow.com/a/43005362):
```
#1 Do you have to support API 4, 5, or 6?
    Yes: No choice but to use ResourcesCompat or ContextCompat.
    No: Keep going to #2.
#2 Do you absolutely need to supply a custom Theme?
    Yes: No choice but to use ResourcesCompat
    No: Use AppCompatResources
```

### :construction: How do we do it?
* Just change all programatic drawable loads to use `AppCompatResources`

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] Just checking image load behaves in same way
