### PR TITLE
ANDROID-10425 - Set min height in lists

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -30,9 +30,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.badge.Badge
-import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.shape.Chevron
 import com.telefonica.mistica.compose.shape.Circle
+import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
@@ -54,7 +54,7 @@ fun ListRowItem(
     val badgeVisible by remember { mutableStateOf(isBadgeVisible) }
 
     val boxModifier = when (backgroundType) {
-        BackgroundType.TYPE_NORMAL -> Modifier
+        BackgroundType.TYPE_NORMAL -> modifier
         BackgroundType.TYPE_BOXED,
         BackgroundType.TYPE_BOXED_INVERSE,
         -> modifier
@@ -84,6 +84,10 @@ fun ListRowItem(
             )
     }
         .fillMaxWidth()
+        .defaultMinSize(minHeight = when(description) {
+            null -> 72.dp
+            else -> 80.dp
+        })
         .padding(16.dp)
 
     val textColorPrimary = when (backgroundType) {


### PR DESCRIPTION
### :goal_net: What's the goal?
There is no minimum height. Setting one.
https://app.zeplin.io/project/5d653c69f828bf7299c551c1/screen/5e9d50079630597dd4731f3d

### :construction: How do we do it?
Just setting the min height

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?


https://user-images.githubusercontent.com/4595241/155322587-19061450-0ed9-4232-9cfc-01ba7adee9d4.mp4


