### PR TITLE
ANDROID-10148 PoC of how to restrict @Composable functions to only allow certain components

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
@@ -32,7 +32,8 @@ const val TITLE = "Title"
 const val SUBTITLE = "Subtitle"
 const val DESCRIPTION = "Description"
 
-val samples = listOf(
+@Composable
+fun samples() = listOf(
     ListItem(
         title = TITLE,
     ),
@@ -130,14 +131,14 @@ val samples = listOf(
     ),
 
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = Tag(content ="PROMO").withColor(MisticaTheme.colors.promo),
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
         icon = { ListIcon() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = Tag("PROMO").withColor(MisticaTheme.colors.promo),
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
@@ -147,7 +148,7 @@ val samples = listOf(
         icon = { Avatar() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = Tag("PROMO").withColor(MisticaTheme.colors.promo),
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
@@ -157,7 +158,7 @@ val samples = listOf(
         icon = { Avatar() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = Tag("PROMO").withColor(MisticaTheme.colors.promo),
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
@@ -172,6 +173,7 @@ val samples = listOf(
 @ExperimentalMaterialApi
 @Composable
 fun Lists() {
+    val samples = samples()
     LazyColumn(
         modifier = Modifier
             .fillMaxSize(),
@@ -248,7 +250,7 @@ data class ListItem(
     val backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
     val badge: String? = null,
     val isBadgeVisible: Boolean = false,
-    val headline: @Composable (() -> Unit)? = null,
+    val headline: Tag? = null,
     val action: @Composable (() -> Unit)? = null,
     val onClick: () -> Unit = {},
 )

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -47,7 +47,7 @@ fun ListRowItem(
     backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
     badge: String? = null,
     isBadgeVisible: Boolean = false,
-    headline: @Composable (() -> Unit)? = null,
+    headline: Tag? = null,
     trailing: @Composable (() -> Unit)? = null,
     onClick: () -> Unit = {},
 ) {
@@ -118,7 +118,7 @@ fun ListRowItem(
                     .align(CenterVertically)
             ) {
                 headline?.let {
-                    it()
+                    it.build()
                     Spacer(modifier = Modifier.height(8.dp))
                 }
                 title?.let {
@@ -177,7 +177,7 @@ fun ListRowItemPreview() {
         val checkedState = remember { mutableStateOf(true) }
         Column {
             ListRowItem(
-                headline = { Tag("promo") },
+                headline = Tag("Promo"),
                 isBadgeVisible = true,
                 title = "Title",
                 subtitle = "Subtitle",

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -1,5 +1,6 @@
 package com.telefonica.mistica.compose.tag
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -49,8 +50,9 @@ class Tag constructor(
 
     fun withColor(color: Color): Tag = this.apply { this.color = color }
 
+    @SuppressLint("ComposableNaming")
     @Composable
-    fun build() {
+    internal fun build() {
         Tag(content = content, modifier = modifier, color = color ?: MisticaTheme.colors.badge)
     }
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -39,6 +39,22 @@ fun Tag(
     }
 }
 
+class Tag constructor(
+    private val content: String,
+) {
+    private var modifier: Modifier = Modifier
+    private var color: Color? = null
+
+    fun withModifier(modifier: Modifier): Tag = this.apply { this.modifier = modifier }
+
+    fun withColor(color: Color): Tag = this.apply { this.color = color }
+
+    @Composable
+    fun build() {
+        Tag(content = content, modifier = modifier, color = color ?: MisticaTheme.colors.badge)
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun TagPreview() {


### PR DESCRIPTION
This is just kind of a PoC, I hadn't time to migrate other usages, but I think it can be a good approach to restrict that some parts of bigger components that are defined as composable to accept only the components we want to add.

### :goal_net: What's the goal?
Limit list row headline to only accept Tags

### :construction: How do we do it?
* Expose a class with the same name as the composable function: Tag
* That class will have a build method that creates the composable
* Restrict the ListRowItem parameter to only accept Tag (the class)

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?

https://user-images.githubusercontent.com/4595241/144257978-1e33b37d-fd6e-4f48-b86e-ae2aa5e95e71.mp4


