### PR TITLE
ANDROID-10428 Remove capitalization on Tags

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -72,7 +72,7 @@ fun Tag(
             }
 
             Text(
-                text = text.captitalizeFirstChar(),
+                text = text,
                 modifier = Modifier.padding(start = if (icon != null) 4.dp else 0.dp),
                 style = MisticaTheme.typography.preset2Medium,
                 color = textColor,
@@ -148,8 +148,4 @@ private fun Int.getStyle() = when (this) {
     TYPE_ERROR -> with(MisticaTheme.colors) { tagBackgroundError to textTagError }
     TYPE_INVERSE -> with(MisticaTheme.colors) { inverse to textTagActive }
     else -> with(MisticaTheme.colors) { tagBackgroundPromo to textTagPromo }
-}
-
-private fun String.captitalizeFirstChar(): String {
-    return lowercase(Locale.getDefault()).replaceFirstChar { if (it.isLowerCase()) it.uppercase() else it.toString() }
 }

--- a/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
+++ b/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
@@ -85,7 +85,7 @@ class TagView @JvmOverloads constructor(
     }
 
     override fun setText(text: CharSequence?, type: BufferType?) {
-        super.setText(text?.toString()?.captitalizeFirstChar(), type)
+        super.setText(text?.toString(), type)
     }
 
     private fun Int.getStyle() = when (this) {
@@ -97,10 +97,6 @@ class TagView @JvmOverloads constructor(
         TYPE_ERROR -> R.attr.tagBackgroundError to R.attr.textTagError
         TYPE_INVERSE -> R.attr.colorInverse to R.attr.textTagActive
         else -> R.attr.tagBackgroundPromo to R.attr.textTagPromo
-    }
-
-    private fun String.captitalizeFirstChar(): String {
-        return lowercase(Locale.getDefault()).replaceFirstChar { if (it.isLowerCase()) it.uppercase() else it.toString() }
     }
 
     companion object {


### PR DESCRIPTION
### :goal_net: What's the goal?
Due to this [ticket](https://jira.tid.es/browse/TGT-548), it has been detected that it was not wanted to force a capitalization of the first character and leave the rest in lowercase. The propose is leave server to customise string format.

Targeting Ticket: [TGT-548](https://jira.tid.es/browse/TGT-548)
Android Ticket: [ANDROID-10428](https://jira.tid.es/browse/ANDROID-10428)

### :construction: How do we do it?
Removing this feature.

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or [download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public)

[Screenshot](https://user-images.githubusercontent.com/8106237/155361856-9b04cc69-2663-4ce2-be8f-f0b9e81080e0.png)

