### PR TITLE
ANDROID-11208 Fix TextInputLayout mistica themes

### DIFF
--- a/library/src/main/res/values/styles_forms.xml
+++ b/library/src/main/res/values/styles_forms.xml
@@ -14,6 +14,7 @@
         <item name="errorTextAppearance">@style/AppTheme.Forms.TextInputLayout.Error</item>
         <item name="helperTextTextAppearance">@style/AppTheme.Forms.TextInputLayout.Helper</item>
         <item name="errorIconDrawable">@null</item>
+        <item name="android:textColorHint">?colorTextSecondary</item>
     </style>
 
     <style name="AppTheme.Forms.TextInputLayout.EditText.TextArea">
@@ -29,9 +30,18 @@
     <style name="AppTheme.Forms.TextInputLayout.Error" parent="TextAppearance.Design.Error">
         <item name="android:textColor">?attr/colorError</item>
         <item name="colorError">?colorError</item>
+        <!-- Preset1 font style -->
+        <item name="android:textSize">12sp</item>
+        <item name="lineHeight">16sp</item>
+        <item name="fontFamily">?font_family_regular</item>
     </style>
 
-    <style name="AppTheme.Forms.TextInputLayout.Hint" parent="TextAppearance.Design.Hint" />
+    <style name="AppTheme.Forms.TextInputLayout.Hint" parent="TextAppearance.Design.Hint">
+        <!-- Preset1 font style -->
+        <item name="android:textSize">12sp</item>
+        <item name="lineHeight">16sp</item>
+        <item name="fontFamily">?font_family_regular</item>
+    </style>
 
     <style name="AppTheme.Forms.TextInputLayout.Helper" parent="AppTheme.TextAppearance.Preset1" />
 


### PR DESCRIPTION
Ticket -> [ANDROID-11208](https://jira.tid.es/browse/ANDROID-11208)

### :goal_net: What's the goal?
Fix TextInputLayout errors detected during Latch v3 development.
Basically:
- Hint and Error indicators should use preset1 and shoud recognize any overriden font
- Big hint text should use ?colorTextSecondary as mistica specifies

This has not been detected in the past because material color used matches our textSecondary, and fields were never used with a different typography than roboto.

### :construction: How do we do it?
* Add preset1 configuration to hint and error styles (Needs to be copied as we can't use multiple inheritance)
* Configure hint text color as ?colorTextSecondary

<img width="883" alt="Captura de pantalla 2022-10-19 a las 17 28 17" src="https://user-images.githubusercontent.com/5360064/196738064-f206e21c-5452-476e-9756-878e11d9b18b.png">

### ☑️ Checks
- [x] No doc needs tu be updated. It's a bug.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos (**should not change**)

<table>
<tbody>
  <tr>
    <td>Before</td>
    <td>After</td>
</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/5360064/196740471-a93ca3b3-e8c7-425c-bd4a-0a50aa8cc544.jpg" width="300" /></td>
    <td><img src="https://user-images.githubusercontent.com/5360064/196740120-d11373d0-8f89-4dcc-b121-7ab591000f27.jpg" width="300" /></td>
  </tr>
</tbody>
</table>

