### PR TITLE
ANDROID-10116 - Remove library dependency from the pom.xml and adding Mistica instead

### DIFF
--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -99,11 +99,19 @@ publishing {
                     def dependenciesNode = asNode().appendNode('dependencies')
 
                     project.configurations.getByName("implementation").allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+                        if (it.group != "com.telefonica.mistica" && it.name != "library") {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
                     }
+
+                    //Add a dependency with the library
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', PUBLISH_GROUP_ID)
+                    dependencyNode.appendNode('artifactId', PUBLISH_ARTIFACT_ID)
+                    dependencyNode.appendNode('version', PUBLISH_VERSION)
                 }
             }
         }
@@ -141,7 +149,7 @@ publishing {
                     def dependenciesNode = asNode().appendNode('dependencies')
 
                     project.configurations.getByName("implementation").allDependencies.each {
-                        if (it.group != "com.telefonica.mistica" && it.name != "library" && it.name != "library-compose") {
+                        if (it.group != "com.telefonica.mistica" && it.name != "library") {
                             def dependencyNode = dependenciesNode.appendNode('dependency')
                             dependencyNode.appendNode('groupId', it.group)
                             dependencyNode.appendNode('artifactId', it.name)


### PR DESCRIPTION


### :goal_net: What's the goal?
If you check https://search.maven.org/artifact/com.telefonica/mistica-compose/3.2.0/aar
you'll see 
![image](https://user-images.githubusercontent.com/4595241/143587937-24bea1da-490f-49e8-a5f2-612a02acf1d9.png)
We should use "mistica" instead

