### PR TITLE
ANDROID-10046 Error reference in Feedbacks

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Feedbacks.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Feedbacks.kt
@@ -28,6 +28,7 @@ fun Feedbacks(
 
     var title: String by remember { mutableStateOf("") }
     var subtitle: String by remember { mutableStateOf("") }
+    var errorReference: String by remember { mutableStateOf("") }
     var firstButtonText: String? by remember { mutableStateOf(null) }
     var secondButtonText: String? by remember { mutableStateOf(null) }
     var isFirstButtonLoading: Boolean by remember { mutableStateOf(false) }
@@ -38,6 +39,7 @@ fun Feedbacks(
             type = type,
             title = title,
             subtitle = subtitle,
+            errorReference = errorReference,
             firstButtonText = firstButtonText,
             secondButtonText = secondButtonText,
             firstButtonOnClick = {},
@@ -53,6 +55,7 @@ fun Feedbacks(
         ) {
             OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("Title") })
             OutlinedTextField(value = subtitle, onValueChange = { subtitle = it }, label = { Text("Subtitle") })
+            OutlinedTextField(value = errorReference, onValueChange = { errorReference = it }, label = { Text("Error Reference") })
             OutlinedTextField(value = firstButtonText ?: "", onValueChange = { firstButtonText = it }, label = { Text("First Button") })
             OutlinedTextField(value = secondButtonText ?: "", onValueChange = { secondButtonText = it }, label = { Text("Second Button") })
             Row {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/activity/FeedbackScreenCatalogActivity.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/activity/FeedbackScreenCatalogActivity.kt
@@ -15,6 +15,7 @@ class FeedbackScreenCatalogActivity : AppCompatActivity() {
     var type: Int? = null
     var title: String? = null
     var subtitle: String? = null
+    var errorReference: String? = null
 
     @LayoutRes
     var customContentLayout: Int? = null
@@ -38,6 +39,7 @@ class FeedbackScreenCatalogActivity : AppCompatActivity() {
             type?.let { setFeedbackType(it) }
             title?.let { setFeedbackTitle(it) }
             subtitle?.let { setFeedbackSubtitle(it) }
+            errorReference?.let { setFeedbackErrorReference(it) }
             customContentLayout?.let { setCustomContentLayout(it) }
             firstButtonText?.let { setFeedbackFirstButtonText(it) }
             secondButtonText?.let { setFeedbackSecondButtonText(it) }
@@ -60,6 +62,7 @@ class FeedbackScreenCatalogActivity : AppCompatActivity() {
         )
         title = intent.getStringExtra(EXTRA_TITLE)
         subtitle = intent.getStringExtra(EXTRA_SUBTITLE)
+        errorReference = intent.getStringExtra(EXTRA_ERROR_REFERENCE)
         customContentLayout = intent.getIntExtra(
             EXTRA_CUSTOM_CONTENT,
             INVALID_DEFAULT_VALUE
@@ -84,6 +87,7 @@ class FeedbackScreenCatalogActivity : AppCompatActivity() {
         const val EXTRA_TYPE = "extra_type"
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_SUBTITLE = "extra_subtitle"
+        const val EXTRA_ERROR_REFERENCE = "extra_error_reference"
         const val EXTRA_CUSTOM_CONTENT = "extra_custom_content"
         const val EXTRA_FIRST_BUTTON_TEXT = "extra_first_button_text"
         const val EXTRA_SECOND_BUTTON_TEXT = "extra_second_button_text"

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/FeedbackScreenCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/FeedbackScreenCatalogFragment.kt
@@ -37,6 +37,7 @@ class FeedbackScreenCatalogFragment(
         val typeDropDown: DropDownInput = view.findViewById(R.id.dropdown_feedback_type)
         val inputTitle: TextInput = view.findViewById(R.id.input_feedback_title)
         val inputSubtitle: TextInput = view.findViewById(R.id.input_feedback_subtitle)
+        val inputErrorReference: TextInput = view.findViewById(R.id.input_feedback_error_reference)
         val inputFirstButtonText: TextInput = view.findViewById(R.id.input_feedback_first_button)
         val inputSecondButtonText: TextInput = view.findViewById(R.id.input_feedback_second_button)
         val checkBoxSecondButtonAsLink: CheckBoxInput = view.findViewById(R.id.check_feedback_second_button_as_link)
@@ -60,6 +61,7 @@ class FeedbackScreenCatalogFragment(
                 context = view.context,
                 title = inputTitle.toNullableString(),
                 subtitle = inputSubtitle.toNullableString(),
+                errorReference = inputErrorReference.toNullableString(),
                 firstButtonText = inputFirstButtonText.toNullableString(),
                 secondButtonText = inputSecondButtonText.toNullableString(),
                 showSecondButtonAsLink = checkBoxSecondButtonAsLink.isChecked(),
@@ -73,6 +75,7 @@ class FeedbackScreenCatalogFragment(
         @FeedbackType type: Int,
         title: String?,
         subtitle: String?,
+        errorReference: String?,
         @LayoutRes customContentLayout: Int = FeedbackScreenCatalogActivity.INVALID_DEFAULT_VALUE,
         firstButtonText: String?,
         secondButtonText: String?,
@@ -83,6 +86,7 @@ class FeedbackScreenCatalogFragment(
             putExtra(FeedbackScreenCatalogActivity.EXTRA_TYPE, type)
             putExtra(FeedbackScreenCatalogActivity.EXTRA_TITLE, title)
             putExtra(FeedbackScreenCatalogActivity.EXTRA_SUBTITLE, subtitle)
+            putExtra(FeedbackScreenCatalogActivity.EXTRA_ERROR_REFERENCE, errorReference)
             putExtra(FeedbackScreenCatalogActivity.EXTRA_FIRST_BUTTON_TEXT, firstButtonText)
             putExtra(FeedbackScreenCatalogActivity.EXTRA_SECOND_BUTTON_TEXT, secondButtonText)
             putExtra(FeedbackScreenCatalogActivity.EXTRA_CUSTOM_CONTENT, customContentLayout)

--- a/catalog/src/main/res/layout/screen_fragment_feedback_catalog.xml
+++ b/catalog/src/main/res/layout/screen_fragment_feedback_catalog.xml
@@ -44,6 +44,15 @@
             app:inputText="This is the feedback description" />
 
         <com.telefonica.mistica.input.TextInput
+            android:id="@+id/input_feedback_error_reference"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:inputType="text"
+            app:inputHint="Error Reference (For Error Feedbacks)"
+            app:inputText="Error reference: #95001" />
+
+        <com.telefonica.mistica.input.TextInput
             android:id="@+id/input_feedback_first_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
@@ -19,6 +19,7 @@ fun Feedback(
     @FeedbackScreenView.FeedbackType type: Int = FeedbackScreenView.TYPE_INFO,
     title: String = "",
     subtitle: String = "",
+    errorReference: String = "",
     firstButtonText: String?,
     secondButtonText: String?,
     firstButtonOnClick: (() -> Unit)?,
@@ -61,6 +62,7 @@ fun Feedback(
             setFeedbackType(type)
             setFeedbackTitle(title)
             setFeedbackSubtitle(subtitle)
+            setFeedbackErrorReference(errorReference)
             firstButtonText?.let { setFeedbackFirstButtonText(firstButtonText) }
             secondButtonText?.let { setFeedbackSecondButtonText(secondButtonText) }
             firstButtonOnClick?.let { setFirstButtonOnClick { firstButtonOnClick() } }

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
@@ -21,7 +21,7 @@ In order to configure it for the specific purpose, it supports both **attribute 
     </attr>
     <attr name="feedbackTitle" format="string"/>
     <attr name="feedbackSubtitle" format="string"/>
-	<attr name="feedbackErrorReference" format="string"/>
+    <attr name="feedbackErrorReference" format="string"/>
     <attr name="feedbackCustomContentLayout" format="reference"/>
     <attr name="feedbackFirstButtonText" format="string"/>
     <attr name="feedbackSecondButtonText" format="string"/>

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
@@ -6,7 +6,7 @@
 
 `com.telefonica.mistica.feedback.screen.view.FeedbackScreenView` allows showing a full screen feedback which can be configured depending on the needs.
 
-It can be used inside any layout like a regular view. When adding it to the view hierarchy, screen entry animations will be performed.
+It can be used inside any layout like a regular view. When adding it to the view hierarchy, entry animations will be performed.
 
 In order to configure it for the specific purpose, it supports both **attribute configuration and databinding for all properties**
 
@@ -31,3 +31,15 @@ In order to configure it for the specific purpose, it supports both **attribute 
     <attr name="feedbackSecondButtonOnClick" format="string"/>
 </declare-styleable>
 ```
+## Fields information
+
+`feedbackType` -> (Required) Type of the feedback for the specific purpose.
+`feedbackTitle` -> (Required) Title
+`feedbackSubtitle` -> (Required) Subtitle
+`feedbackErrorReference` -> (Optional) It allows specifying a error reference text, such as "Error reference: #95001". It is only displayed when field is not an empty string and the current feedback type is error.
+`feedbackCustomContentLayout` -> (Optional) Allows specifying a layout resource that will be inflated, showing its contents below the feedback subtitle.
+`feedbackFirstButtonText` -> (Optional) Allows specifying a Text for the first feedback button. A primary button will be displayed if text is not empty.
+`feedbackSecondButtonText` -> (Optional) Allows specifying a Text for the second feedback button. A secondary button will be displayed if text is not empty.
+`feedbackSecondButtonAsLink` -> (Optional) When specified as true, the second button is displayed as a link button.
+`feedbackFirstButtonOnClick` -> (Optional) Click action associated to first feedback button.
+`feedbackSecondButtonOnClick` -> (Optional) Click action associated to second feedback button.

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
@@ -34,12 +34,21 @@ In order to configure it for the specific purpose, it supports both **attribute 
 ## Fields information
 
 `feedbackType` -> (Required) Type of the feedback for the specific purpose.
+
 `feedbackTitle` -> (Required) Title
+
 `feedbackSubtitle` -> (Required) Subtitle
+
 `feedbackErrorReference` -> (Optional) It allows specifying a error reference text, such as "Error reference: #95001". It is only displayed when field is not an empty string and the current feedback type is error.
+
 `feedbackCustomContentLayout` -> (Optional) Allows specifying a layout resource that will be inflated, showing its contents below the feedback subtitle.
+
 `feedbackFirstButtonText` -> (Optional) Allows specifying a Text for the first feedback button. A primary button will be displayed if text is not empty.
+
 `feedbackSecondButtonText` -> (Optional) Allows specifying a Text for the second feedback button. A secondary button will be displayed if text is not empty.
+
 `feedbackSecondButtonAsLink` -> (Optional) When specified as true, the second button is displayed as a link button.
+
 `feedbackFirstButtonOnClick` -> (Optional) Click action associated to first feedback button.
+
 `feedbackSecondButtonOnClick` -> (Optional) Click action associated to second feedback button.

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/README.md
@@ -4,7 +4,13 @@
     <img src="../../../../../../../../../doc/images/screen_feedbacks/feedbacks.gif">
 </p>
 
-`com.telefonica.mistica.feedback.screen.view.FeedbackScreenView` can be used inside any layout like a regular view, presentation of the view can be diferent depending on the design requirements. In order to configure it for the specific purpose, it supports both **attribute configuration and databinding for all properties**
+`com.telefonica.mistica.feedback.screen.view.FeedbackScreenView` allows showing a full screen feedback which can be configured depending on the needs.
+
+It can be used inside any layout like a regular view. When adding it to the view hierarchy, screen entry animations will be performed.
+
+In order to configure it for the specific purpose, it supports both **attribute configuration and databinding for all properties**
+
+## Available fields
 
 ```xml
 <declare-styleable name="FeedbackScreen">
@@ -15,6 +21,7 @@
     </attr>
     <attr name="feedbackTitle" format="string"/>
     <attr name="feedbackSubtitle" format="string"/>
+	<attr name="feedbackErrorReference" format="string"/>
     <attr name="feedbackCustomContentLayout" format="reference"/>
     <attr name="feedbackFirstButtonText" format="string"/>
     <attr name="feedbackSecondButtonText" format="string"/>

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
@@ -357,6 +357,7 @@ class FeedbackScreenView : ConstraintLayout {
 
             title.alpha = 0F
             subtitle.alpha = 0F
+            errorReference.alpha = 0F
             customContentContainer.alpha = 0F
 
             animation.start()

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
@@ -48,6 +48,7 @@ class FeedbackScreenView : ConstraintLayout {
     private lateinit var icon: LottieAnimationView
     private lateinit var title: TextView
     private lateinit var subtitle: TextView
+    private lateinit var errorReference: TextView
     private lateinit var customContentContainer: FrameLayout
     private lateinit var buttonsContainer: LinearLayout
     private lateinit var firstButton: ProgressButton
@@ -56,6 +57,7 @@ class FeedbackScreenView : ConstraintLayout {
     private var type: Int = TYPE_INFO
     private var titleText: CharSequence = ""
     private var subtitleText: CharSequence = ""
+    private var errorReferenceText: CharSequence = ""
     private var isLoading: Boolean = false
 
     @LayoutRes
@@ -101,6 +103,16 @@ class FeedbackScreenView : ConstraintLayout {
     fun setFeedbackSubtitle(text: CharSequence) {
         subtitleText = text
         subtitle.text = text
+    }
+
+    fun setFeedbackErrorReference(text: CharSequence) {
+        errorReferenceText = text
+        errorReference.text = text
+        errorReference.visibility = if (text.isNotBlank() && type == TYPE_ERROR) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
     }
 
     fun setCustomContentLayout(@LayoutRes layout: Int) {
@@ -162,6 +174,7 @@ class FeedbackScreenView : ConstraintLayout {
             styledAttrs.getText(R.styleable.FeedbackScreen_feedbackTitle)?.let { titleText = it }
             styledAttrs.getText(R.styleable.FeedbackScreen_feedbackSubtitle)
                 ?.let { subtitleText = it }
+            styledAttrs.getText(R.styleable.FeedbackScreen_feedbackErrorReference)?.let { errorReferenceText = it }
             customContentLayout = styledAttrs.getResourceId(
                 R.styleable.FeedbackScreen_feedbackCustomContentLayout,
                 TypedValue.TYPE_NULL
@@ -179,6 +192,7 @@ class FeedbackScreenView : ConstraintLayout {
         icon = findViewById(R.id.icon)
         title = findViewById(R.id.title)
         subtitle = findViewById(R.id.subtitle)
+        errorReference = findViewById(R.id.error_reference)
         customContentContainer = findViewById(R.id.custom_content)
         buttonsContainer = findViewById(R.id.buttons_container)
     }
@@ -282,6 +296,7 @@ class FeedbackScreenView : ConstraintLayout {
         subtitle.setTextColor(subtitleTextColor)
         setFeedbackTitle(titleText)
         setFeedbackSubtitle(subtitleText)
+        setFeedbackErrorReference(errorReferenceText)
     }
 
     private fun configureCustomContentView() {
@@ -329,9 +344,11 @@ class FeedbackScreenView : ConstraintLayout {
                     getFadeInAnim(title),
                     getFadeInAnim(subtitle),
                     getFadeInAnim(customContentContainer),
+                    getFadeInAnim(errorReference),
                     getTranslationYAnim(title),
                     getTranslationYAnim(subtitle),
-                    getTranslationYAnim(customContentContainer)
+                    getTranslationYAnim(customContentContainer),
+                    getTranslationYAnim(errorReference),
                 )
                 interpolator = getCubicBezierInterpolator()
                 duration = TEXTS_ANIMATION_DURATION

--- a/library/src/main/res/layout/screen_feedback.xml
+++ b/library/src/main/res/layout/screen_feedback.xml
@@ -13,7 +13,7 @@
             android:layout_height="wrap_content"
             android:focusable="true"
             android:orientation="vertical"
-            android:paddingTop="24dp">
+            android:paddingTop="24dp" >
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/icon"
@@ -42,8 +42,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"
                 android:layout_marginTop="16dp"
-                android:layout_marginEnd="24dp"
-                android:layout_marginBottom="24dp" />
+                android:layout_marginEnd="24dp" />
 
             <FrameLayout
                 android:id="@+id/custom_content"
@@ -51,8 +50,23 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"
                 android:layout_marginEnd="24dp"
-                android:layout_marginBottom="24dp"
+                android:layout_marginTop="24dp"
                 android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/error_reference"
+                style="@style/AppTheme.TextAppearance.Preset2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="24dp"
+                android:textColor="?colorTextSecondary"
+                android:visibility="gone" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="24dp" />
 
         </LinearLayout>
     </ScrollView>

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -21,6 +21,7 @@
         <attr name="feedbackTitle" format="string" />
         <attr name="feedbackSubtitle" format="string" />
         <attr name="feedbackCustomContentLayout" format="reference" />
+        <attr name="feedbackErrorReference" format="string" />
         <attr name="feedbackFirstButtonText" format="string" />
         <attr name="feedbackSecondButtonText" format="string" />
         <attr name="feedbackSecondButtonAsLink" format="boolean" />


### PR DESCRIPTION
### :goal_net: What's the goal?
Add the possibility of including an error reference text in Error Feedbacks.
Check ticket for details -> ANDROID-10046

As talked with iOS, component will accept whole field text, instead of just the error reference, so, this way mistica does not need to hold any translation/default token.

### :construction: How do we do it?
* Include a new field in the feedback component that allows specifying a string for this
* Adapt compose function with this new parameter

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos

  <img src="https://user-images.githubusercontent.com/5360064/144036524-21ce5ac4-6a4a-42d3-9490-68810b4306ed.jpg" width=200>

- [x] Reviewed by Mistica design team
- [x] [Hockey](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-core-alpha-1/distribution_groups/public)

  <img width="194" alt="Captura de pantalla 2021-11-30 a las 13 05 15" src="https://user-images.githubusercontent.com/5360064/144044294-c3467b1d-e84a-44d8-bfc6-5c7497463969.png">

