### PR TITLE
ANDROID-10672 New corner radius

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/card/Card.kt
@@ -34,7 +34,7 @@ fun Card(
             .focusable()
             .widthIn(min = 184.dp),
         elevation = 0.dp,
-        shape = RoundedCornerShape(4.dp),
+        shape = RoundedCornerShape(8.dp),
         border = BorderStroke(width = 1.dp, color = MisticaTheme.colors.border)
     ) {
         Column {

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -104,7 +104,7 @@ private fun TextBox(
     TextField(
         modifier = Modifier
             .fillMaxWidth()
-            .border(width = 1.dp, color = MisticaTheme.colors.border, shape = RoundedCornerShape(4.dp)),
+            .border(width = 1.dp, color = MisticaTheme.colors.border, shape = RoundedCornerShape(8.dp)),
         enabled = enabled,
         readOnly = readOnly,
         value = value,

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -70,7 +70,7 @@ fun ListRowItem(
             .border(
                 width = 1.dp,
                 color = MisticaTheme.colors.border,
-                shape = RoundedCornerShape(4.dp),
+                shape = RoundedCornerShape(8.dp),
             )
         BackgroundType.TYPE_BOXED_INVERSE -> Modifier
             .background(

--- a/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/card/EmptyStateCardView.kt
@@ -259,11 +259,11 @@ class EmptyStateCardView @JvmOverloads constructor(
 
     fun setImageSize(@ImageSize imageSize: Int) {
         val imageWidth: Int = when (imageSize) {
-            IMAGE_SIZE_ICON -> context.convertDpToPx(64)
+            IMAGE_SIZE_ICON -> context.convertDpToPx(ICON_SIZE_DP)
             else -> ViewGroup.LayoutParams.WRAP_CONTENT
         }
         val imageHeight: Int = when (imageSize) {
-            IMAGE_SIZE_ICON -> context.convertDpToPx(64)
+            IMAGE_SIZE_ICON -> context.convertDpToPx(ICON_SIZE_DP)
             else -> context.convertDpToPx(112)
         }
         image.scaleType = when (imageSize) {
@@ -284,6 +284,7 @@ class EmptyStateCardView @JvmOverloads constructor(
         const val BUTTONS_CONFIG_SECONDARY = 4
         const val BUTTONS_CONFIG_SECONDARY_LINK = 5
         const val LINK = 6
+        private const val ICON_SIZE_DP = 48
 
         const val IMAGE_SIZE_ICON = 0
         const val IMAGE_SIZE_SMALL = 1

--- a/library/src/main/res/drawable/bg_callout.xml
+++ b/library/src/main/res/drawable/bg_callout.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="?attr/colorBackgroundAlternative" />
-    <corners android:radius="4dp" />
+    <corners android:radius="@dimen/callout_corner_radius" />
 </shape>

--- a/library/src/main/res/drawable/bg_callout_inverse.xml
+++ b/library/src/main/res/drawable/bg_callout_inverse.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="?attr/colorBackgroundContainer" />
-    <corners android:radius="4dp" />
+    <corners android:radius="@dimen/callout_corner_radius" />
 </shape>

--- a/library/src/main/res/drawable/bg_textinputedittext.xml
+++ b/library/src/main/res/drawable/bg_textinputedittext.xml
@@ -1,7 +1,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="?colorBackgroundContainer" />
-    <corners android:radius="5dp" />
+    <corners android:radius="8dp" />
     <stroke
         android:width="1dp"
         android:color="?colorBorder" />

--- a/library/src/main/res/drawable/boxed_list_row_background.xml
+++ b/library/src/main/res/drawable/boxed_list_row_background.xml
@@ -6,7 +6,7 @@
         <shape>
             <!-- Color is irrelevant for mask -->
             <solid android:color="#000000" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/list_row_corner_radius" />
         </shape>
     </item>
 
@@ -16,7 +16,7 @@
             <stroke
                 android:width="1dp"
                 android:color="?colorBorder" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/list_row_corner_radius" />
         </shape>
     </item>
 </ripple>

--- a/library/src/main/res/layout/screen_feedback.xml
+++ b/library/src/main/res/layout/screen_feedback.xml
@@ -37,7 +37,7 @@
 
             <TextView
                 android:id="@+id/subtitle"
-                style="@style/AppTheme.TextAppearance.Preset4.Light"
+                style="@style/AppTheme.TextAppearance.Preset4"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"

--- a/library/src/main/res/values/dimens_callout.xml
+++ b/library/src/main/res/values/dimens_callout.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="highlighted_card_corner_radius">8dp</dimen>
+	<dimen name="callout_corner_radius">8dp</dimen>
 </resources>

--- a/library/src/main/res/values/dimens_card_view.xml
+++ b/library/src/main/res/values/dimens_card_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="card_corner_radius">4dp</dimen>
+    <dimen name="card_corner_radius">8dp</dimen>
     <dimen name="card_min_width">184dp</dimen>
 </resources>

--- a/library/src/main/res/values/dimens_popover.xml
+++ b/library/src/main/res/values/dimens_popover.xml
@@ -3,5 +3,5 @@
     <dimen name="popover_elevation">2dp</dimen>
     <dimen name="popover_arrow_margin_vertical">-1dp</dimen>
     <dimen name="popover_arrow_margin_horizontal">-6dp</dimen>
-    <dimen name="popover_custom_corner_radius">4dp</dimen>
+    <dimen name="popover_custom_corner_radius">8dp</dimen>
 </resources>

--- a/library/src/main/res/values/list_row_corner_radius.xml
+++ b/library/src/main/res/values/list_row_corner_radius.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="highlighted_card_corner_radius">8dp</dimen>
+	<dimen name="list_row_corner_radius">8dp</dimen>
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
As part of Mistica Evolution, there have been some changes related to corner radius and other small changes

### :construction: How do we do it?
Change (compose and xml) the corner radius here and there from 4px to 8px (actually dp on Android) in the following components:
- Cards (data and media)
- Callout
- Popover
- Boxed list items
- Empty state card
- Forms

Other fixes:
- Change feedback subtitle style from light to regular
- Empty state card icon size from 64 to 48

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public)
![Captura de pantalla 2022-06-21 a las 11 41 02](https://user-images.githubusercontent.com/47142570/174769529-f9398db2-4492-4396-a951-d91e1b68b68c.png)
- [x] Reviewed by Mistica design team

### XML
| component | before | after |
| ---- | ---- | ---- |
| media card | ![Captura de pantalla 2022-06-21 a las 10 54 06](https://user-images.githubusercontent.com/47142570/174759490-ee50463b-c403-40bc-9899-2db2df95e4d0.png)| ![Captura de pantalla 2022-06-21 a las 10 57 34](https://user-images.githubusercontent.com/47142570/174760246-35d88bc7-0857-463d-a098-ea645e568406.png)|
| data card | ![Captura de pantalla 2022-06-21 a las 10 53 46](https://user-images.githubusercontent.com/47142570/174759423-dbd54c60-9167-4970-b280-6a6965fa8714.png)| ![Captura de pantalla 2022-06-21 a las 10 45 59](https://user-images.githubusercontent.com/47142570/174757765-e65af2f0-541f-4c26-b4a0-034660b8de35.png)|
| callout | ![Captura de pantalla 2022-06-21 a las 10 53 25](https://user-images.githubusercontent.com/47142570/174759349-971a8ca4-c853-443a-b7e9-8fd5456b7a8c.png)|![Captura de pantalla 2022-06-21 a las 10 45 33](https://user-images.githubusercontent.com/47142570/174757649-445ca689-61b8-438e-b886-8b5ff839c828.png)|
| popover | ![Captura de pantalla 2022-06-21 a las 10 54 35](https://user-images.githubusercontent.com/47142570/174759591-0aa10f6c-2a27-4edd-b44b-3a0155b4456b.png)| ![Captura de pantalla 2022-06-21 a las 10 48 26](https://user-images.githubusercontent.com/47142570/174758261-58988bf8-c181-4a30-ade2-0e9609c6813d.png)|
| boxed list item | ![Captura de pantalla 2022-06-21 a las 10 55 01](https://user-images.githubusercontent.com/47142570/174759679-288c661d-ba32-4ec2-b805-bcf6d1953196.png)| ![Captura de pantalla 2022-06-21 a las 10 47 47](https://user-images.githubusercontent.com/47142570/174758148-c84c3f42-0e9a-4f0d-b746-1427461c572c.png)|
| empty state card | ![Captura de pantalla 2022-06-21 a las 10 55 45](https://user-images.githubusercontent.com/47142570/174759855-0bc30b15-c2f5-44f3-9ff8-16fd52cfc5b1.png)| ![Captura de pantalla 2022-06-21 a las 10 46 34](https://user-images.githubusercontent.com/47142570/174757885-5325854d-a02d-4946-a382-e540eb0ca15f.png)|
| forms | ![Captura de pantalla 2022-06-21 a las 10 55 26](https://user-images.githubusercontent.com/47142570/174759784-87e79e1b-800f-490e-9243-4c7322dcedea.png)| ![Captura de pantalla 2022-06-21 a las 10 47 03](https://user-images.githubusercontent.com/47142570/174757971-bbc69ede-9398-4900-89d4-e920a62eb7e6.png)|
| feedback subtitle | ![Captura de pantalla 2022-06-21 a las 11 07 44](https://user-images.githubusercontent.com/47142570/174762384-bee3059a-ad05-48dd-8a03-4ebad1726b08.png)| ![Captura de pantalla 2022-06-21 a las 10 59 13](https://user-images.githubusercontent.com/47142570/174760597-128d061b-e1fa-41d7-99e5-94880c4852e5.png)|
| empty state card icon | ![Captura de pantalla 2022-06-21 a las 11 16 59](https://user-images.githubusercontent.com/47142570/174764656-314f0925-0f8c-41a8-860c-9a760c6017bf.png)| ![Captura de pantalla 2022-06-21 a las 11 19 56](https://user-images.githubusercontent.com/47142570/174764972-31dff770-0baa-43b6-98a6-607aff613f81.png)|


### Compose (callout and popover still don't have a Compose version)
| component | before | after |
| ---- | ---- | ---- |
| media card | ![Captura de pantalla 2022-06-21 a las 10 51 49](https://user-images.githubusercontent.com/47142570/174759007-317374df-149b-4b8e-bf5e-6820d6709754.png)| ![Captura de pantalla 2022-06-21 a las 10 41 12](https://user-images.githubusercontent.com/47142570/174756635-ff784639-acac-4f7a-882c-7826f2c7229b.png)|
| data card | ![Captura de pantalla 2022-06-21 a las 10 51 28](https://user-images.githubusercontent.com/47142570/174758933-a83c6b5d-daef-429e-a422-e454dd9c0950.png)| ![Captura de pantalla 2022-06-21 a las 10 40 20](https://user-images.githubusercontent.com/47142570/174756457-254b188b-1778-4416-ac68-11a8ae653e19.png)|
| boxed list item | ![Captura de pantalla 2022-06-21 a las 10 52 16](https://user-images.githubusercontent.com/47142570/174759110-63938b9e-12d0-47b9-870b-f1ee4bf7378e.png)| ![Captura de pantalla 2022-06-21 a las 10 41 58](https://user-images.githubusercontent.com/47142570/174756841-c16da97a-1bd9-4853-b2a2-8a6d00e1abdc.png)|
| empty state card | ![Captura de pantalla 2022-06-21 a las 10 52 36](https://user-images.githubusercontent.com/47142570/174759186-291f3d0c-f7b0-4bbf-aeac-a1a1f13880da.png)| ![Captura de pantalla 2022-06-21 a las 10 44 30](https://user-images.githubusercontent.com/47142570/174757409-d967d8f7-f7f7-4e4c-bb28-38e013f1f793.png)|
| forms | ![Captura de pantalla 2022-06-21 a las 10 50 51](https://user-images.githubusercontent.com/47142570/174758778-76bc0d69-4131-4a53-943e-150077dbeed3.png)| ![Captura de pantalla 2022-06-21 a las 10 39 19](https://user-images.githubusercontent.com/47142570/174756249-69eb0a55-d03c-46af-9815-62b0d1638222.png)|
| feedback subtitle | ![Captura de pantalla 2022-06-21 a las 11 06 40](https://user-images.githubusercontent.com/47142570/174762206-12a1f0de-278e-4c48-87bb-4bb6e3215f6a.png)| ![Captura de pantalla 2022-06-21 a las 11 01 49](https://user-images.githubusercontent.com/47142570/174761200-be72944e-d88e-47a4-aacc-40ea65759b37.png)|
| empty state card icon | ![Captura de pantalla 2022-06-21 a las 11 17 55](https://user-images.githubusercontent.com/47142570/174764574-37e5432e-86a7-48c1-bcbb-e1d63950018c.png)| ![Captura de pantalla 2022-06-21 a las 11 19 21](https://user-images.githubusercontent.com/47142570/174764865-30d50583-bdea-48c4-9c65-28b01136c4f2.png)|
