### PR TITLE
Wrap IndterminateStepperView into AndroidView composable

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
@@ -46,6 +46,7 @@ import com.telefonica.mistica.compose.catalog.ui.components.Feedbacks
 import com.telefonica.mistica.compose.catalog.ui.components.Inputs
 import com.telefonica.mistica.compose.catalog.ui.components.Lists
 import com.telefonica.mistica.compose.catalog.ui.components.MediaCards
+import com.telefonica.mistica.compose.catalog.ui.components.Steppers
 import com.telefonica.mistica.compose.catalog.ui.components.Tags
 import com.telefonica.mistica.compose.catalog.ui.components.Texts
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -152,6 +153,7 @@ fun CatalogNavHost(
         composable(NavigationRoutes.CAROUSELS) { Carousels() }
         composable(NavigationRoutes.EMPTY_STATE_CARD) { EmptyStateCards() }
         composable(NavigationRoutes.EMPTY_STATE_SCREEN) { EmptyStateScreens() }
+        composable(NavigationRoutes.STEPPER) { Steppers() }
     }
 }
 
@@ -217,6 +219,11 @@ fun Catalog(
             name = "Empty State Card",
             icon = R.drawable.ic_empty_states,
             navigation = NavigationRoutes.EMPTY_STATE_CARD
+        ),
+        ComponentScreen(
+            name = "Steppers",
+            icon = R.drawable.ic_stepper,
+            navigation = NavigationRoutes.STEPPER
         ),
     )
     Column {
@@ -292,4 +299,5 @@ object NavigationRoutes {
     const val CAROUSELS = "carousels"
     const val EMPTY_STATE_SCREEN = "empty-state-screen"
     const val EMPTY_STATE_CARD = "empty-state-card"
+    const val STEPPER = "stepper"
 }

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Buttons.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Buttons.kt
@@ -1,7 +1,6 @@
 package com.telefonica.mistica.compose.catalog.ui.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Steppers.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Steppers.kt
@@ -63,19 +63,21 @@ private fun IndeterminateStepperDemo(modifier: Modifier) {
             Button(
                 text = "Previous",
                 onClickListener = {
-                    if (progress - 10 >= 0) {
-                        progress -= 10
+                    if (progress - STEPPER_DEMO_PROGRESS_INTERVAL >= 0) {
+                        progress -= STEPPER_DEMO_PROGRESS_INTERVAL
                     }
                 }
             )
             Button(
                 text = "Next",
                 onClickListener = {
-                    if (progress + 10 <= 100) {
-                        progress += 10
+                    if (progress + STEPPER_DEMO_PROGRESS_INTERVAL <= 100) {
+                        progress += STEPPER_DEMO_PROGRESS_INTERVAL
                     }
                 }
             )
         }
     }
 }
+
+const val STEPPER_DEMO_PROGRESS_INTERVAL = 20

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Steppers.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Steppers.kt
@@ -1,0 +1,81 @@
+package com.telefonica.mistica.compose.catalog.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.telefonica.mistica.compose.button.Button
+import com.telefonica.mistica.compose.stepper.IndeterminateStepper
+
+@Composable
+fun Steppers() {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(scrollState)
+    ) {
+        IndeterminateStepper(
+            modifier = Modifier.fillMaxWidth(),
+            progress = 0
+        )
+        IndeterminateStepper(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            progress = 50
+        )
+        IndeterminateStepperDemo(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun IndeterminateStepperDemo(modifier: Modifier) {
+    var progress by remember {
+        mutableStateOf(0)
+    }
+
+    Column(modifier = modifier) {
+        IndeterminateStepper(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            progress = progress
+        )
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+            Button(
+                text = "Previous",
+                onClickListener = {
+                    if (progress - 10 >= 0) {
+                        progress -= 10
+                    }
+                }
+            )
+            Button(
+                text = "Next",
+                onClickListener = {
+                    if (progress + 10 <= 100) {
+                        progress += 10
+                    }
+                }
+            )
+        }
+    }
+}

--- a/catalog-compose/src/main/res/drawable/ic_stepper.xml
+++ b/catalog-compose/src/main/res/drawable/ic_stepper.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M0,0h24v24h-24z"
+      android:fillColor="#F2F2F2"
+      android:fillAlpha="0.03"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M6,12m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0"
+      android:fillColor="#003245"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M6,11h11v2h-11z"
+      android:fillColor="#003245"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M18,12m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0"
+      android:fillColor="#003245"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M18,12m-3,0a3,3 0,1 1,6 0a3,3 0,1 1,-6 0"
+      android:fillColor="#FFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/library-compose/README.md
+++ b/library-compose/README.md
@@ -68,6 +68,7 @@ Mística-compose supports a subset of the Mística elements. The objective is to
 * [Empty States](./src/main/java/com/telefonica/mistica/compose/emptystate/screen)
 * [Empty State Cards](./src/main/java/com/telefonica/mistica/compose/emptystate/card)
 * [Inputs](./src/main/java/com/telefonica/mistica/compose/input)
+* [Steppers](./src/main/java/com/telefonica/mistica/compose/stepper)
 
 ## Fonts
 Mística-compose supports the same fonts supported in Mística. See [MisticaTypography](https://github.com/Telefonica/mistica-android/library-compose/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt)
@@ -105,8 +106,9 @@ There is a Mística-compose catalog in the [Demo app](https://github.com/Telefon
 | Controls					|     |     |    				
 | Media Cards				|  ✅️ |  Composable   |
 | Data Cards				|  ✅️ |  Composable   |
-| Steppers					|     |     |    				
-| Tabs						|     |     |    			
+| Indeterminate Stepper		|  ✅️ |  AndroidView  |
+| Determinate Stepper		|     |     |
+| Tabs						|     |     |
 | Empty States				|  ✅ | AndroidView   |
 | Empty State Cards			|  ✅ | AndroidView   |
 | Callout					|     |     |    						

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/stepper/IndeterminateStepper.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/stepper/IndeterminateStepper.kt
@@ -1,0 +1,27 @@
+package com.telefonica.mistica.compose.stepper
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.telefonica.mistica.stepper.IndeterminateStepperView
+
+@Composable
+fun IndeterminateStepper(
+    modifier: Modifier = Modifier,
+    progress: Int,
+) {
+    val context = LocalContext.current
+
+    AndroidView(
+        modifier = modifier,
+        factory = {
+            IndeterminateStepperView(context).also {
+                it.setProgress(progress, animate = false)
+            }
+        },
+        update = {
+            it.setProgress(progress, animate = true)
+        }
+    )
+}

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/stepper/README.md
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/stepper/README.md
@@ -1,0 +1,15 @@
+There are two types of steppers:
+
+### Indeterminate
+
+<p align="center">
+   <img src="../../../../../../../../doc/images/steppers/indeterminate_stepper.png" />
+</p>
+
+Compose version of `com.telefonica.mistica.stepper.IndeterminateStepperView`. Use `progress: Int` param to determine the current progress of the stepper. If
+the value passed is lower than 0 then 0 will be set;on the other hand, if a value greater than 100 is passed then 100 will be set.
+
+
+### Determined
+
+Not migrated yet to compose

--- a/library/src/main/java/com/telefonica/mistica/stepper/DeterminateStepperView.kt
+++ b/library/src/main/java/com/telefonica/mistica/stepper/DeterminateStepperView.kt
@@ -154,7 +154,7 @@ class DeterminateStepperView @JvmOverloads constructor(
 
     private fun setUpIndeterminateStepper() {
         indeterminateStepper = IndeterminateStepperView(context)
-        setIndeterminateStep(FIRST_STEP)
+        setIndeterminateStep(FIRST_STEP, animate = false)
         addView(indeterminateStepper)
     }
 
@@ -170,7 +170,7 @@ class DeterminateStepperView @JvmOverloads constructor(
         if (isDetermined) {
             setDeterminedStep(step)
         } else {
-            setIndeterminateStep(step)
+            setIndeterminateStep(step, animate = true)
         }
     }
 
@@ -209,9 +209,9 @@ class DeterminateStepperView @JvmOverloads constructor(
         }
     }
 
-    private fun setIndeterminateStep(step: Int) {
+    private fun setIndeterminateStep(step: Int, animate: Boolean) {
         val progress = (MAX_INDETERMINATE_PROGRESS / (maxSteps + 1)) * step
-        indeterminateStepper?.setProgress(progress.roundToInt())
+        indeterminateStepper?.setProgress(progress.roundToInt(), animate)
     }
 
     private fun complete() {

--- a/library/src/main/java/com/telefonica/mistica/stepper/IndeterminateStepperView.kt
+++ b/library/src/main/java/com/telefonica/mistica/stepper/IndeterminateStepperView.kt
@@ -40,18 +40,22 @@ class IndeterminateStepperView @JvmOverloads constructor(
             )
 
             val progress = styledAttrs.getInteger(R.styleable.IndeterminateStepperView_progress, 0)
-            setProgress(progress)
+            setProgress(progress, animate = false)
         }
     }
 
-    fun setProgress(progress: Int) {
-        ValueAnimator.ofInt(progressBar.progress, progress).apply {
-            addUpdateListener {
-                progressBar.progress = it.animatedValue as Int
+    fun setProgress(progress: Int, animate: Boolean = true) {
+        if (animate) {
+            ValueAnimator.ofInt(progressBar.progress, progress).apply {
+                addUpdateListener {
+                    progressBar.progress = it.animatedValue as Int
+                }
+                duration = PROGRESS_ANIMATION_DURATION
+                interpolator = AccelerateDecelerateInterpolator()
+                start()
             }
-            duration = PROGRESS_ANIMATION_DURATION
-            interpolator = AccelerateDecelerateInterpolator()
-            start()
+        } else {
+            progressBar.progress = progress
         }
     }
 

--- a/library/src/main/java/com/telefonica/mistica/stepper/IndeterminateStepperView.kt
+++ b/library/src/main/java/com/telefonica/mistica/stepper/IndeterminateStepperView.kt
@@ -4,7 +4,7 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.DecelerateInterpolator
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import androidx.databinding.BindingMethod
@@ -51,7 +51,7 @@ class IndeterminateStepperView @JvmOverloads constructor(
                     progressBar.progress = it.animatedValue as Int
                 }
                 duration = PROGRESS_ANIMATION_DURATION
-                interpolator = AccelerateDecelerateInterpolator()
+                interpolator = DecelerateInterpolator()
                 start()
             }
         } else {
@@ -68,7 +68,7 @@ class IndeterminateStepperView @JvmOverloads constructor(
     }
 
     private companion object {
-        const val PROGRESS_ANIMATION_DURATION = 500L
+        const val PROGRESS_ANIMATION_DURATION = 100L
         const val EMPTY_PROGRESS = 0
         const val FULL_PROGRESS = 100
     }


### PR DESCRIPTION
### :goal_net: What's the goal?
Migrate Stepper to compose, but for now only `IndeterminateStepperView` view since it is needed by another app.

### :construction: How do we do it?
- Wrap `IndeterminateStepperView` into `IndeterminateStepper`
- Add param `animate: Boolean = true` to `IndeterminateStepperView::setProgress` method because there are some places where animation needs to be explicitly disabled

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.

### :test_tube: How can I test this?
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public)
- [x] Reviewed by Mistica design team
- [x] 🖼️ Screenshots/Videos

https://user-images.githubusercontent.com/47142570/160644415-5d879efd-09e4-45de-81d2-97ed609520ad.mov


