### PR TITLE
ANDROID-10144 Compose Tag Evolution

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
@@ -42,6 +42,7 @@ import com.telefonica.mistica.compose.catalog.R
 import com.telefonica.mistica.compose.catalog.ui.components.Buttons
 import com.telefonica.mistica.compose.catalog.ui.components.Feedbacks
 import com.telefonica.mistica.compose.catalog.ui.components.Lists
+import com.telefonica.mistica.compose.catalog.ui.components.Tags
 import com.telefonica.mistica.compose.catalog.ui.components.Texts
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.BlauBrand
@@ -140,6 +141,7 @@ fun CatalogNavHost(
         composable(NavigationRoutes.TEXTS) { Texts() }
         composable(NavigationRoutes.FEEDBACKS) { Feedbacks() }
         composable(NavigationRoutes.LISTS) { Lists() }
+        composable(NavigationRoutes.TAGS) { Tags() }
     }
 }
 
@@ -170,7 +172,12 @@ fun Catalog(
             name = "Lists",
             icon = R.drawable.ic_lists,
             navigation = NavigationRoutes.LISTS
-        )
+        ),
+        ComponentScreen(
+            name = "Tags",
+            icon = R.drawable.ic_tags,
+            navigation = NavigationRoutes.TAGS
+        ),
     )
     Column {
 
@@ -238,4 +245,5 @@ object NavigationRoutes {
     const val TEXTS = "texts"
     const val FEEDBACKS = "feedbacks"
     const val LISTS = "lists"
+    const val TAGS = "tags"
 }

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
@@ -27,6 +27,7 @@ import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.shape.Circle
 import com.telefonica.mistica.compose.list.ListRowItem
 import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 
 const val TITLE = "Title"
 const val SUBTITLE = "Subtitle"
@@ -130,14 +131,14 @@ val samples = listOf(
     ),
 
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = { Tag("PROMO", style = TYPE_PROMO) },
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
         icon = { ListIcon() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = { Tag("PROMO", style = TYPE_PROMO) },
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
@@ -147,7 +148,7 @@ val samples = listOf(
         icon = { Avatar() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = { Tag("PROMO", style = TYPE_PROMO) },
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
@@ -157,7 +158,7 @@ val samples = listOf(
         icon = { Avatar() },
     ),
     ListItem(
-        headline = { Tag("PROMO", color = MisticaTheme.colors.promo) },
+        headline = { Tag("PROMO", style = TYPE_PROMO) },
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Tags.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Tags.kt
@@ -1,0 +1,71 @@
+package com.telefonica.mistica.compose.catalog.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.telefonica.mistica.compose.tag.Tag
+import com.telefonica.mistica.compose.tag.TagCatalogPreview
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.tag.TagView
+
+@ExperimentalFoundationApi
+@Composable
+fun Tags() {
+    val customText = remember { mutableStateOf(TextFieldValue("Promotion")) }
+
+    Column(
+        modifier = Modifier.padding(vertical = 32.dp, horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        TagCatalogPreview()
+        Surface(
+            color = MisticaTheme.colors.tagBackgroundInactive,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+        ) {}
+
+        Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 16.dp))
+        Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 8.dp), icon = android.R.drawable.ic_lock_power_off)
+
+        Surface(
+            color = MisticaTheme.colors.brand,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+                .height(96.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE)
+                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE, modifier = Modifier.padding(top = 8.dp), icon = android.R.drawable
+                    .ic_lock_power_off)
+            }
+        }
+
+        TextField(
+            value = customText.value,
+            onValueChange = { customText.value = it },
+            label = { Text(text = "Type something...") },
+            modifier = Modifier.fillMaxWidth(),
+            colors = TextFieldDefaults.textFieldColors(backgroundColor = MisticaTheme.colors.backgroundContainer),
+        )
+    }
+}

--- a/catalog-compose/src/main/res/drawable-nodpi/ic_tags.xml
+++ b/catalog-compose/src/main/res/drawable-nodpi/ic_tags.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.03"
+        android:fillColor="#F2F2F2"
+        android:fillType="nonZero"
+        android:pathData="M0,0h24v24h-24z" />
+    <path
+        android:fillColor="#003245"
+        android:fillType="nonZero"
+        android:pathData="M19.5096,14.0548L14.054,19.5104C13.6667,19.8977 13.0399,19.9014 12.6481,19.5186L4.3489,11.4116C4.1563,11.2234 4.0477,10.9655 4.0477,10.6963L4.0477,5.0518C4.0477,4.4995 4.4954,4.0518 5.0477,4.0518L10.6957,4.0518C10.9649,4.0518 11.2228,4.1604 11.4109,4.3529L19.5177,12.6488C19.9006,13.0405 19.897,13.6674 19.5096,14.0548Z" />
+    <path
+        android:fillColor="#FFF"
+        android:fillType="nonZero"
+        android:pathData="M8.464,8.464m-2.019,0a2.019,2.019 0,1 1,4.038 0a2.019,2.019 0,1 1,-4.038 0" />
+</vector>

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -1,65 +1,183 @@
 package com.telefonica.mistica.compose.tag
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
-import com.telefonica.mistica.compose.theme.brand.TelefonicaBrand
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+import com.telefonica.mistica.tag.TagStyle
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_ACTIVE
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_ERROR
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_INACTIVE
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_INVERSE
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_SUCCESS
+import com.telefonica.mistica.tag.TagView.Companion.TYPE_WARNING
+import java.util.Locale
 
 @Composable
 fun Tag(
-    content: String,
+    text: String,
     modifier: Modifier = Modifier,
-    color: Color = MisticaTheme.colors.badge,
+    @TagStyle style: Int = TYPE_PROMO,
+    @DrawableRes icon: Int? = null,
 ) {
+    val (background, textColor) = style.getStyle()
+
     Surface(
-        modifier = modifier,
-        shape = RoundedCornerShape(4.dp),
-        color = color,
+        modifier = modifier
+            .wrapContentSize()
+            .defaultMinSize(minWidth = 48.dp)
+            .height(28.dp),
+        shape = RoundedCornerShape(50.dp),
+        color = background,
     ) {
-        Text(
-            text = content.uppercase(),
-            style = MisticaTheme.typography.preset1Medium,
-            color = Color.White,
-            modifier = Modifier.padding(
-                horizontal = 8.dp,
-            ),
-        )
+        Row(
+            modifier = Modifier.padding(start = if (icon != null) 8.dp else 12.dp, end = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+
+            if (icon != null) {
+                Image(
+                    painter = painterResource(id = icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    colorFilter = ColorFilter.tint(textColor),
+                    contentScale = ContentScale.Fit
+                )
+            }
+
+            Text(
+                text = text.captitalizeFirstChar(),
+                modifier = Modifier.padding(start = if (icon != null) 4.dp else 0.dp),
+                style = MisticaTheme.typography.preset2Medium,
+                color = textColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 
+class Tag constructor(
+    private val content: String,
+) {
+    private var modifier: Modifier = Modifier
+
+    @TagStyle
+    private var style: Int = TYPE_PROMO
+
+    @DrawableRes
+    private var icon: Int? = null
+
+    fun withModifier(modifier: Modifier) = apply { this.modifier = modifier }
+    fun withStyle(@TagStyle style: Int) = apply { this.style = style }
+    fun withIcon(@DrawableRes icon: Int?) = apply { this.icon = icon }
+
+    @Composable
+    fun build() {
+        Tag(text = content, modifier = modifier, style = style, icon = icon)
+    }
+}
+
+@ExperimentalFoundationApi
 @Preview(showBackground = true)
 @Composable
 fun TagPreview() {
-    MisticaTheme(brand = TelefonicaBrand) {
-        Column {
-            Box(
-                modifier = Modifier
-                    .size(150.dp, 100.dp)
-                    .background(MisticaTheme.colors.backgroundContainer),
-            ) {
-                Tag(
-                    content = "new",
-                    color = MisticaTheme.colors.promo,
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .shadow(
-                            elevation = 2.dp,
-                            shape = RoundedCornerShape(4.dp)
-                        ),
-                )
-            }
+    MisticaTheme(brand = MovistarBrand) {
+        Column(
+            modifier = Modifier
+                .padding(vertical = 32.dp, horizontal = 16.dp)
+                .background(MisticaTheme.colors.backgroundContainer),
+        ) {
+            TagCatalogPreview()
         }
     }
+}
+
+@ExperimentalFoundationApi
+@Composable
+fun TagCatalogPreview() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Surface(
+            color = MisticaTheme.colors.brand,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(60.dp)
+        ) {
+            Tag(text = "Inverse", style = TYPE_INVERSE, modifier = Modifier.padding(8.dp))
+        }
+        LazyVerticalGrid(
+            cells = GridCells.Fixed(3),
+            modifier = Modifier.padding(16.dp)
+        ) {
+            item { Tag(text = "Promotion", style = TYPE_PROMO, modifier = Modifier.padding(4.dp)) }
+            item { Tag(text = "Active", style = TYPE_ACTIVE, modifier = Modifier.padding(4.dp)) }
+            item { Tag(text = "Inactive", style = TYPE_INACTIVE, modifier = Modifier.padding(4.dp)) }
+            item { Tag(text = "Success", style = TYPE_SUCCESS, modifier = Modifier.padding(4.dp)) }
+            item { Tag(text = "Warning", style = TYPE_WARNING, modifier = Modifier.padding(4.dp)) }
+            item { Tag(text = "Error", style = TYPE_ERROR, modifier = Modifier.padding(4.dp)) }
+        }
+        Surface(
+            color = MisticaTheme.colors.brand,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+                .height(60.dp)
+        ) {
+            Tag(text = "Inverse", style = TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = android.R.drawable.ic_lock_power_off)
+        }
+        LazyVerticalGrid(
+            cells = GridCells.Fixed(3),
+            modifier = Modifier.padding(16.dp)
+        ) {
+            item { Tag(text = "Promotion", style = TYPE_PROMO, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+            item { Tag(text = "Active", style = TYPE_ACTIVE, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+            item { Tag(text = "Inactive", style = TYPE_INACTIVE, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+            item { Tag(text = "Success", style = TYPE_SUCCESS, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+            item { Tag(text = "Warning", style = TYPE_WARNING, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+            item { Tag(text = "Error", style = TYPE_ERROR, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+        }
+    }
+}
+
+@Composable
+private fun Int.getStyle() = when (this) {
+    TYPE_PROMO -> with(MisticaTheme.colors) { tagBackgroundPromo to textTagPromo }
+    TYPE_ACTIVE -> with(MisticaTheme.colors) { tagBackgroundActive to textTagActive }
+    TYPE_INACTIVE -> with(MisticaTheme.colors) { tagBackgroundInactive to textTagInactive }
+    TYPE_SUCCESS -> with(MisticaTheme.colors) { tagBackgroundSuccess to textTagSuccess }
+    TYPE_WARNING -> with(MisticaTheme.colors) { tagBackgroundWarning to textTagWarning }
+    TYPE_ERROR -> with(MisticaTheme.colors) { tagBackgroundError to textTagError }
+    TYPE_INVERSE -> with(MisticaTheme.colors) { inverse to textTagActive }
+    else -> with(MisticaTheme.colors) { tagBackgroundPromo to textTagPromo }
+}
+
+private fun String.captitalizeFirstChar(): String {
+    return lowercase(Locale.getDefault()).replaceFirstChar { if (it.isLowerCase()) it.uppercase() else it.toString() }
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
@@ -184,14 +184,17 @@ private object BlauPaletteColor {
     val blau_color_yellow = Color(0xFFFFA922)
     val blau_color_yellow_70 = Color(0xFF996614)
     val blau_color_yellow_60 = Color(0xFFF09500)
+    val blau_color_yellow_40 = Color(0xFFFFC364)
     val blau_color_yellow_10 = Color(0xFFFFF6E9)
 
     val blau_color_green = Color(0xFF30D300)
     val blau_color_green_70 = Color(0xFF1D7F00)
+    val blau_color_green_30 = Color(0xFF97E980)
     val blau_color_green_10 = Color(0xFFEAFBE5)
 
     val blau_color_red = Color(0xFFF64417)
     val blau_color_red_70 = Color(0xFFC93712)
+    val blau_color_red_40 = Color(0xFFF97C5D)
     val blau_color_red_30 = Color(0xFFFA9E87)
     val blau_color_red_20 = Color(0xFFFCC7B9)
     val blau_color_red_10 = Color(0xFFFEECE8)

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
@@ -99,6 +99,18 @@ object BlauBrand : Brand {
         loginLoadingGradientSecond = BlauPaletteColor.blau_color_blue_primary,
         loginLoadingGradientThird = BlauPaletteColor.blau_color_blue_primary,
         loginLoadingGradientFourth = BlauPaletteColor.blau_color_blue_primary,
+        tagBackgroundSuccess = BlauPaletteColor.blau_color_green_10,
+        tagBackgroundWarning = BlauPaletteColor.blau_color_yellow_10,
+        tagBackgroundError = BlauPaletteColor.blau_color_red_10,
+        tagBackgroundPromo = BlauPaletteColor.blau_color_purple_10,
+        tagBackgroundActive = BlauPaletteColor.blau_color_blue_secondary10,
+        tagBackgroundInactive = BlauPaletteColor.blau_color_grey_2,
+        textTagSuccess = BlauPaletteColor.blau_color_green_70,
+        textTagWarning = BlauPaletteColor.blau_color_yellow_70,
+        textTagError = BlauPaletteColor.blau_color_red_70,
+        textTagPromo = BlauPaletteColor.blau_color_purple,
+        textTagActive = BlauPaletteColor.blau_color_blue_secondary,
+        textTagInactive = BlauPaletteColor.blau_color_grey_5,
     )
 
     override val darkColors = lightColors.copy(
@@ -163,6 +175,18 @@ object BlauBrand : Brand {
         textNavigationBarSecondary = BlauPaletteColor.blau_color_grey_4,
         textAppBar = BlauPaletteColor.blau_color_grey_5,
         textAppBarSelected = BlauPaletteColor.blau_color_grey_2,
+        tagBackgroundSuccess = BlauPaletteColor.blau_color_white_5_alpha,
+        tagBackgroundWarning = BlauPaletteColor.blau_color_white_5_alpha,
+        tagBackgroundError = BlauPaletteColor.blau_color_white_5_alpha,
+        tagBackgroundPromo = BlauPaletteColor.blau_color_white_5_alpha,
+        tagBackgroundActive = BlauPaletteColor.blau_color_white_5_alpha,
+        tagBackgroundInactive = BlauPaletteColor.blau_color_white_5_alpha,
+        textTagSuccess = BlauPaletteColor.blau_color_green_30,
+        textTagWarning = BlauPaletteColor.blau_color_yellow_40,
+        textTagError = BlauPaletteColor.blau_color_red_40,
+        textTagPromo = BlauPaletteColor.blau_color_purple_30,
+        textTagActive = BlauPaletteColor.blau_color_blue_primary30,
+        textTagInactive = BlauPaletteColor.blau_color_grey_4,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -99,6 +99,18 @@ object MovistarBrand : Brand {
         loginLoadingGradientSecond = MovistarPaletteColor.movistar_color_blue_dark,
         loginLoadingGradientThird = MovistarPaletteColor.movistar_color_blue_dark,
         loginLoadingGradientFourth = MovistarPaletteColor.movistar_color_blue_dark,
+        tagBackgroundSuccess = MovistarPaletteColor.movistar_color_green_10,
+        tagBackgroundWarning = MovistarPaletteColor.movistar_color_egg_10,
+        tagBackgroundError = MovistarPaletteColor.movistar_color_pepper_10,
+        tagBackgroundPromo = MovistarPaletteColor.movistar_color_purple_10,
+        tagBackgroundActive = MovistarPaletteColor.movistar_color_blue_10,
+        tagBackgroundInactive = MovistarPaletteColor.movistar_color_grey_1,
+        textTagSuccess = MovistarPaletteColor.movistar_color_green_70,
+        textTagWarning = MovistarPaletteColor.movistar_color_egg_80,
+        textTagError = MovistarPaletteColor.movistar_color_pepper_70,
+        textTagPromo = MovistarPaletteColor.movistar_color_purple_70,
+        textTagActive = MovistarPaletteColor.movistar_color_blue,
+        textTagInactive = MovistarPaletteColor.movistar_color_grey_5,
     )
 
     override val darkColors =
@@ -164,10 +176,22 @@ object MovistarBrand : Brand {
             loginLoadingGradientSecond = MovistarPaletteColor.movistar_color_grey_6,
             loginLoadingGradientThird = MovistarPaletteColor.movistar_color_grey_6,
             loginLoadingGradientFourth = MovistarPaletteColor.movistar_color_grey_6,
+            tagBackgroundSuccess = MovistarPaletteColor.movistar_color_white_5_alpha,
+            tagBackgroundWarning = MovistarPaletteColor.movistar_color_white_5_alpha,
+            tagBackgroundError = MovistarPaletteColor.movistar_color_white_5_alpha,
+            tagBackgroundPromo = MovistarPaletteColor.movistar_color_white_5_alpha,
+            tagBackgroundActive = MovistarPaletteColor.movistar_color_white_5_alpha,
+            tagBackgroundInactive = MovistarPaletteColor.movistar_color_white_5_alpha,
+            textTagSuccess = MovistarPaletteColor.movistar_color_green_40,
+            textTagWarning = MovistarPaletteColor.movistar_color_egg_40,
+            textTagError = MovistarPaletteColor.movistar_color_pepper_40,
+            textTagPromo = MovistarPaletteColor.movistar_color_purple_40,
+            textTagActive = MovistarPaletteColor.movistar_color_blue_40,
+            textTagInactive = MovistarPaletteColor.movistar_color_grey_4,
         )
 }
 
-object MovistarProminentBrand: Brand {
+object MovistarProminentBrand : Brand {
 
     override val compatibilityTheme: Int
         get() = R.style.MisticaTheme_Movistar_Prominent

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -193,22 +193,42 @@ object MovistarProminentBrand: Brand {
 
 private object MovistarPaletteColor {
     val movistar_color_blue = Color(0xFF019DF4)
+    val movistar_color_blue_10 = Color(0xFFE6F5FD)
+    val movistar_color_blue_40 = Color(0xFF4DBAF7)
     val movistar_color_blue_dark = Color(0xFF008EDD)
     val movistar_color_blue_light50 = Color(0xFF80CEF9)
     val movistar_color_blue_light30 = Color(0xFFB3E1FB)
     val movistar_color_blue_light10 = Color(0xFFE6F5FD)
+
     val movistar_color_green = Color(0xFF5CB615)
+    val movistar_color_green_10 = Color(0xFFEFF8E8)
+    val movistar_color_green_40 = Color(0xFF8DCC5B)
+    val movistar_color_green_70 = Color(0xFF407F0F)
     val movistar_color_green_dark = Color(0xFF499110)
     val movistar_color_green_light50 = Color(0xFFADDA8A)
     val movistar_color_green_light50_40_alpha = Color(0x66ADDA8A)
     val movistar_color_green_light30 = Color(0xFFCEE9B9)
+
     val movistar_color_pepper = Color(0xFFFF374A)
+    val movistar_color_pepper_10 = Color(0xFFFFEBED)
+    val movistar_color_pepper_40 = Color(0xFFFF7380)
+    val movistar_color_pepper_70 = Color(0xFFB22634)
     val movistar_color_pepper_dark = Color(0xFFD73241)
     val movistar_color_pepper_light30 = Color(0xFFFFC3C8)
+
     val movistar_color_egg = Color(0xFFF28D15)
+    val movistar_color_egg_10 = Color(0xFFFEF4E8)
+    val movistar_color_egg_40 = Color(0xFFF6AF5B)
+    val movistar_color_egg_80 = Color(0xFF6D3F09)
     val movistar_color_egg_light = Color(0xFFF8D2B3)
+
     val movistar_color_pink = Color(0xFFE63780)
+
     val movistar_color_purple = Color(0xFFA13EA1)
+    val movistar_color_purple_10 = Color(0xFFF6ECF6)
+    val movistar_color_purple_40 = Color(0xFFBD78BD)
+    val movistar_color_purple_70 = Color(0xFF712B71)
+
     val movistar_color_grey_1 = Color(0xFFF6F6F6)
     val movistar_color_grey_2 = Color(0xFFEEEEEE)
     val movistar_color_grey_3 = Color(0xFFDDDDDD)
@@ -219,6 +239,8 @@ private object MovistarPaletteColor {
 
     // Prominent Color Palette
     val movistar_prominent_color_blue = Color(0xFF0B2739)
+    val movistar_prominent_color_blue_10 = Color(0xFFE6F5FD)
+    val movistar_prominent_color_blue_40 = Color(0xFF4DBAF7)
     val movistar_prominent_color_blue_dark = Color(0xFF081F2D)
     val movistar_prominent_color_blue_light_20 = Color(0xFFCED3D7)
     val movistar_prominent_color_blue_light_50 = Color(0xFF85939C)

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
@@ -174,6 +174,8 @@ object O2Brand : Brand {
 
 private object O2PaletteColor {
     val o2_color_blue_primary = Color(0xFF0019A5)
+    val o2_color_blue_primary_10 = Color(0xFFE5E8F6)
+    val o2_color_blue_primary_15 = Color(0xFFCCD1ED)
     val o2_color_blue_primary_dark = Color(0xFF000066)
     val o2_color_blue_primary_light_50 = Color(0xFF808CD2)
     val o2_color_blue_primary_light_10 = Color(0xFFCCD1ED)
@@ -188,16 +190,34 @@ private object O2PaletteColor {
     val o2_color_teal = Color(0xFF01B7B4)
     val o2_color_teal_dark = Color(0xFF099E9B)
     val o2_color_teal_light = Color(0xFFB1E4E3)
+
     val o2_color_green = Color(0xFF91C90E)
+    val o2_color_green_10 = Color(0xFFF4FAE7)
+    val o2_color_green_40 = Color(0xFFB2D956)
+    val o2_color_green_80 = Color(0xFF415A06)
     val o2_color_green_light = Color(0xFFDEEEB7)
+
     val o2_color_yellow = Color(0xFFFEDB00)
     val o2_color_yellow_light = Color(0xFFFEF6C3)
+
     val o2_color_orange = Color(0xFFFF7F41)
+    val o2_color_orange_10 = Color(0xFFFFF2EC)
+    val o2_color_orange_40 = Color(0xFFFFA57A)
+    val o2_color_orange_75 = Color(0xFFA6522A)
     val o2_color_orange_light = Color(0xFFFFD6C2)
+
     val o2_color_coral = Color(0xFFFF706E)
+
     val o2_color_pink = Color(0xFFCB31A0)
+
     val o2_color_purple = Color(0xFF953698)
+    val o2_color_purple_10 = Color(0xFFF4EAF5)
+    val o2_color_purple_30 = Color(0xFFCA9ACB)
+
     val o2_color_pepper = Color(0xFFFF374A)
+    val o2_color_pepper_10 = Color(0xFFFEEBED)
+    val o2_color_pepper_40 = Color(0xFFFF7380)
+    val o2_color_pepper_60 = Color(0xFFC32B3D)
     val o2_color_pepper_dark = Color(0xFFD73241)
     val o2_color_pepper_light30 = Color(0xFFFFC3C8)
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
@@ -99,6 +99,18 @@ object O2Brand : Brand {
         loginLoadingGradientSecond = O2PaletteColor.o2_color_blue_primary,
         loginLoadingGradientThird = O2PaletteColor.o2_color_blue_primary,
         loginLoadingGradientFourth = O2PaletteColor.o2_color_blue_primary,
+        tagBackgroundSuccess = O2PaletteColor.o2_color_green_10,
+        tagBackgroundWarning = O2PaletteColor.o2_color_orange_10,
+        tagBackgroundError = O2PaletteColor.o2_color_pepper_10,
+        tagBackgroundPromo = O2PaletteColor.o2_color_purple_10,
+        tagBackgroundActive = O2PaletteColor.o2_color_blue_primary_10,
+        tagBackgroundInactive = O2PaletteColor.o2_color_grey_1,
+        textTagSuccess = O2PaletteColor.o2_color_green_80,
+        textTagWarning = O2PaletteColor.o2_color_orange_75,
+        textTagError = O2PaletteColor.o2_color_pepper_60,
+        textTagPromo = O2PaletteColor.o2_color_purple,
+        textTagActive = O2PaletteColor.o2_color_blue_primary,
+        textTagInactive = O2PaletteColor.o2_color_grey_5,
     )
 
     override val darkColors = lightColors.copy(
@@ -169,6 +181,18 @@ object O2Brand : Brand {
         textNavigationBarSecondary = O2PaletteColor.o2_color_grey_4,
         textAppBar = O2PaletteColor.o2_color_grey_5,
         textAppBarSelected = O2PaletteColor.o2_color_grey_2,
+        tagBackgroundSuccess = O2PaletteColor.o2_color_white_5_alpha,
+        tagBackgroundWarning = O2PaletteColor.o2_color_white_5_alpha,
+        tagBackgroundError = O2PaletteColor.o2_color_white_5_alpha,
+        tagBackgroundPromo = O2PaletteColor.o2_color_white_5_alpha,
+        tagBackgroundActive = O2PaletteColor.o2_color_white_5_alpha,
+        tagBackgroundInactive = O2PaletteColor.o2_color_white_5_alpha,
+        textTagSuccess = O2PaletteColor.o2_color_green_40,
+        textTagWarning = O2PaletteColor.o2_color_orange_40,
+        textTagError = O2PaletteColor.o2_color_pepper_40,
+        textTagPromo = O2PaletteColor.o2_color_purple_30,
+        textTagActive = O2PaletteColor.o2_color_blue_primary_15,
+        textTagInactive = O2PaletteColor.o2_color_grey_4,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2ClassicBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2ClassicBrand.kt
@@ -99,6 +99,18 @@ object O2ClassicBrand : Brand {
         loginLoadingGradientSecond = O2ClassicPaletteColor.o2_classic_gradient_second,
         loginLoadingGradientThird = O2ClassicPaletteColor.o2_classic_gradient_third,
         loginLoadingGradientFourth = O2ClassicPaletteColor.o2_classic_gradient_fourth,
+        tagBackgroundSuccess = O2ClassicPaletteColor.o2_classic_color_green_10,
+        tagBackgroundWarning = O2ClassicPaletteColor.o2_classic_color_orange_10,
+        tagBackgroundError = O2ClassicPaletteColor.o2_classic_color_pepper_10,
+        tagBackgroundPromo = O2ClassicPaletteColor.o2_classic_color_pink_10,
+        tagBackgroundActive = O2ClassicPaletteColor.o2_classic_color_blue_10,
+        tagBackgroundInactive = O2ClassicPaletteColor.o2_classic_color_grey_1,
+        textTagSuccess = O2ClassicPaletteColor.o2_classic_color_green_75,
+        textTagWarning = O2ClassicPaletteColor.o2_classic_color_orange_80,
+        textTagError = O2ClassicPaletteColor.o2_classic_color_pepper_70,
+        textTagPromo = O2ClassicPaletteColor.o2_classic_color_pink_60,
+        textTagActive = O2ClassicPaletteColor.o2_classic_color_blue,
+        textTagInactive = O2ClassicPaletteColor.o2_classic_color_grey_5,
     )
 
     override val darkColors = lightColors.copy(
@@ -161,6 +173,18 @@ object O2ClassicBrand : Brand {
         textNavigationBarSecondary = O2ClassicPaletteColor.o2_classic_color_grey_4,
         textAppBar = O2ClassicPaletteColor.o2_classic_color_grey_5,
         textAppBarSelected = O2ClassicPaletteColor.o2_classic_color_grey_2,
+        tagBackgroundSuccess = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        tagBackgroundWarning = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        tagBackgroundError = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        tagBackgroundPromo = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        tagBackgroundActive = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        tagBackgroundInactive = O2ClassicPaletteColor.o2_classic_color_white_5_alpha,
+        textTagSuccess = O2ClassicPaletteColor.o2_classic_color_green_40,
+        textTagWarning = O2ClassicPaletteColor.o2_classic_color_orange_40,
+        textTagError = O2ClassicPaletteColor.o2_classic_color_pepper_40,
+        textTagPromo = O2ClassicPaletteColor.o2_classic_color_pink_40,
+        textTagActive = O2ClassicPaletteColor.o2_classic_color_blue_30,
+        textTagInactive = O2ClassicPaletteColor.o2_classic_color_grey_4,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2ClassicBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/O2ClassicBrand.kt
@@ -166,6 +166,8 @@ object O2ClassicBrand : Brand {
 
 private object O2ClassicPaletteColor {
     val o2_classic_color_blue = Color(0xFF032B5A)
+    val o2_classic_color_blue_10 = Color(0xFFE6EAEE)
+    val o2_classic_color_blue_30 = Color(0xFF8195AC)
     val o2_classic_color_blue_dark = Color(0xFF04264E)
     val o2_classic_color_blue_light_60 = Color(0xFF6C8BAF)
     val o2_classic_color_sky_blue = Color(0xFF0090D0)
@@ -179,16 +181,34 @@ private object O2ClassicPaletteColor {
     val o2_classic_color_gem = Color(0xFF01B7B4)
     val o2_classic_color_gem_dark = Color(0xFF099E9B)
     val o2_classic_color_gem_light_30 = Color(0xFF99E2E1)
+
     val o2_classic_color_yellow = Color(0xFFFFCC00)
+
     val o2_classic_color_green = Color(0xFF84B50F)
+    val o2_classic_color_green_10 = Color(0xFFF3F8E7)
+    val o2_classic_color_green_40 = Color(0xFFA9CB57)
+    val o2_classic_color_green_75 = Color(0xFF4D621D)
     val o2_classic_color_green_light = Color(0xFFDAE8B7)
+
     val o2_classic_color_pepper = Color(0xFFFF374A)
+    val o2_classic_color_pepper_10 = Color(0xFFFFEBED)
+    val o2_classic_color_pepper_40 = Color(0xFFFF7380)
+    val o2_classic_color_pepper_70 = Color(0xFFB22634)
     val o2_classic_color_pepper_dark = Color(0xFFD73241)
     val o2_classic_color_pepper_light_30 = Color(0xFFFFC3C8)
+
     val o2_classic_color_orange = Color(0xFFFF7F41)
+    val o2_classic_color_orange_10 = Color(0xFFFFF2EC)
+    val o2_classic_color_orange_40 = Color(0xFFFFA57A)
+    val o2_classic_color_orange_80 = Color(0xFF73391D)
     val o2_classic_color_orange_light = Color(0xFFFFD6C2)
+
     val o2_classic_color_coral = Color(0xFFFF706E)
+
     val o2_classic_color_pink = Color(0xFFEB3C7D)
+    val o2_classic_color_pink_10 = Color(0xFFFDEBF2)
+    val o2_classic_color_pink_40 = Color(0xFFF59DBE)
+    val o2_classic_color_pink_60 = Color(0xFFBC3064)
 
     val o2_classic_gradient_first = Color(0xFF102550)
     val o2_classic_gradient_second = Color(0xFF0B4680)

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
@@ -196,6 +196,8 @@ object TelefonicaBrand : Brand {
 
 private object TelefonicaPaletteColor {
     val telefonica_color_blue = Color(0xFF0066FF)
+    val telefonica_color_blue_30 = Color(0xFF80B3FF)
+
     val telefonica_color_blue_dark = Color(0xFF0356C9)
     val telefonica_color_blue_light50 = Color(0xFF80B2FF)
     val telefonica_color_blue_light30 = Color(0xFFB3D1FF)
@@ -215,18 +217,30 @@ private object TelefonicaPaletteColor {
     val telefonica_color_egg_light = Color(0xFFF8D2B3)
 
     val telefonica_color_ambar = Color(0xFFEAC344)
+    val telefonica_color_ambar_10 = Color(0xFFFDF9EC)
+    val telefonica_color_ambar_40 = Color(0xFFF0D57C)
+    val telefonica_color_ambar_70 = Color(0xFF69581F)
     val telefonica_color_ambar_light = Color(0xFFF5E98A)
     val telefonica_color_ambar_dark = Color(0xFFAD842D)
 
     val telefonica_color_coral = Color(0xFFE66C64)
+    val telefonica_color_coral_10 = Color(0xFFFDF0EF)
+    val telefonica_color_coral_40 = Color(0xFFE3A19A)
+    val telefonica_color_coral_70 = Color(0xFFD50000)
     val telefonica_color_coral_light = Color(0xFFE3A19A)
     val telefonica_color_coral_dark = Color(0xFF912C31)
 
     val telefonica_color_orchid = Color(0xFFC466EF)
+    val telefonica_color_orchid_10 = Color(0xFFF9F0FD)
+    val telefonica_color_orchid_40 = Color(0xFFD694F4)
+    val telefonica_color_orchid_70 = Color(0xFF8947A7)
     val telefonica_color_orchid_light = Color(0xFFE7C2F8)
     val telefonica_color_orchid_dark = Color(0xFF8A1A93)
 
     val telefonica_color_turquoise = Color(0xFF59C2C9)
+    val telefonica_color_turquoise_10 = Color(0xFFEEF9FA)
+    val telefonica_color_turquoise_40 = Color(0xFF8BD4D9)
+    val telefonica_color_turquoise_70 = Color(0xFF3E888D)
     val telefonica_color_turquoise_light = Color(0xFF67E0E5)
     val telefonica_color_turquoise_dark = Color(0xFF3E8A8A)
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
@@ -99,6 +99,18 @@ object TelefonicaBrand : Brand {
         loginLoadingGradientSecond = TelefonicaPaletteColor.telefonica_color_blue_dark,
         loginLoadingGradientThird = TelefonicaPaletteColor.telefonica_color_blue_dark,
         loginLoadingGradientFourth = TelefonicaPaletteColor.telefonica_color_blue_dark,
+        tagBackgroundSuccess = TelefonicaPaletteColor.telefonica_color_turquoise_10,
+        tagBackgroundWarning = TelefonicaPaletteColor.telefonica_color_ambar_10,
+        tagBackgroundError = TelefonicaPaletteColor.telefonica_color_coral_10,
+        tagBackgroundPromo = TelefonicaPaletteColor.telefonica_color_orchid_10,
+        tagBackgroundActive = TelefonicaPaletteColor.telefonica_color_grey_1,
+        tagBackgroundInactive = TelefonicaPaletteColor.telefonica_color_grey_1,
+        textTagSuccess = TelefonicaPaletteColor.telefonica_color_turquoise_70,
+        textTagWarning = TelefonicaPaletteColor.telefonica_color_ambar_70,
+        textTagError = TelefonicaPaletteColor.telefonica_color_coral_70,
+        textTagPromo = TelefonicaPaletteColor.telefonica_color_orchid_70,
+        textTagActive = TelefonicaPaletteColor.telefonica_color_blue,
+        textTagInactive = TelefonicaPaletteColor.telefonica_color_grey_6,
     )
 
     override val darkColors = MisticaColors(
@@ -191,6 +203,18 @@ object TelefonicaBrand : Brand {
         loginLoadingGradientSecond = TelefonicaPaletteColor.telefonica_color_grey_6,
         loginLoadingGradientThird = TelefonicaPaletteColor.telefonica_color_grey_6,
         loginLoadingGradientFourth = TelefonicaPaletteColor.telefonica_color_grey_6,
+        tagBackgroundSuccess = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        tagBackgroundWarning = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        tagBackgroundError = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        tagBackgroundPromo = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        tagBackgroundActive = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        tagBackgroundInactive = TelefonicaPaletteColor.telefonica_color_white_5_alpha,
+        textTagSuccess = TelefonicaPaletteColor.telefonica_color_turquoise_40,
+        textTagWarning = TelefonicaPaletteColor.telefonica_color_ambar_40,
+        textTagError = TelefonicaPaletteColor.telefonica_color_coral_40,
+        textTagPromo = TelefonicaPaletteColor.telefonica_color_orchid_40,
+        textTagActive = TelefonicaPaletteColor.telefonica_color_blue_30,
+        textTagInactive = TelefonicaPaletteColor.telefonica_color_grey_4,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
@@ -99,6 +99,18 @@ object VivoBrand : Brand {
         loginLoadingGradientSecond = VivoPaletteColor.vivo_color_purple,
         loginLoadingGradientThird = VivoPaletteColor.vivo_color_purple,
         loginLoadingGradientFourth = VivoPaletteColor.vivo_color_purple,
+        tagBackgroundSuccess = VivoPaletteColor.vivo_color_green_light10,
+        tagBackgroundWarning = VivoPaletteColor.vivo_color_orange_light10,
+        tagBackgroundError = VivoPaletteColor.vivo_color_pepper_light10,
+        tagBackgroundPromo = VivoPaletteColor.vivo_color_purple_light10,
+        tagBackgroundActive = VivoPaletteColor.vivo_color_purple_light10,
+        tagBackgroundInactive = VivoPaletteColor.vivo_color_grey_1,
+        textTagSuccess = VivoPaletteColor.vivo_color_green_dark,
+        textTagWarning = VivoPaletteColor.vivo_color_orange_dark,
+        textTagError = VivoPaletteColor.vivo_color_pepper_dark_80,
+        textTagPromo = VivoPaletteColor.vivo_color_purple,
+        textTagActive = VivoPaletteColor.vivo_color_purple,
+        textTagInactive = VivoPaletteColor.vivo_color_grey_5,
     )
 
     override val darkColors = lightColors.copy(
@@ -168,6 +180,18 @@ object VivoBrand : Brand {
         textNavigationBarSecondary = VivoPaletteColor.vivo_color_grey_4,
         textAppBar = VivoPaletteColor.vivo_color_grey_5,
         textAppBarSelected = VivoPaletteColor.vivo_color_grey_2,
+        tagBackgroundSuccess = VivoPaletteColor.vivo_color_white_5_alpha,
+        tagBackgroundWarning = VivoPaletteColor.vivo_color_white_5_alpha,
+        tagBackgroundError = VivoPaletteColor.vivo_color_white_5_alpha,
+        tagBackgroundPromo = VivoPaletteColor.vivo_color_white_5_alpha,
+        tagBackgroundActive = VivoPaletteColor.vivo_color_white_5_alpha,
+        tagBackgroundInactive = VivoPaletteColor.vivo_color_white_5_alpha,
+        textTagSuccess = VivoPaletteColor.vivo_color_green_light30,
+        textTagWarning = VivoPaletteColor.vivo_color_orange_light40,
+        textTagError = VivoPaletteColor.vivo_color_pepper_light40,
+        textTagPromo = VivoPaletteColor.vivo_color_purple_light50,
+        textTagActive = VivoPaletteColor.vivo_color_purple_light50,
+        textTagInactive = VivoPaletteColor.vivo_color_grey_4,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
@@ -182,16 +182,26 @@ private object VivoPaletteColor {
 
     val vivo_color_green = Color(0xFF99CC33)
     val vivo_color_green_dark = Color(0xFF33A14A)
+    val vivo_color_green_light10 = Color(0xFFEDF8E8)
+    val vivo_color_green_light30 = Color(0xFF91AE9E)
     val vivo_color_green_light40 = Color(0xFFD6EAAD)
 
     val vivo_color_blue = Color(0xFF00ABDB)
+
     val vivo_color_orange = Color(0xFFFF9900)
     val vivo_color_orange_dark = Color(0xFFFA6324)
     val vivo_color_orange_light = Color(0xFFFFD699)
+    val vivo_color_orange_light10 = Color(0xFFFFEFE1)
+    val vivo_color_orange_light40 = Color(0xFFFFB84C)
+
     val vivo_color_pink = Color(0xFFEB3D7D)
+
     val vivo_color_pepper = Color(0xFFCC1F59)
     val vivo_color_pepper_dark = Color(0xFFB71D63)
+    val vivo_color_pepper_dark_80 = Color(0xFF8F2052)
+    val vivo_color_pepper_light10 = Color(0xFFFCE4EF)
     val vivo_color_pepper_light30 = Color(0xFFF7B1CB)
+    val vivo_color_pepper_light40 = Color(0xFFDB628B)
 
     val vivo_color_grey_1 = Color(0xFFF6F6F6)
     val vivo_color_grey_2 = Color(0xFFEEEEEE)

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
@@ -97,6 +97,18 @@ class MisticaColors(
     loginLoadingGradientSecond: Color = Color.Unspecified,
     loginLoadingGradientThird: Color = Color.Unspecified,
     loginLoadingGradientFourth: Color = Color.Unspecified,
+    tagBackgroundSuccess: Color = Color.Unspecified,
+    tagBackgroundWarning: Color = Color.Unspecified,
+    tagBackgroundError: Color = Color.Unspecified,
+    tagBackgroundPromo: Color = Color.Unspecified,
+    tagBackgroundActive: Color = Color.Unspecified,
+    tagBackgroundInactive: Color = Color.Unspecified,
+    textTagSuccess: Color = Color.Unspecified,
+    textTagWarning: Color = Color.Unspecified,
+    textTagError: Color = Color.Unspecified,
+    textTagPromo: Color = Color.Unspecified,
+    textTagActive: Color = Color.Unspecified,
+    textTagInactive: Color = Color.Unspecified,
 ) {
     var appBarBackground by mutableStateOf(appBarBackground, structuralEqualityPolicy())
         internal set
@@ -276,6 +288,30 @@ class MisticaColors(
         internal set
     var loginLoadingGradientFourth by mutableStateOf(loginLoadingGradientFourth, structuralEqualityPolicy())
         internal set
+    var tagBackgroundSuccess by mutableStateOf(tagBackgroundSuccess, structuralEqualityPolicy())
+        internal set
+    var tagBackgroundWarning by mutableStateOf(tagBackgroundWarning, structuralEqualityPolicy())
+        internal set
+    var tagBackgroundError by mutableStateOf(tagBackgroundError, structuralEqualityPolicy())
+        internal set
+    var tagBackgroundPromo by mutableStateOf(tagBackgroundPromo, structuralEqualityPolicy())
+        internal set
+    var tagBackgroundActive by mutableStateOf(tagBackgroundActive, structuralEqualityPolicy())
+        internal set
+    var tagBackgroundInactive by mutableStateOf(tagBackgroundInactive, structuralEqualityPolicy())
+        internal set
+    var textTagSuccess by mutableStateOf(textTagSuccess, structuralEqualityPolicy())
+        internal set
+    var textTagWarning by mutableStateOf(textTagWarning, structuralEqualityPolicy())
+        internal set
+    var textTagError by mutableStateOf(textTagError, structuralEqualityPolicy())
+        internal set
+    var textTagPromo by mutableStateOf(textTagPromo, structuralEqualityPolicy())
+        internal set
+    var textTagActive by mutableStateOf(textTagActive, structuralEqualityPolicy())
+        internal set
+    var textTagInactive by mutableStateOf(textTagInactive, structuralEqualityPolicy())
+        internal set
 
     fun copy(
         appBarBackground: Color = this.appBarBackground,
@@ -367,6 +403,18 @@ class MisticaColors(
         loginLoadingGradientSecond: Color = this.loginLoadingGradientSecond,
         loginLoadingGradientThird: Color = this.loginLoadingGradientThird,
         loginLoadingGradientFourth: Color = this.loginLoadingGradientFourth,
+        tagBackgroundSuccess: Color = this.tagBackgroundSuccess,
+        tagBackgroundWarning: Color = this.tagBackgroundWarning,
+        tagBackgroundError: Color = this.tagBackgroundError,
+        tagBackgroundPromo: Color = this.tagBackgroundPromo,
+        tagBackgroundActive: Color = this.tagBackgroundActive,
+        tagBackgroundInactive: Color = this.tagBackgroundInactive,
+        textTagSuccess: Color = this.textTagSuccess,
+        textTagWarning: Color = this.textTagWarning,
+        textTagError: Color = this.textTagError,
+        textTagPromo: Color = this.textTagPromo,
+        textTagActive: Color = this.textTagActive,
+        textTagInactive: Color = this.textTagInactive,
     ): MisticaColors = MisticaColors(
         appBarBackground,
         background,

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
@@ -505,6 +505,18 @@ class MisticaColors(
         loginLoadingGradientSecond,
         loginLoadingGradientThird,
         loginLoadingGradientFourth,
+        tagBackgroundSuccess,
+        tagBackgroundWarning,
+        tagBackgroundError,
+        tagBackgroundPromo,
+        tagBackgroundActive,
+        tagBackgroundInactive,
+        textTagSuccess,
+        textTagWarning,
+        textTagError,
+        textTagPromo,
+        textTagActive,
+        textTagInactive,
     )
 
     internal fun MisticaColors.updateColorsFrom(other: MisticaColors) {
@@ -597,6 +609,18 @@ class MisticaColors(
         loginLoadingGradientSecond = other.loginLoadingGradientSecond
         loginLoadingGradientThird = other.loginLoadingGradientThird
         loginLoadingGradientFourth = other.loginLoadingGradientFourth
+        tagBackgroundSuccess = other.tagBackgroundSuccess
+        tagBackgroundWarning = other.tagBackgroundWarning
+        tagBackgroundError = other.tagBackgroundError
+        tagBackgroundPromo = other.tagBackgroundPromo
+        tagBackgroundActive = other.tagBackgroundActive
+        tagBackgroundInactive = other.tagBackgroundInactive
+        textTagSuccess = other.textTagSuccess
+        textTagWarning = other.textTagWarning
+        textTagError = other.textTagError
+        textTagPromo = other.textTagPromo
+        textTagActive = other.textTagActive
+        textTagInactive = other.textTagInactive
     }
 }
 


### PR DESCRIPTION
### :goal_net: What's the goal?
The objective is to duplicate the evolved Tag component to the Composable version.

### :construction: How do we do it?
Following the UX indications, certain attributes of the view have been modified to adapt to evolution

### ☑️ Checks
- [x] Tested with dark mode.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
- [] [Manually - App Center (Not uploaded yet)]()

![Light Mode](https://user-images.githubusercontent.com/8106237/145584433-3be9f27d-148d-4f45-be9d-fe7cb44f6445.png)
![Dark Mode](https://user-images.githubusercontent.com/8106237/145584453-fd79c22d-eeb7-4ad3-b847-5af73052fb3e.png)

