### PR TITLE
ANDROID-10054 - Deleting app tag

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="false"
+        android:supportsRtl="true"
         android:name=".CatalogApplication"
         android:theme="@style/MisticaTheme.Movistar">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
         android:name=".CatalogApplication"
         android:theme="@style/MisticaTheme.Movistar">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
         android:name=".CatalogApplication"
         android:theme="@style/MisticaTheme.Movistar">
 

--- a/catalog/lint.xml
+++ b/catalog/lint.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <issue id="RtlEnabled" severity="ignore" />
     <issue id="HardcodedText" severity="ignore">
         <ignore path="**_catalog.xml" />
     </issue>

--- a/catalog/src/main/AndroidManifest.xml
+++ b/catalog/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 		package="com.telefonica.mistica.catalog"
 		>
 
-	<application android:supportsRtl="false">
+	<application android:supportsRtl="true">
 		<activity
 				android:name="com.telefonica.mistica.catalog.ui.ComponentCatalogActivity"
 				android:exported="false"

--- a/catalog/src/main/AndroidManifest.xml
+++ b/catalog/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 		package="com.telefonica.mistica.catalog"
 		>
 
-	<application android:supportsRtl="true">
+	<application>
 		<activity
 				android:name="com.telefonica.mistica.catalog.ui.ComponentCatalogActivity"
 				android:exported="false"

--- a/library/lint.xml
+++ b/library/lint.xml
@@ -2,6 +2,7 @@
 <lint>
     <issue id="UnusedResources" severity="ignore" />
     <issue id="GradleDependency" severity="ignore" />
+    <issue id="RtlEnabled" severity="ignore" />
     <issue id="ObsoleteLintCustomCheck" severity="ignore" />
     <issue id="VectorPath">
         <ignore path="**/res/drawable/feedback_info_o2.xml"/>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,6 +2,5 @@
     package="com.telefonica.mistica">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <application android:supportsRtl="true" />
 
 </manifest>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,6 +2,5 @@
     package="com.telefonica.mistica">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <application android:supportsRtl="false" />
 
 </manifest>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,5 +2,6 @@
     package="com.telefonica.mistica">
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <application android:supportsRtl="true" />
 
 </manifest>

--- a/library/src/main/res/layout/list_row_item.xml
+++ b/library/src/main/res/layout/list_row_item.xml
@@ -112,6 +112,7 @@
 			android:layout_height="0dp"
 			android:layout_marginTop="9dp"
 			android:paddingEnd="25dp"
+			android:paddingStart="0dp"
 			android:visibility="gone"
 			tools:visibility="visible"
 			app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
### :goal_net: What's the goal?
We're exporting `supportRtls = false` attribute in Mística. This ticket fixes the errors that doesn't enable us to set it to true and then removes it from the manifest.

### :construction: How do we do it?
 I've fixed the lint error (only one) so we can support Rtls (according to Lint).

Then I've excluded the supportRtls tag from the library manifest by ignoring the lint rule that checks it.

The rule was forcing me to put it in the manifest:
```
/Users/gmerino/Workspace/tuenti/mistica-android/library/src/main/AndroidManifest.xml: Error: The project references RTL attributes, but does not explicitly enable or disable RTL support with android:supportsRtl in the manifest [RtlEnabled]
```


### :test_tube: How can I test this?
- Having blue ball should be enough
- Tested lists manually
