### PR TITLE
Set default text color for compose themes

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
@@ -42,7 +42,9 @@ fun MisticaTheme(
     }.apply { updateColorsFrom(colors) }
 
     val typography = remember {
-        MisticaTypography()
+        MisticaTypography(
+            defaultTextColor = rememberedColors.textPrimary
+        )
     }.apply { updateWith(brand.fontFamily) }
 
     CompositionLocalProvider(

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -12,6 +13,7 @@ import androidx.compose.ui.unit.sp
 
 class MisticaTypography(
     private var fontFamily: FontFamily = FontFamily.SansSerif,
+    private var defaultTextColor: Color = Color.Unspecified,
 ) {
     var preset8 by mutableStateOf(buildPreset8(), structuralEqualityPolicy())
         private set
@@ -62,6 +64,7 @@ class MisticaTypography(
         TextStyle(
             letterSpacing = 0.sp,
             fontFamily = fontFamily,
+            color = defaultTextColor,
         )
 
     private fun buildPreset8() =


### PR DESCRIPTION
### :goal_net: What's the goal?
Just set default text color on compose themes, so brand and dark mode config changes modifies it.

### :construction: How do we do it?
* Just configure base text style with a default color

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
<img width="320" alt="Captura de pantalla 2021-11-12 a las 13 10 21" src="https://user-images.githubusercontent.com/5360064/141465059-27f6c20c-765d-4fee-8e0a-a8f53b5374cf.png">

