### PR TITLE
Movistar new presets

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
@@ -45,7 +45,15 @@ fun MisticaTheme(
         MisticaTypography(
             defaultTextColor = rememberedColors.textPrimary
         )
-    }.apply { updateWith(brand.fontFamily) }
+    }.apply {
+        updateWith(
+            fontFamily = brand.fontFamily,
+            preset8FontWeight = brand.preset8FontWeight,
+            preset7FontWeight = brand.preset7FontWeight,
+            preset6FontWeight = brand.preset6FontWeight,
+            preset5FontWeight = brand.preset5FontWeight,
+        )
+    }
 
     CompositionLocalProvider(
         LocalMisticaColors provides rememberedColors,

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
@@ -1,6 +1,7 @@
 package com.telefonica.mistica.compose.theme.brand
 
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import com.telefonica.mistica.compose.theme.color.MisticaColors
 
 interface Brand {
@@ -9,4 +10,12 @@ interface Brand {
     val darkColors: MisticaColors
     val fontFamily: FontFamily
         get() = FontFamily.SansSerif
+    val preset5FontWeight: FontWeight
+        get() = FontWeight.Light
+    val preset6FontWeight: FontWeight
+        get() = FontWeight.Light
+    val preset7FontWeight: FontWeight
+        get() = FontWeight.Light
+    val preset8FontWeight: FontWeight
+        get() = FontWeight.Light
 }

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -1,6 +1,7 @@
 package com.telefonica.mistica.compose.theme.brand
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.theme.color.MisticaColors
 
@@ -185,6 +186,18 @@ object MovistarBrand : Brand {
             successHigh = MovistarPaletteColor.movistar_color_green_40,
             warningHigh = MovistarPaletteColor.movistar_color_egg_40,
         )
+
+    override val preset5FontWeight: FontWeight
+        get() = FontWeight.Medium
+
+    override val preset6FontWeight: FontWeight
+        get() = FontWeight.Medium
+
+    override val preset7FontWeight: FontWeight
+        get() = FontWeight.Medium
+
+    override val preset8FontWeight: FontWeight
+        get() = FontWeight.Medium
 }
 
 object MovistarProminentBrand : Brand {
@@ -209,6 +222,18 @@ object MovistarProminentBrand : Brand {
     )
 
     override val darkColors: MisticaColors = MovistarBrand.darkColors
+
+    override val preset5FontWeight: FontWeight
+        get() = MovistarBrand.preset5FontWeight
+
+    override val preset6FontWeight: FontWeight
+        get() = MovistarBrand.preset6FontWeight
+
+    override val preset7FontWeight: FontWeight
+        get() = MovistarBrand.preset7FontWeight
+
+    override val preset8FontWeight: FontWeight
+        get() = MovistarBrand.preset8FontWeight
 }
 
 private object MovistarPaletteColor {

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
@@ -67,32 +67,40 @@ class MisticaTypography(
             color = defaultTextColor,
         )
 
-    private fun buildPreset8() =
+    private fun buildPreset8(
+        fontWeight: FontWeight = FontWeight.Light
+    ) =
         buildBaseStyle().copy(
             fontSize = 32.sp,
             lineHeight = 40.sp,
-            fontWeight = FontWeight.Light,
+            fontWeight = fontWeight,
         )
 
-    private fun buildPreset7() =
+    private fun buildPreset7(
+        fontWeight: FontWeight = FontWeight.Light
+    ) =
         buildBaseStyle().copy(
             fontSize = 28.sp,
             lineHeight = 32.sp,
-            fontWeight = FontWeight.Light,
+            fontWeight = fontWeight,
         )
 
-    private fun buildPreset6() =
+    private fun buildPreset6(
+        fontWeight: FontWeight = FontWeight.Light
+    ) =
         buildBaseStyle().copy(
             fontSize = 24.sp,
             lineHeight = 32.sp,
-            fontWeight = FontWeight.Light,
+            fontWeight = fontWeight,
         )
 
-    private fun buildPreset5() =
+    private fun buildPreset5(
+        fontWeight: FontWeight = FontWeight.Light
+    ) =
         buildBaseStyle().copy(
             fontSize = 22.sp,
             lineHeight = 24.sp,
-            fontWeight = FontWeight.Normal,
+            fontWeight = fontWeight,
         )
 
     private fun buildPreset4() =
@@ -161,13 +169,17 @@ class MisticaTypography(
         )
 
     fun updateWith(
-        fontFamily: FontFamily
+        fontFamily: FontFamily,
+        preset8FontWeight: FontWeight,
+        preset7FontWeight: FontWeight,
+        preset6FontWeight: FontWeight,
+        preset5FontWeight: FontWeight,
     ) {
         this.fontFamily = fontFamily
-        preset8 = buildPreset8()
-        preset7 = buildPreset7()
-        preset6 = buildPreset6()
-        preset5 = buildPreset5()
+        preset8 = buildPreset8(fontWeight = preset8FontWeight)
+        preset7 = buildPreset7(fontWeight = preset7FontWeight)
+        preset6 = buildPreset6(fontWeight = preset6FontWeight)
+        preset5 = buildPreset5(fontWeight = preset5FontWeight)
         preset4 = buildPreset4()
         preset4Light = buildPreset4Light()
         preset4Medium = buildPreset4Medium()

--- a/library/src/main/res/values/attrs_fonts.xml
+++ b/library/src/main/res/values/attrs_fonts.xml
@@ -7,4 +7,10 @@
         <attr name="font_family_medium" format="string"/>
     </declare-styleable>
 
+    <declare-styleable name="PresetFonts">
+        <attr name="preset5Font" format="string"/>
+        <attr name="preset6Font" format="string"/>
+        <attr name="preset7Font" format="string"/>
+        <attr name="preset8Font" format="string"/>
+    </declare-styleable>
 </resources>

--- a/library/src/main/res/values/styles_fonts.xml
+++ b/library/src/main/res/values/styles_fonts.xml
@@ -8,25 +8,25 @@
     <style name="AppTheme.TextAppearance.Preset8">
         <item name="android:textSize">32sp</item>
         <item name="lineHeight">40sp</item>
-        <item name="android:fontFamily">?font_family_light</item>
+        <item name="android:fontFamily">?preset8Font</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset7">
         <item name="android:textSize">28sp</item>
         <item name="lineHeight">32sp</item>
-        <item name="android:fontFamily">?font_family_light</item>
+        <item name="android:fontFamily">?preset7Font</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset6">
         <item name="android:textSize">24sp</item>
         <item name="lineHeight">32sp</item>
-        <item name="android:fontFamily">?font_family_light</item>
+        <item name="android:fontFamily">?preset6Font</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset5">
         <item name="android:textSize">22sp</item>
         <item name="lineHeight">24sp</item>
-        <item name="android:fontFamily">?font_family_light</item>
+        <item name="android:fontFamily">?preset5Font</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset4">

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -31,6 +31,10 @@
         <item name="font_family_regular">sans-serif</item>
         <item name="font_family_medium">sans-serif-medium</item>
 
+        <item name="preset5Font">?font_family_light</item>
+        <item name="preset6Font">?font_family_light</item>
+        <item name="preset7Font">?font_family_light</item>
+        <item name="preset8Font">?font_family_light</item>
     </style>
 
 </resources>

--- a/library/src/main/res/values/themes_movistar.xml
+++ b/library/src/main/res/values/themes_movistar.xml
@@ -144,6 +144,12 @@
 
 		<!-- Stepper -->
 		<item name="stepperFinishedStepAnimation">@raw/feedback_success</item>
+
+		<!-- Presets overrides -->
+		<item name="preset5Font">?font_family_medium</item>
+		<item name="preset6Font">?font_family_medium</item>
+		<item name="preset7Font">?font_family_medium</item>
+		<item name="preset8Font">?font_family_medium</item>
 	</style>
 
 	<style name="MisticaMovistarProminentOverride">


### PR DESCRIPTION
### :goal_net: What's the goal?
Presets from 5 to 8 are now Medium and not Light only in Movistar

### :construction: How do we do it?
- XML style presets: Create four new attributes to be referenced from each preset definition and set light as their default value in main base them and override them to Medium only in Movistar
- Compose typography presets: parametrize buildPresetX methods from `MisticaTypography` class and add `presetXFontWeight` properties to `Brand` interface with Light as default value and override them only in Movistar

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public). Download the one with this title:
![Captura de pantalla 2022-06-16 a las 10 26 23](https://user-images.githubusercontent.com/47142570/174027232-882a9985-3f9c-4aae-9175-a1cbd5d09f7a.png)
- [x] Reviewed by Mistica design team

| compose movistar | compose other brand |
| ---- | ---- |
|![Captura de pantalla 2022-06-16 a las 10 12 33](https://user-images.githubusercontent.com/47142570/174024797-59630ebf-1d50-46d1-bd98-9f80bb3cfe48.png)|![Captura de pantalla 2022-06-16 a las 10 12 48](https://user-images.githubusercontent.com/47142570/174024825-425914c7-abec-4bcc-aee2-afb1d05175b2.png)|

| xml movistar | xml other brand |
| ---- | ---- |
|![Captura de pantalla 2022-06-16 a las 10 13 05](https://user-images.githubusercontent.com/47142570/174024858-560fa374-7818-46c3-b0b3-314b09bb0a2f.png)|![Captura de pantalla 2022-06-16 a las 10 13 18](https://user-images.githubusercontent.com/47142570/174024873-fb88aeb7-05f2-4ae8-b47d-f669972fb283.png)|

