### PR TITLE
ANDROID-11216 update coil version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-android-extensions'
     id 'com.betomorrow.appcenter'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         kotlin_version = "1.6.21"
         support_version = "1.2.0"
         accompanist_version = "0.22.0-rc"
+        coil_version = '2.1.0'
     }
     repositories {
         google()

--- a/catalog-compose/build.gradle
+++ b/catalog-compose/build.gradle
@@ -51,8 +51,7 @@ dependencies {
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "androidx.navigation:navigation-compose:2.4.1"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
-    implementation "io.coil-kt:coil:1.4.0"
-    implementation "io.coil-kt:coil-compose:1.4.0"
+    implementation "io.coil-kt:coil-compose:$coil_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
@@ -16,9 +16,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import coil.compose.rememberImagePainter
+import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.telefonica.mistica.compose.catalog.R
 import com.telefonica.mistica.compose.list.BackgroundType
@@ -273,11 +276,11 @@ fun Avatar() {
 @Composable
 fun Avatar(url: String) {
     Image(
-        painter = rememberImagePainter(
-            data = url,
-            builder = {
-                transformations(CircleCropTransformation())
-            }
+        painter = rememberAsyncImagePainter(
+            ImageRequest.Builder(LocalContext.current)
+                .data(url)
+                .apply { transformations(CircleCropTransformation()) }
+                .build()
         ),
         contentDescription = null,
         modifier = Modifier.size(40.dp)

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Lists.kt
@@ -20,15 +20,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import coil.compose.rememberImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.telefonica.mistica.compose.catalog.R
 import com.telefonica.mistica.compose.list.BackgroundType
-import com.telefonica.mistica.compose.shape.Chevron
-import com.telefonica.mistica.compose.tag.Tag
-import com.telefonica.mistica.compose.shape.Circle
 import com.telefonica.mistica.compose.list.ListRowItem
+import com.telefonica.mistica.compose.shape.Chevron
+import com.telefonica.mistica.compose.shape.Circle
+import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 
@@ -135,7 +134,7 @@ fun samples() = listOf(
     ),
 
     ListItem(
-        headline = Tag(content ="PROMO").withStyle(TYPE_PROMO),
+        headline = Tag(content = "PROMO").withStyle(TYPE_PROMO),
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-android-extensions'
     id 'kotlin-kapt'
     id 'maven-publish'
 }

--- a/library-compose/build.gradle
+++ b/library-compose/build.gradle
@@ -50,8 +50,7 @@ dependencies {
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
-    implementation "io.coil-kt:coil:1.4.0"
-    implementation "io.coil-kt:coil-compose:1.4.0"
+    implementation "io.coil-kt:coil-compose:$coil_version"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/library-compose/src/main/java/com/telefonica/mistica/compose/card/datacard/IconPainter.kt
+++ b/library-compose/src/main/java/com/telefonica/mistica/compose/card/datacard/IconPainter.kt
@@ -11,9 +11,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.telefonica.mistica.compose.shape.Circle
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -84,11 +86,11 @@ sealed class IconPainter {
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
             ) {
                 Image(
-                    painter = rememberImagePainter(
-                        data = url,
-                        builder = {
-                            transformations(CircleCropTransformation())
-                        }
+                    painter = rememberAsyncImagePainter(
+                        ImageRequest.Builder(LocalContext.current)
+                            .data(url)
+                            .apply { transformations(CircleCropTransformation()) }
+                            .build()
                     ),
                     contentDescription = null,
                     modifier = Modifier.size(40.dp)

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-android-extensions'
     id 'kotlin-kapt'
     id 'maven-publish'
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Update coil version as it depends on a version of okhttp that has a vulnerabilty.

### :construction: How do we do it?
Update coil version:The minimum supported API is now 21.
No breaking changes apply: https://coil-kt.github.io/coil/upgrading/
Coil 2.2.0 requires update compile sdk to 32 as it depends on compose 1.2.1: https://coil-kt.github.io/coil/changelog/ so version 2.1.0 has been applied

### ☑️ Checks
- [X] I updated the documentation (readmes, wikis, etc). No components are changed
- [X] Tested with dark mode. No components changed
- [X] Tested with API 21: Coil version minsdk is 21

### :test_tube: How can I test this?
Tested using catalog app

### 📓 Notes

After reviewing further version updates, we are blocked by current sdk version. I have created a newer task to increase versions and use a compose a stable version: https://jira.tid.es/browse/ANDROID-11299

### Poyake
kotlin-extensions are not used in the project