### PR TITLE
ANDROID-10672 movistar presets from 5 to 8 from medium to bold

### DIFF
--- a/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -164,16 +164,16 @@ object MovistarBrand : Brand {
         )
 
     override val preset5FontWeight: FontWeight
-        get() = FontWeight.Medium
+        get() = FontWeight.Bold
 
     override val preset6FontWeight: FontWeight
-        get() = FontWeight.Medium
+        get() = FontWeight.Bold
 
     override val preset7FontWeight: FontWeight
-        get() = FontWeight.Medium
+        get() = FontWeight.Bold
 
     override val preset8FontWeight: FontWeight
-        get() = FontWeight.Medium
+        get() = FontWeight.Bold
 }
 
 object MovistarProminentBrand : Brand {

--- a/library/src/main/res/values/attrs_fonts.xml
+++ b/library/src/main/res/values/attrs_fonts.xml
@@ -13,4 +13,33 @@
         <attr name="preset7Font" format="string"/>
         <attr name="preset8Font" format="string"/>
     </declare-styleable>
+
+    <declare-styleable name="PresetStyles">
+        <!-- Important:
+        These constants are the same as "android:textStyle" flag values
+        and they have been replicated for each type of preset because
+        it's not possible to reference the original values out of android:textStyle usage.
+        -->
+        <attr name="preset5Style" format="reference">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+        <attr name="preset6Style" format="reference">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+        <attr name="preset7Style" format="reference">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+        <attr name="preset8Style" format="reference">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+    </declare-styleable>
+
 </resources>

--- a/library/src/main/res/values/styles_fonts.xml
+++ b/library/src/main/res/values/styles_fonts.xml
@@ -9,24 +9,28 @@
         <item name="android:textSize">32sp</item>
         <item name="lineHeight">40sp</item>
         <item name="android:fontFamily">?preset8Font</item>
+        <item name="android:textStyle">?preset8Style</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset7">
         <item name="android:textSize">28sp</item>
         <item name="lineHeight">32sp</item>
         <item name="android:fontFamily">?preset7Font</item>
+        <item name="android:textStyle">?preset7Style</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset6">
         <item name="android:textSize">24sp</item>
         <item name="lineHeight">32sp</item>
         <item name="android:fontFamily">?preset6Font</item>
+        <item name="android:textStyle">?preset6Style</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset5">
         <item name="android:textSize">22sp</item>
         <item name="lineHeight">24sp</item>
         <item name="android:fontFamily">?preset5Font</item>
+        <item name="android:textStyle">?preset5Style</item>
     </style>
 
     <style name="AppTheme.TextAppearance.Preset4">

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -35,6 +35,11 @@
         <item name="preset6Font">?font_family_light</item>
         <item name="preset7Font">?font_family_light</item>
         <item name="preset8Font">?font_family_light</item>
+
+        <item name="preset5Style">normal</item>
+        <item name="preset6Style">normal</item>
+        <item name="preset7Style">normal</item>
+        <item name="preset8Style">normal</item>
     </style>
 
 </resources>

--- a/library/src/main/res/values/themes_movistar.xml
+++ b/library/src/main/res/values/themes_movistar.xml
@@ -134,10 +134,15 @@
 		<item name="stepperFinishedStepAnimation">@raw/feedback_success</item>
 
 		<!-- Presets overrides -->
-		<item name="preset5Font">?font_family_medium</item>
-		<item name="preset6Font">?font_family_medium</item>
-		<item name="preset7Font">?font_family_medium</item>
-		<item name="preset8Font">?font_family_medium</item>
+		<item name="preset5Font">?font_family_regular</item>
+		<item name="preset6Font">?font_family_regular</item>
+		<item name="preset7Font">?font_family_regular</item>
+		<item name="preset8Font">?font_family_regular</item>
+
+		<item name="preset5Style">bold</item>
+		<item name="preset6Style">bold</item>
+		<item name="preset7Style">bold</item>
+		<item name="preset8Style">bold</item>
 	</style>
 
 	<style name="MisticaMovistarProminentOverride">


### PR DESCRIPTION
### :goal_net: What's the goal?
Presets from 5 to 8 and only in Movistar brand should be Bold instead of Medium as they currently are

### :construction: How do we do it?
Update text style in compose and xml presets

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public)
- [ ] Reviewed by Mistica design team


