### PR TITLE
ANDROID-10252 [Compose] Fix ListRowItem vertical padding and title style

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
@@ -212,10 +212,6 @@ fun Lists() {
                 trailing = item.action,
                 onClick = item.onClick,
             )
-            Divider(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                color = MisticaTheme.colors.divider
-            )
         }
         items(samples.map {
             it.copy(
@@ -234,10 +230,6 @@ fun Lists() {
                 description = item.description,
                 trailing = item.action,
                 onClick = item.onClick,
-            )
-            Divider(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                color = MisticaTheme.colors.divider
             )
         }
     }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -58,7 +58,7 @@ fun ListRowItem(
         BackgroundType.TYPE_BOXED,
         BackgroundType.TYPE_BOXED_INVERSE,
         -> modifier
-            .padding(16.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
     }
         .fillMaxWidth()
         .clip(shape = RoundedCornerShape(4.dp))
@@ -124,7 +124,7 @@ fun ListRowItem(
                 title?.let {
                     Text(
                         text = it,
-                        style = MisticaTheme.typography.preset3Light,
+                        style = MisticaTheme.typography.preset3,
                         color = textColorPrimary,
                     )
                 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix ListRowItem vertical padding and title style (only in Compose version of the component)

### :construction: How do we do it?
- Row title from light to regular
- Space between rows should be 16dp, when each row sum 8dp
- Removed dividers from catalog in order to be aligned with non-composable catalog where there aren't dividers

### :test_tube: How can I test this?
| Before | After |
| ------ | ------ |
| <img width="373" alt="Captura de pantalla 2022-01-19 a las 16 27 29" src="https://user-images.githubusercontent.com/47142570/150161835-3ade0509-1583-485f-a6f1-799388c843b5.png"> | <img width="376" alt="Captura de pantalla 2022-01-19 a las 16 20 09" src="https://user-images.githubusercontent.com/47142570/150161718-871dc975-9b2f-46a5-95d4-69dc06105af2.png"> |
