### PR TITLE
Add visual transformation param to Text, Email and Phone inputs

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
@@ -191,7 +191,7 @@ private fun TextInputWithTransformation() {
 
 object PhoneVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
-        val newText = AnnotatedString("$PREFIX  $text")
+        val newText = AnnotatedString("$PREFIX$text")
         return TransformedText(newText, object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int =
                 offset + PREFIX_LENGTH

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
@@ -17,6 +17,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.button.Button
 import com.telefonica.mistica.compose.button.ButtonStyle
@@ -43,8 +47,8 @@ fun Inputs() {
         TextInputWithError()
         Title("Text Input With Assertive Text that is way too long to fit in the given space")
         TextInputWithHelperText()
-        Title("Password input")
-        PasswordInput()
+        Title("Text input with transformation")
+        TextInputWithTransformation()
         Title("Phone input")
         PhoneInputSample()
         Title("Email input")
@@ -147,25 +151,6 @@ private fun TextInputWithHelperText(
 }
 
 @Composable
-private fun PasswordInput() {
-    var text by remember {
-        mutableStateOf("")
-    }
-
-    TextInput(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp, start = 16.dp, end = 16.dp)
-        ,
-        value = text,
-        onValueChange = {
-            text = it
-        },
-        label = "Type Something"
-    )
-}
-
-@Composable
 private fun PhoneInputSample() {
     var text by remember {
         mutableStateOf("")
@@ -182,6 +167,42 @@ private fun PhoneInputSample() {
         },
         label = "Type Something"
     )
+}
+
+@Composable
+private fun TextInputWithTransformation() {
+    var text by remember {
+        mutableStateOf("")
+    }
+
+    TextInput(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp)
+        ,
+        value = text,
+        onValueChange = {
+            text = it
+        },
+        label = "Your name",
+        visualTransformation = PhoneVisualTransformation
+    )
+}
+
+object PhoneVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val newText = AnnotatedString("$PREFIX  $text")
+        return TransformedText(newText, object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int =
+                offset + PREFIX_LENGTH
+
+            override fun transformedToOriginal(offset: Int): Int =
+                offset - PREFIX_LENGTH
+        })
+    }
+
+    private const val PREFIX = "Hola,  "
+    private const val PREFIX_LENGTH = PREFIX.length
 }
 
 @Composable

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.compose.input
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 
 @Composable
 fun EmailInput(
@@ -18,6 +19,7 @@ fun EmailInput(
     enabled: Boolean = true,
     readOnly: Boolean = false,
     onClick: (() -> Unit)? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
@@ -33,6 +35,7 @@ fun EmailInput(
         enabled = enabled,
         readOnly = readOnly,
         onClick = onClick,
+        visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
             keyboardType = KeyboardType.Email
         )

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.compose.input
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 
 @Composable
 fun PhoneInput(
@@ -18,6 +19,7 @@ fun PhoneInput(
     enabled: Boolean = true,
     readOnly: Boolean = false,
     onClick: (() -> Unit)? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
@@ -33,6 +35,7 @@ fun PhoneInput(
         enabled = enabled,
         readOnly = readOnly,
         onClick = onClick,
+        visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
             keyboardType = KeyboardType.Phone
         )

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.compose.input
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 
 @Composable
 fun TextInput(
@@ -18,6 +19,7 @@ fun TextInput(
     enabled: Boolean = true,
     readOnly: Boolean = false,
     onClick: (() -> Unit)? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     TextInputImpl(
@@ -33,6 +35,7 @@ fun TextInput(
         enabled = enabled,
         readOnly = readOnly,
         onClick = onClick,
+        visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
             keyboardType = KeyboardType.Text
         )

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
@@ -42,6 +43,7 @@ internal fun TextInputImpl(
     enabled: Boolean,
     readOnly: Boolean,
     onClick: (() -> Unit)?,
+    visualTransformation: VisualTransformation,
     keyboardOptions: FoundationKeyboardOptions,
 ) {
     val colors = if (isInverse) {
@@ -66,6 +68,7 @@ internal fun TextInputImpl(
                 enabled = enabled,
                 readOnly = readOnly,
                 onClick = onClick,
+                visualTransformation = visualTransformation,
                 keyboardOptions = keyboardOptions
             )
             Underline(
@@ -87,6 +90,7 @@ private fun TextBox(
     enabled: Boolean,
     readOnly: Boolean,
     onClick: (() -> Unit)?,
+    visualTransformation: VisualTransformation,
     keyboardOptions: FoundationKeyboardOptions,
 ) {
     val interactionSource = remember {
@@ -126,6 +130,7 @@ private fun TextBox(
             errorCursorColor = MisticaTheme.colors.controlActive,
         ),
         maxLines = 1,
+        visualTransformation = visualTransformation,
     )
 }
 

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -129,6 +129,7 @@ private fun TextBox(
             errorIndicatorColor = Color.Transparent,
             errorCursorColor = MisticaTheme.colors.controlActive,
         ),
+        singleLine = true,
         maxLines = 1,
         visualTransformation = visualTransformation,
     )


### PR DESCRIPTION
### :goal_net: What's the goal?
In some cases we will want to add some visual effects/format to a text input. I'm exposing the same `VisualTransformation` param that built-in `TextField` expose

### :construction: How do we do it?
- Propagate `VisualTransformation` from `TextField` to `PhoneInput`, `EmailInput` and `TextInput` and setting `VisualTransformation.None`. as the default value (just like in `TextField`).
- Add catalog example

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos

https://user-images.githubusercontent.com/47142570/159954971-13203686-688a-4f23-a49a-a09b23970ccd.mov


