### PR TITLE
ANDROID-10345 Do not capitalize data card subtitle in compose

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
@@ -81,8 +81,6 @@ internal fun CardActions(primaryButton: Action?, linkButton: Action?) {
     }
 }
 
-
-
 @Composable
 internal fun CardContent(
     tag: Tag?,
@@ -100,7 +98,6 @@ internal fun CardContent(
             ) {
                 tag.build()
             }
-
         }
         preTitle?.let {
 
@@ -122,7 +119,7 @@ internal fun CardContent(
         subtitle?.let {
             Text(
                 modifier = Modifier.padding(top =4.dp),
-                text = subtitle.uppercase(),
+                text = subtitle,
                 style = MisticaTheme.typography.preset2,
             )
         }


### PR DESCRIPTION
### :goal_net: What's the goal?
Non-composable DataCard don't force caps on its subtitle so we shouldn't be doing the same in the Compose version.

### :construction: How do we do it?
Remove call to `uppercase` over DataCard subtitle


### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
## Before
![Captura de pantalla 2022-02-08 a las 16 40 45](https://user-images.githubusercontent.com/47142570/153022771-177e58fd-fe52-4e05-b8e1-3d992a58f181.png)
## After
![Captura de pantalla 2022-02-08 a las 16 40 00](https://user-images.githubusercontent.com/47142570/153022787-e5b7c434-b1ae-4ed6-a4e2-72053e798354.png)
## Non Compose DataCard
![Captura de pantalla 2022-02-08 a las 16 41 03](https://user-images.githubusercontent.com/47142570/153022812-f0b66d3a-750a-4237-967b-f39000bd1104.png)

- [ ] Reviewed by Mistica design team
