### PR TITLE
ANDROID-11320 Add colorCustomTabsBackground to all brands

### DIFF
--- a/library/src/main/res/values-night/themes_blau.xml
+++ b/library/src/main/res/values-night/themes_blau.xml
@@ -12,6 +12,7 @@
 		<item name="colorNavigationBarBackground">@color/blau_color_darkModeBlack</item>
 		<item name="colorBackgroundAlternative">@color/blau_color_darkModeGrey</item>
 		<item name="colorBackgroundFeedbackBottom">@color/blau_color_darkModeBlack</item>
+		<item name="colorCustomTabsBackground">@color/blau_color_darkModeBlack</item>
 
 		<item name="colorSkeletonWave">@color/blau_color_grey_5</item>
 

--- a/library/src/main/res/values-night/themes_movistar.xml
+++ b/library/src/main/res/values-night/themes_movistar.xml
@@ -13,6 +13,7 @@
         <item name="colorNavigationBarBackground">@color/movistar_color_darkModeBlack</item>
         <item name="colorBackgroundAlternative">@color/movistar_color_darkModeGrey</item>
         <item name="colorBackgroundFeedbackBottom">@color/movistar_color_darkModeBlack</item>
+        <item name="colorCustomTabsBackground">@color/movistar_color_darkModeBlack</item>
 
         <item name="colorSkeletonWave">@color/movistar_color_grey_5_30_alpha</item>
 

--- a/library/src/main/res/values-night/themes_o2.xml
+++ b/library/src/main/res/values-night/themes_o2.xml
@@ -14,6 +14,7 @@
         <item name="colorNavigationBarBackground">@color/o2_color_darkModeBlack</item>
         <item name="colorBackgroundAlternative">@color/o2_color_darkModeGrey</item>
         <item name="colorBackgroundFeedbackBottom">@color/o2_color_darkModeBlack</item>
+        <item name="colorCustomTabsBackground">@color/o2_color_darkModeBlack</item>
 
         <item name="colorSkeletonWave">@color/o2_color_grey_5_30_alpha</item>
 

--- a/library/src/main/res/values-night/themes_o2_classic.xml
+++ b/library/src/main/res/values-night/themes_o2_classic.xml
@@ -14,6 +14,7 @@
         <item name="colorNavigationBarBackground">@color/o2_classic_color_darkModeBlack</item>
         <item name="colorBackgroundAlternative">@color/o2_classic_color_darkModeGrey</item>
         <item name="colorBackgroundFeedbackBottom">@color/o2_classic_color_darkModeBlack</item>
+        <item name="colorCustomTabsBackground">@color/o2_classic_color_darkModeBlack</item>
 
         <item name="colorSkeletonWave">@color/o2_classic_color_grey_5_30_alpha</item>
 

--- a/library/src/main/res/values-night/themes_telefonica.xml
+++ b/library/src/main/res/values-night/themes_telefonica.xml
@@ -16,6 +16,7 @@
         <item name="colorNavigationBarBackground">@color/telefonica_color_darkModeBlack</item>
         <item name="colorBackgroundAlternative">@color/telefonica_color_darkModeGrey</item>
         <item name="colorBackgroundFeedbackBottom">@color/telefonica_color_darkModeBlack</item>
+        <item name="colorCustomTabsBackground">@color/telefonica_color_darkModeBlack</item>
 
         <item name="colorSkeletonWave">@color/telefonica_color_grey_5</item>
 

--- a/library/src/main/res/values-night/themes_vivo.xml
+++ b/library/src/main/res/values-night/themes_vivo.xml
@@ -14,6 +14,7 @@
         <item name="colorNavigationBarBackground">@color/vivo_color_darkModeBlack</item>
         <item name="colorBackgroundAlternative">@color/vivo_color_darkModeGrey</item>
         <item name="colorBackgroundFeedbackBottom">@color/vivo_color_darkModeBlack</item>
+        <item name="colorCustomTabsBackground">@color/vivo_color_darkModeBlack</item>
 
         <item name="colorSkeletonWave">@color/vivo_color_grey_5_30_alpha</item>
 

--- a/library/src/main/res/values/attrs_colors.xml
+++ b/library/src/main/res/values/attrs_colors.xml
@@ -14,6 +14,7 @@
         <attr name="colorNavigationBarBackground" format="color|reference" />
         <attr name="colorBackgroundAlternative" format="color|reference" />
         <attr name="colorBackgroundFeedbackBottom" format="color|reference" />
+        <attr name="colorCustomTabsBackground" format="color|reference" />
 
         <attr name="colorSkeletonWave" format="color|reference" />
 

--- a/library/src/main/res/values/themes_blau.xml
+++ b/library/src/main/res/values/themes_blau.xml
@@ -16,6 +16,7 @@
 		<item name="colorNavigationBarBackground">@color/blau_color_blue_primary</item>
 		<item name="colorBackgroundAlternative">@color/blau_color_blue_primary20</item>
 		<item name="colorBackgroundFeedbackBottom">@color/blau_color_blue_primary</item>
+		<item name="colorCustomTabsBackground">@color/blau_color_blue_primary</item>
 
 		<item name="colorSkeletonWave">@color/blau_color_grey_2</item>
 

--- a/library/src/main/res/values/themes_movistar.xml
+++ b/library/src/main/res/values/themes_movistar.xml
@@ -16,6 +16,7 @@
 		<item name="colorNavigationBarBackground">@color/movistar_color_blue</item>
 		<item name="colorBackgroundAlternative">@color/movistar_color_grey_1</item>
 		<item name="colorBackgroundFeedbackBottom">@color/movistar_color_blue</item>
+		<item name="colorCustomTabsBackground">@color/movistar_color_white</item>
 
 		<item name="colorSkeletonWave">@color/movistar_color_grey_2</item>
 

--- a/library/src/main/res/values/themes_o2.xml
+++ b/library/src/main/res/values/themes_o2.xml
@@ -16,6 +16,7 @@
         <item name="colorNavigationBarBackground">@color/o2_color_blue_primary</item>
         <item name="colorBackgroundAlternative">@color/o2_color_grey_1</item>
         <item name="colorBackgroundFeedbackBottom">@color/o2_color_blue_primary</item>
+        <item name="colorCustomTabsBackground">@color/o2_color_blue_primary</item>
 
         <item name="colorSkeletonWave">@color/o2_color_grey_2</item>
 

--- a/library/src/main/res/values/themes_o2_classic.xml
+++ b/library/src/main/res/values/themes_o2_classic.xml
@@ -16,6 +16,7 @@
         <item name="colorNavigationBarBackground">@color/o2_classic_color_blue</item>
         <item name="colorBackgroundAlternative">@color/o2_classic_color_grey_1</item>
         <item name="colorBackgroundFeedbackBottom">@color/o2_classic_gradient_fourth</item>
+        <item name="colorCustomTabsBackground">@color/o2_classic_color_blue</item>
 
         <item name="colorSkeletonWave">@color/o2_classic_color_grey_2</item>
 

--- a/library/src/main/res/values/themes_telefonica.xml
+++ b/library/src/main/res/values/themes_telefonica.xml
@@ -16,6 +16,7 @@
         <item name="colorNavigationBarBackground">@color/telefonica_color_blue</item>
         <item name="colorBackgroundAlternative">@color/telefonica_color_grey_1</item>
         <item name="colorBackgroundFeedbackBottom">@color/telefonica_color_blue</item>
+        <item name="colorCustomTabsBackground">@color/telefonica_color_blue</item>
 
         <item name="colorSkeletonWave">@color/telefonica_color_grey_2</item>
 

--- a/library/src/main/res/values/themes_vivo.xml
+++ b/library/src/main/res/values/themes_vivo.xml
@@ -16,6 +16,7 @@
         <item name="colorNavigationBarBackground">@color/vivo_color_purple</item>
         <item name="colorBackgroundAlternative">@color/vivo_color_grey_1</item>
         <item name="colorBackgroundFeedbackBottom">@color/vivo_color_purple</item>
+        <item name="colorCustomTabsBackground">@color/vivo_color_purple</item>
 
         <item name="colorSkeletonWave">@color/vivo_color_grey_2</item>
 


### PR DESCRIPTION
### :goal_net: What's the goal?
Add a new color `colorCustomTabsBackground` to all brands following the changes of this PR https://github.com/Telefonica/mistica-design/pull/892.

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### ☑️ Screenshots
| Brand        | Screenshots           | Dark  Screenshots         |
| ------------- |-------------|-------------|
| Vivo | <img src="https://user-images.githubusercontent.com/2582348/202395809-52ead674-5950-4bbb-a7c7-154d07f2533d.png" alt="drawing" width="200"/> | <img src="https://user-images.githubusercontent.com/2582348/202395824-091a75b5-60f4-4f4f-8296-5fe4d0356b87.png" alt="drawing" width="200"/> |
| Movistar | <img src="https://user-images.githubusercontent.com/2582348/202399451-9676920a-6e4a-4671-9fb3-ee69fb9d25c2.png" alt="drawing" width="200"/> | <img src="https://user-images.githubusercontent.com/2582348/202399440-cde00850-1f34-45de-886f-cdfd50f4ef19.png" alt="drawing" width="200"/> |
| My O2      | <img src="https://user-images.githubusercontent.com/2582348/202401950-6dd65754-2bff-4a97-a30b-b7dbdc1ec21a.png" alt="drawing" width="200"/> | <img src="https://user-images.githubusercontent.com/2582348/202401960-13448eb5-739c-4625-bacd-6dc6cfc05158.png" alt="drawing" width="200"/> |
