### PR TITLE
ANDROID-10672 Fix corner radius in boxed inverse list row item

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -37,6 +37,8 @@ import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
+private val B0XED_CORNER_RADIUS = 8.dp
+
 @ExperimentalMaterialApi
 @Composable
 fun ListRowItem(
@@ -62,7 +64,7 @@ fun ListRowItem(
             .padding(horizontal = 16.dp, vertical = 8.dp)
     }
         .fillMaxWidth()
-        .clip(shape = RoundedCornerShape(4.dp))
+        .clip(shape = RoundedCornerShape(B0XED_CORNER_RADIUS))
         .makeClickableIfNeeded(onClick)
 
     val rowModifier = when (backgroundType) {
@@ -71,17 +73,17 @@ fun ListRowItem(
             .border(
                 width = 1.dp,
                 color = MisticaTheme.colors.border,
-                shape = RoundedCornerShape(8.dp),
+                shape = RoundedCornerShape(B0XED_CORNER_RADIUS),
             )
         BackgroundType.TYPE_BOXED_INVERSE -> Modifier
             .background(
                 color = MisticaTheme.colors.backgroundBrand,
-                shape = RoundedCornerShape(4.dp),
+                shape = RoundedCornerShape(B0XED_CORNER_RADIUS),
             )
             .border(
                 width = 1.dp,
                 color = MisticaTheme.colors.border,
-                shape = RoundedCornerShape(4.dp),
+                shape = RoundedCornerShape(B0XED_CORNER_RADIUS),
             )
     }
         .fillMaxWidth()

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -80,11 +80,6 @@ fun ListRowItem(
                 color = MisticaTheme.colors.backgroundBrand,
                 shape = RoundedCornerShape(B0XED_CORNER_RADIUS),
             )
-            .border(
-                width = 1.dp,
-                color = MisticaTheme.colors.border,
-                shape = RoundedCornerShape(B0XED_CORNER_RADIUS),
-            )
     }
         .fillMaxWidth()
         .defaultMinSize(minHeight = when(description) {

--- a/library/src/main/res/drawable/boxed_inverse_list_row_background.xml
+++ b/library/src/main/res/drawable/boxed_inverse_list_row_background.xml
@@ -6,14 +6,14 @@
         <shape>
             <!-- A color needs to be defined for the the mask to work, but it doesn't matter which color is used -->
             <solid android:color="#000000" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/list_row_corner_radius" />
         </shape>
     </item>
 
     <item android:id="@android:id/background">
         <shape>
             <solid android:color="?colorBackgroundBrand" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/list_row_corner_radius" />
         </shape>
     </item>
 </ripple>


### PR DESCRIPTION
### :goal_net: What's the goal?
Corner radius on  boxed list row items should be set to 8dp, it was changed for its standard version but not for its "inverse" version.

### :construction: How do we do it?
4dp to 8dp on boxed inverse list row item

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public)
<img width="416" alt="Captura de pantalla 2022-07-11 a las 15 17 19" src="https://user-images.githubusercontent.com/47142570/178273017-1d24570a-eedd-46ab-8866-21b2d08c4b1d.png">

- [x] Reviewed by Mistica design team

XML
<img width="428" alt="Captura de pantalla 2022-07-11 a las 15 11 17" src="https://user-images.githubusercontent.com/47142570/178271850-d86a539a-0d6c-46ad-9420-d0c826bf1e25.png">

Compose
<img width="429" alt="Captura de pantalla 2022-07-11 a las 15 10 52" src="https://user-images.githubusercontent.com/47142570/178271778-cab4995c-d307-4887-916d-27a24c043178.png">

