### PR TITLE
ANDROID-10257 - Not uploading mappings (they doesn't exist in debug)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ appcenter {
             appName = "mistica"
         }
     }
+    uploadMappingFiles = false
 }
 
 dependencies {


### PR DESCRIPTION
### :goal_net: What's the goal?
ANDROID-10257 The appcenter plugin has a bug that crashes the upload when attempting to upload the mapping file if it doesn't exist

### :construction: How do we do it?
In Mística we will never have mapping file. So I'm setting the upload mapping file flag to false

