### PR TITLE
ANDROID-10348 Allow customization in Compose DataCard icon

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/card/datacard/IconPainter.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/card/datacard/IconPainter.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -27,16 +28,23 @@ sealed class IconPainter {
         }
     }
 
-    class ResourceIconPainter(val iconRes: Int) : IconPainter() {
+    class ResourceIconPainter(
+        val iconRes: Int,
+        val iconTint: Color?,
+        val backgroundColor: Color,
+    ) : IconPainter() {
         @Composable
         override fun Paint() {
             Box(
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
             ) {
-                Circle {
+                Circle(
+                    color = backgroundColor
+                ) {
                     Image(
                         painter = painterResource(id = iconRes),
                         contentDescription = null,
+                        colorFilter = iconTint?.let { ColorFilter.tint(iconTint) },
                         contentScale = ContentScale.Crop
                     )
                 }
@@ -90,7 +98,16 @@ sealed class IconPainter {
     }
 }
 
-fun resourceIconPainter(@DrawableRes iconRes: Int) = IconPainter.ResourceIconPainter(iconRes)
+@Composable
+fun resourceIconPainter(
+    @DrawableRes iconRes: Int,
+    iconTint: Color? = null,
+    backgroundColor: Color = MisticaTheme.colors.neutralLow,
+) = IconPainter.ResourceIconPainter(
+    iconRes = iconRes,
+    iconTint = iconTint,
+    backgroundColor = backgroundColor
+)
 
 fun textIconPainter(
     text: String,


### PR DESCRIPTION
### :goal_net: What's the goal?
DataCard component in Compose library allows to set an icon using a drawable resource Id but it is not possible to customize the resulting icon shown.

### :construction: How do we do it?
I have added two extra params with default values so the change is not breaking:
- `iconTint: Color? = null`
- `backgroundColor: Color = MisticaTheme.color.neutralLow` (current value for the icon background)

This isn't a change on the specification of DataCard but an internal change required by us so we can have moreo control over how its icon is drawn (without having to have multiple assets instead of just one but tinted multiple times)

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). Not needed, we don't document every method on readmes.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
The following screenshot shows a DataCard with an icon tinted and a background with a custom color as well
![Captura de pantalla 2022-02-09 a las 9 56 45](https://user-images.githubusercontent.com/47142570/153160433-691d119c-8ee7-414e-afcf-1a0aa2478ea2.png)
- [x] Reviewed by Mistica design team

