### PR TITLE
ANDROID-10695 Make Feedback onBackpressed param optional

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
@@ -1,16 +1,12 @@
 package com.telefonica.mistica.compose.feedback
 
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import com.telefonica.mistica.feedback.screen.view.FeedbackScreenView
 
@@ -31,7 +27,7 @@ fun Feedback(
     var shouldPerformTheAnimation by remember { mutableStateOf(true) }
 
     onBackPressed?.let {
-        BackHandler(it)
+        BackHandler(onBack = onBackPressed)
     }
 
     AndroidView(factory = { context ->
@@ -56,32 +52,5 @@ fun Feedback(
             }
         }
     })
-}
 
-@Composable
-private fun BackHandler(
-    onBackPressed: () -> Unit
-) {
-    val currentOnBack by rememberUpdatedState(newValue = onBackPressed)
-
-    val backCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                currentOnBack()
-            }
-
-        }
-    }
-
-    val backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current) {
-        "No OnBackPressedDispatcherOwner was provided via LocalOnBackPressedDispatcherOwner"
-    }.onBackPressedDispatcher
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    DisposableEffect(lifecycleOwner, backDispatcher) {
-        backDispatcher.addCallback(lifecycleOwner, backCallback)
-        onDispose {
-            backCallback.remove()
-        }
-    }
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
@@ -21,36 +21,17 @@ fun Feedback(
     subtitle: String = "",
     errorReference: String = "",
     firstButtonText: String?,
-    secondButtonText: String?,
+    secondButtonText: String? = null,
     firstButtonOnClick: (() -> Unit)?,
-    secondButtonOnClick: (() -> Unit)?,
+    secondButtonOnClick: (() -> Unit)? = null,
     isFirstButtonLoading: Boolean = false,
     secondButtonAsLink: Boolean = false,
-    onBackPressed: (() -> Unit)
-    ) {
-
-    val currentOnBack by rememberUpdatedState(newValue = onBackPressed)
+    onBackPressed: (() -> Unit)? = null
+) {
     var shouldPerformTheAnimation by remember { mutableStateOf(true) }
 
-    val backCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                currentOnBack()
-            }
-
-        }
-    }
-
-    val backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current) {
-        "No OnBackPressedDispatcherOwner was provided via LocalOnBackPressedDispatcherOwner"
-    }.onBackPressedDispatcher
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    DisposableEffect(lifecycleOwner, backDispatcher) {
-        backDispatcher.addCallback(lifecycleOwner, backCallback)
-        onDispose {
-            backCallback.remove()
-        }
+    onBackPressed?.let {
+        BackHandler(it)
     }
 
     AndroidView(factory = { context ->
@@ -74,6 +55,33 @@ fun Feedback(
                 shouldPerformTheAnimation = false
             }
         }
+    })
+}
+
+@Composable
+private fun BackHandler(
+    onBackPressed: () -> Unit
+) {
+    val currentOnBack by rememberUpdatedState(newValue = onBackPressed)
+
+    val backCallback = remember {
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                currentOnBack()
+            }
+
+        }
     }
-    )
+
+    val backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current) {
+        "No OnBackPressedDispatcherOwner was provided via LocalOnBackPressedDispatcherOwner"
+    }.onBackPressedDispatcher
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, backDispatcher) {
+        backDispatcher.addCallback(lifecycleOwner, backCallback)
+        onDispose {
+            backCallback.remove()
+        }
+    }
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/feedback/Feedback.kt
@@ -7,11 +7,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.telefonica.mistica.feedback.screen.view.FeedbackScreenView
 
 @Composable
 fun Feedback(
+    modifier: Modifier = Modifier,
     @FeedbackScreenView.FeedbackType type: Int = FeedbackScreenView.TYPE_INFO,
     title: String = "",
     subtitle: String = "",
@@ -30,27 +32,30 @@ fun Feedback(
         BackHandler(onBack = onBackPressed)
     }
 
-    AndroidView(factory = { context ->
-        FeedbackScreenView(context).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            shouldAnimateOnAttachedToWindow = false
-            setFeedbackType(type)
-            setFeedbackTitle(title)
-            setFeedbackSubtitle(subtitle)
-            setFeedbackErrorReference(errorReference)
-            firstButtonText?.let { setFeedbackFirstButtonText(firstButtonText) }
-            secondButtonText?.let { setFeedbackSecondButtonText(secondButtonText) }
-            firstButtonOnClick?.let { setFirstButtonOnClick { firstButtonOnClick() } }
-            secondButtonOnClick?.let { setSecondButtonOnClick { secondButtonOnClick() } }
-            setFeedbackSecondButtonAsLink(secondButtonAsLink)
-            setIsLoading(isFirstButtonLoading)
-            if (shouldPerformTheAnimation) {
-                animateViews()
-                shouldPerformTheAnimation = false
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            FeedbackScreenView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                shouldAnimateOnAttachedToWindow = false
+                setFeedbackType(type)
+                setFeedbackTitle(title)
+                setFeedbackSubtitle(subtitle)
+                setFeedbackErrorReference(errorReference)
+                firstButtonText?.let { setFeedbackFirstButtonText(firstButtonText) }
+                secondButtonText?.let { setFeedbackSecondButtonText(secondButtonText) }
+                firstButtonOnClick?.let { setFirstButtonOnClick { firstButtonOnClick() } }
+                secondButtonOnClick?.let { setSecondButtonOnClick { secondButtonOnClick() } }
+                setFeedbackSecondButtonAsLink(secondButtonAsLink)
+                setIsLoading(isFirstButtonLoading)
+                if (shouldPerformTheAnimation) {
+                    animateViews()
+                    shouldPerformTheAnimation = false
+                }
             }
         }
-    })
+    )
 
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
`onBackPressed` param from `Feedback` composable component should be optional so the back event is not overridden when needed.

### :construction: How do we do it?
- Make `onBackPressed` nullable with a default `null` value and only explicitly handle back event when it is present.
- Also add `null` default values to second button text and its click listener

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [x] Tested manually that passing null as `onBackPressed` do not override the back event
