### PR TITLE
ANDROID-10304 Fix margin Tag to any view in Cards

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
@@ -94,17 +94,15 @@ internal fun CardContent(
     Column {
         if (tag != null) {
             Box(modifier = Modifier
-                .padding(
-                    top = 8.dp
-                )
+                .padding(top = 8.dp, bottom = 8.dp)
             ) {
                 tag.build()
             }
         }
-        preTitle?.let {
 
+        preTitle?.let {
             Text(
-                modifier = Modifier.padding(top = 16.dp),
+                modifier = Modifier.padding(top = 8.dp),
                 text = preTitle,
                 style = MisticaTheme.typography.preset1,
                 color = MisticaTheme.colors.highlight
@@ -113,14 +111,14 @@ internal fun CardContent(
 
         title?.let {
             Text(
-                modifier = Modifier.padding(top = 4.dp),
+                modifier = Modifier.padding(top = 8.dp),
                 text = title,
                 style = MisticaTheme.typography.preset4,
             )
         }
         subtitle?.let {
             Text(
-                modifier = Modifier.padding(top =4.dp),
+                modifier = Modifier.padding(top = 8.dp),
                 text = subtitle,
                 style = MisticaTheme.typography.preset2,
             )

--- a/library/src/main/res/layout/card_content_view.xml
+++ b/library/src/main/res/layout/card_content_view.xml
@@ -11,6 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         android:visibility="gone"
         tools:text="HEADLINE"
         tools:visibility="visible" />
@@ -19,7 +20,7 @@
         android:id="@+id/card_pre_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="8dp"
         android:textAllCaps="true"
         android:textAppearance="@style/AppTheme.TextAppearance.Preset1"
         android:textColor="?colorHighlight"


### PR DESCRIPTION
### :goal_net: What's the goal?
Let 16dp from TagView not taking into account whether view is below.

### :construction: How do we do it?
Changing margins

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [x] 🖼️ Screenshots/Videos
- [x] Mistica App QR or [download link](https://install.appcenter.ms/orgs/Tuenti-Organization/apps/Mistica-Catalog)
- [ ] Reviewed by Mistica design team

<img width="853" alt="Screenshot 2022-02-15 at 10 46 17" src="https://user-images.githubusercontent.com/8106237/154036441-a876a6b3-5f60-4e4d-9c7d-300137903bdb.png">
