### PR TITLE
NOV-232171: Add test tags in ListRowItem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.1.1'
-        kotlin_version = "1.6.10"
+        compose_version = '1.2.0-beta02'
+        kotlin_version = "1.6.21"
         support_version = "1.2.0"
         accompanist_version = "0.22.0-rc"
     }

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
@@ -26,9 +26,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -59,6 +62,7 @@ import com.telefonica.mistica.compose.theme.brand.O2ClassicBrand
 import com.telefonica.mistica.compose.theme.brand.TelefonicaBrand
 import com.telefonica.mistica.compose.theme.brand.VivoBrand
 
+@ExperimentalComposeUiApi
 @ExperimentalFoundationApi
 @ExperimentalMaterialApi
 class CatalogMainActivity : ComponentActivity() {
@@ -70,7 +74,9 @@ class CatalogMainActivity : ComponentActivity() {
         setContent {
             MisticaTheme(brand = brand) {
                 val navController = rememberNavController()
-                Scaffold { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.semantics { this.testTagsAsResourceId = true }
+                ) { innerPadding ->
                     CatalogNavHost(
                         navController,
                         modifier = Modifier.padding(innerPadding),

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Tags.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Tags.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.Divider
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -50,7 +50,7 @@ fun Tags() {
                 Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp))
             }
             LazyVerticalGrid(
-                cells = GridCells.Fixed(3),
+                columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
             ) {
                 item { Tag(text = "Promotion", style = TagView.TYPE_PROMO, modifier = Modifier.padding(4.dp)) }
@@ -70,7 +70,7 @@ fun Tags() {
                 Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = android.R.drawable.ic_lock_power_off)
             }
             LazyVerticalGrid(
-                cells = GridCells.Fixed(3),
+                columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
             ) {
                 item { Tag(text = "Promotion", style = TagView.TYPE_PROMO, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -28,19 +29,27 @@ fun Badge(
             shape = CircleShape,
             color = MisticaTheme.colors.badge,
             modifier = modifier
+                .testTag(BadgeTestTags.BADGE)
                 .size(8.dp),
         ) { }
     } else {
         androidx.compose.material.Badge(
             backgroundColor = MisticaTheme.colors.badge,
-            modifier = modifier,
+            modifier = modifier.testTag(BadgeTestTags.BADGE_NUMBER),
         ) {
             Text(
+                modifier = Modifier.testTag(BadgeTestTags.BADGE_NUMBER_VALUE),
                 text = content,
                 color = MisticaTheme.colors.textPrimaryInverse,
             )
         }
     }
+}
+
+object BadgeTestTags {
+    const val BADGE = "badge"
+    const val BADGE_NUMBER = "badge_number"
+    const val BADGE_NUMBER_VALUE = "badge_number_value"
 }
 
 @ExperimentalMaterialApi

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -105,7 +106,7 @@ fun ListRowItem(
     }
 
     Box(
-        modifier = boxModifier
+        modifier = boxModifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM)
     ) {
         Row(
             modifier = rowModifier
@@ -130,6 +131,7 @@ fun ListRowItem(
                         text = it,
                         style = MisticaTheme.typography.preset3,
                         color = textColorPrimary,
+                        modifier = Modifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM_TITLE),
                     )
                 }
                 subtitle?.let {
@@ -138,6 +140,7 @@ fun ListRowItem(
                         style = MisticaTheme.typography.preset2,
                         color = textColorSecondary,
                         modifier = Modifier
+                            .testTag(ListRowItemTestTags.LIST_ROW_ITEM_SUBTITLE)
                             .padding(vertical = 2.dp)
                             .defaultMinSize(minHeight = 20.dp),
                     )
@@ -148,6 +151,7 @@ fun ListRowItem(
                         style = MisticaTheme.typography.preset2,
                         color = textColorSecondary,
                         modifier = Modifier
+                            .testTag(ListRowItemTestTags.LIST_ROW_ITEM_DESCRIPTION)
                             .padding(vertical = 2.dp)
                             .defaultMinSize(minHeight = 20.dp),
                     )
@@ -179,6 +183,13 @@ private fun Modifier.makeClickableIfNeeded(onClick: (() -> Unit)?): Modifier =
     } else {
         this
     }
+
+object ListRowItemTestTags {
+    const val LIST_ROW_ITEM = "list_row_item"
+    const val LIST_ROW_ITEM_DESCRIPTION = "list_row_item_description"
+    const val LIST_ROW_ITEM_SUBTITLE = "list_row_item_subtitle"
+    const val LIST_ROW_ITEM_TITLE = "list_row_item_title"
+}
 
 @ExperimentalMaterialApi
 @Preview(showBackground = true)

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/shape/Chevron.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/shape/Chevron.kt
@@ -2,7 +2,9 @@ package com.telefonica.mistica.compose.shape
 
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -11,8 +13,13 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 fun Chevron(isInverse: Boolean = false) {
     val colorFilter = ColorFilter.tint(color = MisticaTheme.colors.inverse)
     Image(
+        modifier = Modifier.testTag(ChevronTestTags.CHEVRON),
         painter = painterResource(id = R.drawable.icn_arrow),
         contentDescription = null,
         colorFilter = if (isInverse) colorFilter else null
     )
+}
+
+object ChevronTestTags {
+    const val CHEVRON = "chevron"
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,7 +58,9 @@ fun Tag(
         color = background,
     ) {
         Row(
-            modifier = Modifier.padding(start = if (icon != null) 8.dp else 12.dp, end = 12.dp),
+            modifier = Modifier
+                .testTag(TagTestTags.TAG)
+                .padding(start = if (icon != null) 8.dp else 12.dp, end = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
 
@@ -73,7 +76,9 @@ fun Tag(
 
             Text(
                 text = text,
-                modifier = Modifier.padding(start = if (icon != null) 4.dp else 0.dp),
+                modifier = Modifier
+                    .testTag(TagTestTags.TAG_TEXT)
+                    .padding(start = if (icon != null) 4.dp else 0.dp),
                 style = MisticaTheme.typography.preset2Medium,
                 color = textColor,
                 maxLines = 1,
@@ -81,6 +86,11 @@ fun Tag(
             )
         }
     }
+}
+
+object TagTestTags {
+    const val TAG = "tag"
+    const val TAG_TEXT = "tag_text"
 }
 
 class Tag constructor(
@@ -124,7 +134,7 @@ internal fun TagPreview() {
                 Tag(text = "Inverse", style = TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = android.R.drawable.ic_lock_power_off)
             }
             LazyVerticalGrid(
-                cells = GridCells.Fixed(3),
+                columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
             ) {
                 item { Tag(text = "Promotion", style = TYPE_PROMO, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }


### PR DESCRIPTION
### :goal_net: What's the goal?
_Add test tags for elements in lists component. With last version of jetpack-compose testTags are mapped as resource-ids._

### :construction: How do we do it?
_Provide a description of the implementation. A list of steps would be ideal._
* Update compose version to 1.2.0-beta02.
* Update kotlin version to 1.6.21. (Move GridCells and LazyVerticalGrid to grid subpackage)
* Add test tags.

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). No needed
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
<img width="651" alt="Captura de pantalla 2022-06-15 a las 13 04 35" src="https://user-images.githubusercontent.com/52443195/173814328-db3c9185-ff50-47cc-9a15-cdd8769e0e37.png">
<img width="646" alt="Captura de pantalla 2022-06-15 a las 13 04 18" src="https://user-images.githubusercontent.com/52443195/173814338-80635479-09e9-4cec-95ce-22576751142e.png">
<img width="645" alt="Captura de pantalla 2022-06-15 a las 13 04 10" src="https://user-images.githubusercontent.com/52443195/173814343-50ab74ae-92f7-469f-abb1-b22a14d4c8a1.png">

- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
