### PR TITLE
ANDROID-9906 Update library module name

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,6 +19,10 @@ android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true
     }
+
+    kotlinOptions {
+        moduleName = "com.telefonica.mistica"
+    }
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
### :goal_net: What's the goal?
The goal of this change is to fix a problem when two libraries with the same module name are included in the same project. The file `META-INF/library_release.kotlin_module` has the same name in both cases and it throws an error.

### :construction: How do we do it?
* Just specifying a name to the library module `com.telefonica.mistica` in this case to avoid duplicates.

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
![imagen](https://user-images.githubusercontent.com/2582348/134860235-6b1e90de-a5de-4e08-ad78-0eff4d957b05.png)

