### PR TITLE
ANDROID-11369 snackbar allow 10 seconds

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
@@ -55,8 +55,8 @@ class SnackBarCatalogFragment : Fragment() {
                     }
                 }
                 val duration = when {
-                    snackbarLenght10.isChecked -> SnackbarLenght.LENGTH_10
-                    else -> SnackbarLenght.LENGTH_5
+                    snackbarLenght10.isChecked -> SnackbarLenght.LONG
+                    else -> SnackbarLenght.SHORT
                 }
                 when (SnackBarType.valueOf(dropDownInput.dropDown.text.toString())) {
                     SnackBarType.INFORMATIVE -> showInformative(duration)

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
@@ -7,9 +7,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
+import android.widget.RadioButton
 import androidx.fragment.app.Fragment
 import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.feedback.SnackbarBuilder
+import com.telefonica.mistica.feedback.SnackbarLenght
 import com.telefonica.mistica.input.DropDownInput
 import com.telefonica.mistica.input.TextInput
 
@@ -18,7 +20,7 @@ class SnackBarCatalogFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         return layoutInflater.inflate(R.layout.screen_snackbar_catalog, container, false)
@@ -31,6 +33,7 @@ class SnackBarCatalogFragment : Fragment() {
         val inputAction: TextInput = view.findViewById(R.id.input_snackbar_action)
         val dropDownInput: DropDownInput = view.findViewById(R.id.dropdown_snackbar_type)
         val createButton: Button = view.findViewById(R.id.button_create_snackbar)
+        val snackbarLenght10: RadioButton = view.findViewById(R.id.radio_button_10_sec)
 
         with(dropDownInput.dropDown) {
             setAdapter(
@@ -48,12 +51,16 @@ class SnackBarCatalogFragment : Fragment() {
             SnackbarBuilder(view, inputText.text.toString()).apply {
                 inputAction.text.toString().let { actionText ->
                     if (actionText.isNotEmpty()) {
-                        withAction(actionText, View.OnClickListener { })
+                        withAction(actionText, { })
                     }
                 }
+                val duration = when {
+                    snackbarLenght10.isChecked -> SnackbarLenght.LENGTH_10
+                    else -> SnackbarLenght.LENGTH_5
+                }
                 when (SnackBarType.valueOf(dropDownInput.dropDown.text.toString())) {
-                    SnackBarType.INFORMATIVE -> showInformative()
-                    SnackBarType.CRITICAL -> showCritical()
+                    SnackBarType.INFORMATIVE -> showInformative(duration)
+                    SnackBarType.CRITICAL -> showCritical(duration)
                 }
             }
         }

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/SnackBarCatalogFragment.kt
@@ -11,7 +11,7 @@ import android.widget.RadioButton
 import androidx.fragment.app.Fragment
 import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.feedback.SnackbarBuilder
-import com.telefonica.mistica.feedback.SnackbarLenght
+import com.telefonica.mistica.feedback.SnackbarLength
 import com.telefonica.mistica.input.DropDownInput
 import com.telefonica.mistica.input.TextInput
 
@@ -33,7 +33,7 @@ class SnackBarCatalogFragment : Fragment() {
         val inputAction: TextInput = view.findViewById(R.id.input_snackbar_action)
         val dropDownInput: DropDownInput = view.findViewById(R.id.dropdown_snackbar_type)
         val createButton: Button = view.findViewById(R.id.button_create_snackbar)
-        val snackbarLenght10: RadioButton = view.findViewById(R.id.radio_button_10_sec)
+        val snackbarLength10: RadioButton = view.findViewById(R.id.radio_button_10_sec)
 
         with(dropDownInput.dropDown) {
             setAdapter(
@@ -55,8 +55,8 @@ class SnackBarCatalogFragment : Fragment() {
                     }
                 }
                 val duration = when {
-                    snackbarLenght10.isChecked -> SnackbarLenght.LONG
-                    else -> SnackbarLenght.SHORT
+                    snackbarLength10.isChecked -> SnackbarLength.LONG
+                    else -> SnackbarLength.SHORT
                 }
                 when (SnackBarType.valueOf(dropDownInput.dropDown.text.toString())) {
                     SnackBarType.INFORMATIVE -> showInformative(duration)

--- a/catalog/src/main/res/layout/screen_snackbar_catalog.xml
+++ b/catalog/src/main/res/layout/screen_snackbar_catalog.xml
@@ -1,87 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-		xmlns:app="http://schemas.android.com/apk/res-auto"
-		xmlns:tools="http://schemas.android.com/tools"
-		tools:viewBindingIgnore="true"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:gravity="center_horizontal"
-		android:orientation="vertical"
-		android:padding="16dp"
-		>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:viewBindingIgnore="true">
 
-	<com.telefonica.mistica.title.TitleView
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_gravity="start"
-			app:title="SnackBar Tester"
-			/>
+    <com.telefonica.mistica.title.TitleView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        app:title="SnackBar Tester" />
 
-	<com.telefonica.mistica.input.TextInput
-			android:id="@+id/input_snackbar_message"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginTop="8dp"
-			android:inputType="text"
-			app:inputHint="SnackBar Message Text"
-			/>
+    <com.telefonica.mistica.input.TextInput
+        android:id="@+id/input_snackbar_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:inputType="text"
+        app:inputHint="SnackBar Message Text" />
 
-	<com.telefonica.mistica.input.TextInput
-			android:id="@+id/input_snackbar_action"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginTop="8dp"
-			android:inputType="text"
-			app:inputHint="SnackBar Action Text"
-			/>
+    <com.telefonica.mistica.input.TextInput
+        android:id="@+id/input_snackbar_action"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:inputType="text"
+        app:inputHint="SnackBar Action Text" />
 
-	<com.telefonica.mistica.input.DropDownInput
-			android:id="@+id/dropdown_snackbar_type"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginTop="8dp"
-			app:inputHint="SnackBar Type"
-			/>
+    <com.telefonica.mistica.input.DropDownInput
+        android:id="@+id/dropdown_snackbar_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:inputHint="SnackBar Type" />
 
-	<RadioGroup
-			android:id="@+id/radio_group_snackbar_length"
-			android:layout_marginTop="12dp"
-			android:layout_width="match_parent"
-			android:orientation="horizontal"
-			android:gravity="center"
-			android:layout_height="wrap_content"
-			>
+    <RadioGroup
+        android:id="@+id/radio_group_snackbar_length"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:orientation="horizontal">
 
-		<RadioButton
-				android:id="@+id/radio_button_5_sec"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:text="5 seconds"
-				android:checked="true"
-				/>
+        <RadioButton
+            android:id="@+id/radio_button_5_sec"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="5 seconds" />
 
-		<RadioButton
-				android:id="@+id/radio_button_10_sec"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:text="10 seconds"
-				/>
+        <RadioButton
+            android:id="@+id/radio_button_10_sec"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="10 seconds" />
 
-	</RadioGroup>
+    </RadioGroup>
 
-	<TextView
-			android:layout_width="wrap_content"
-			android:gravity="center"
-			android:text="Time only applies if no action set"
-			android:layout_height="wrap_content"
-			/>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Time only applies if no action set" />
 
-	<com.telefonica.mistica.button.Button
-			android:id="@+id/button_create_snackbar"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginTop="12dp"
-			android:text="Test!"
-			/>
+    <com.telefonica.mistica.button.Button
+        android:id="@+id/button_create_snackbar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Test!" />
 
 </LinearLayout>

--- a/catalog/src/main/res/layout/screen_snackbar_catalog.xml
+++ b/catalog/src/main/res/layout/screen_snackbar_catalog.xml
@@ -44,7 +44,7 @@
 			/>
 
 	<RadioGroup
-			android:id="@+id/radio_group_snackbar_lenght"
+			android:id="@+id/radio_group_snackbar_length"
 			android:layout_marginTop="12dp"
 			android:layout_width="match_parent"
 			android:orientation="horizontal"

--- a/catalog/src/main/res/layout/screen_snackbar_catalog.xml
+++ b/catalog/src/main/res/layout/screen_snackbar_catalog.xml
@@ -1,48 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:viewBindingIgnore="true"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="center_horizontal"
-    android:orientation="vertical"
-    android:padding="16dp">
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		xmlns:tools="http://schemas.android.com/tools"
+		tools:viewBindingIgnore="true"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:gravity="center_horizontal"
+		android:orientation="vertical"
+		android:padding="16dp"
+		>
 
-    <com.telefonica.mistica.title.TitleView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        app:title="SnackBar Tester" />
+	<com.telefonica.mistica.title.TitleView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_gravity="start"
+			app:title="SnackBar Tester"
+			/>
 
-    <com.telefonica.mistica.input.TextInput
-        android:id="@+id/input_snackbar_message"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:inputType="text"
-        app:inputHint="SnackBar Message Text" />
+	<com.telefonica.mistica.input.TextInput
+			android:id="@+id/input_snackbar_message"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			android:inputType="text"
+			app:inputHint="SnackBar Message Text"
+			/>
 
-    <com.telefonica.mistica.input.TextInput
-        android:id="@+id/input_snackbar_action"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:inputType="text"
-        app:inputHint="SnackBar Action Text" />
+	<com.telefonica.mistica.input.TextInput
+			android:id="@+id/input_snackbar_action"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			android:inputType="text"
+			app:inputHint="SnackBar Action Text"
+			/>
 
-    <com.telefonica.mistica.input.DropDownInput
-        android:id="@+id/dropdown_snackbar_type"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        app:inputHint="SnackBar Type" />
+	<com.telefonica.mistica.input.DropDownInput
+			android:id="@+id/dropdown_snackbar_type"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			app:inputHint="SnackBar Type"
+			/>
 
-    <com.telefonica.mistica.button.Button
-        android:id="@+id/button_create_snackbar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:text="Test!" />
+	<RadioGroup
+			android:id="@+id/radio_group_snackbar_lenght"
+			android:layout_marginTop="12dp"
+			android:layout_width="match_parent"
+			android:orientation="horizontal"
+			android:gravity="center"
+			android:layout_height="wrap_content"
+			>
+
+		<RadioButton
+				android:id="@+id/radio_button_5_sec"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="5 seconds"
+				android:checked="true"
+				/>
+
+		<RadioButton
+				android:id="@+id/radio_button_10_sec"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="10 seconds"
+				/>
+
+	</RadioGroup>
+
+	<TextView
+			android:layout_width="wrap_content"
+			android:gravity="center"
+			android:text="Time only applies if no action set"
+			android:layout_height="wrap_content"
+			/>
+
+	<com.telefonica.mistica.button.Button
+			android:id="@+id/button_create_snackbar"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="12dp"
+			android:text="Test!"
+			/>
 
 </LinearLayout>

--- a/library/src/main/java/com/telefonica/mistica/feedback/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/README.md
@@ -21,6 +21,8 @@ Builder allows SnackBar customization:
 * `withCallback(Callback callback)`
   * Adds a callback for dismiss action. Dismiss action by definition will only work when using a coordinator layout as anchor view for the SnackBar.
 
-Finally, depending on the type of SnackBar, use one of the following to display it:
+Finally, depending on the type of SnackBar, use one of the following to display it. These methods allow an argument to choose the duration of 5 second or 10.
+5 is the default.
 * `showInformative()`
+* `showInformative(SnackbarLenght.LENGTH_10)`
 * `showCritical()`

--- a/library/src/main/java/com/telefonica/mistica/feedback/README.md
+++ b/library/src/main/java/com/telefonica/mistica/feedback/README.md
@@ -21,8 +21,8 @@ Builder allows SnackBar customization:
 * `withCallback(Callback callback)`
   * Adds a callback for dismiss action. Dismiss action by definition will only work when using a coordinator layout as anchor view for the SnackBar.
 
-Finally, depending on the type of SnackBar, use one of the following to display it. These methods allow an argument to choose the duration of 5 second or 10.
-5 is the default.
+Finally, depending on the type of SnackBar, use one of the following to display it.
+These methods allow an argument to choose the duration betweeen SHORT (5 seconds) or LONG (10 seconds). SHORT is the default.
 * `showInformative()`
-* `showInformative(SnackbarLenght.LENGTH_10)`
+* `showInformative(SnackbarLength.SHORT)`
 * `showCritical()`

--- a/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
@@ -42,7 +42,7 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @JvmOverloads
-    open fun showInformative(snackbarLenght: SnackbarLenght = SnackbarLenght.LENGTH_5): Snackbar {
+    open fun showInformative(snackbarLenght: SnackbarLenght = SnackbarLenght.SHORT): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
         val snackbar = createSnackbar(spannable, snackbarLenght)
         setBackgroundColor(snackbar, R.attr.colorFeedbackInfoBackground)
@@ -52,7 +52,7 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @JvmOverloads
-    open fun showCritical(snackbarLenght: SnackbarLenght = SnackbarLenght.LENGTH_5): Snackbar {
+    open fun showCritical(snackbarLenght: SnackbarLenght = SnackbarLenght.SHORT): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
         val snackbar = createSnackbar(spannable, snackbarLenght)
         setBackgroundColor(snackbar, R.attr.colorFeedbackErrorBackground)
@@ -86,7 +86,7 @@ open class SnackbarBuilder(view: View?, text: String) {
     private fun createSnackbar(text: CharSequence, snackbarLenght: SnackbarLenght): Snackbar {
         val duration = when {
             areSticky() -> Snackbar.LENGTH_INDEFINITE
-            actionText != null -> SnackbarLenght.LENGTH_10.duration()
+            actionText != null -> SnackbarLenght.LONG.duration()
             else -> snackbarLenght.duration()
         }
         val snackbar = Snackbar.make(view, text, duration)
@@ -116,13 +116,13 @@ open class SnackbarBuilder(view: View?, text: String) {
 }
 
 enum class SnackbarLenght {
-    LENGTH_5,
-    LENGTH_10;
+    SHORT,
+    LONG;
 
     fun duration(): Int =
         when (this) {
-            LENGTH_5 -> DURATION_WITHOUT_ACTION
-            LENGTH_10 -> DURATION_WITH_ACTION
+            SHORT -> DURATION_WITHOUT_ACTION
+            LONG -> DURATION_WITH_ACTION
         }
 
     companion object {

--- a/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
@@ -41,18 +41,20 @@ open class SnackbarBuilder(view: View?, text: String) {
         this.callback = callback
     }
 
-    open fun showInformative(): Snackbar {
+    @JvmOverloads
+    open fun showInformative(snackbarLenght: SnackbarLenght = SnackbarLenght.LENGTH_5): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
-        val snackbar = createSnackbar(spannable)
+        val snackbar = createSnackbar(spannable, snackbarLenght)
         setBackgroundColor(snackbar, R.attr.colorFeedbackInfoBackground)
         setActionTextColor(snackbar, R.attr.colorTextLinkSnackbar)
         snackbar.show()
         return snackbar
     }
 
-    open fun showCritical(): Snackbar {
+    @JvmOverloads
+    open fun showCritical(snackbarLenght: SnackbarLenght = SnackbarLenght.LENGTH_5): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
-        val snackbar = createSnackbar(spannable)
+        val snackbar = createSnackbar(spannable, snackbarLenght)
         setBackgroundColor(snackbar, R.attr.colorFeedbackErrorBackground)
         setActionTextColor(snackbar, R.attr.colorTextPrimaryInverse)
         snackbar.show()
@@ -81,14 +83,11 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @Suppress("DEPRECATION")
-    private fun createSnackbar(text: CharSequence): Snackbar {
-        var duration = Snackbar.LENGTH_INDEFINITE
-        if (!areSticky()) {
-            duration = if (actionText != null) {
-                DURATION_WITH_ACTION
-            } else {
-                DURATION_WITHOUT_ACTION
-            }
+    private fun createSnackbar(text: CharSequence, snackbarLenght: SnackbarLenght): Snackbar {
+        val duration = when {
+            areSticky() -> Snackbar.LENGTH_INDEFINITE
+            actionText != null -> SnackbarLenght.LENGTH_10.duration()
+            else -> snackbarLenght.duration()
         }
         val snackbar = Snackbar.make(view, text, duration)
         setTextStyles(snackbar)
@@ -112,8 +111,22 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     companion object {
+        private const val MAX_TEXT_LINES = 4
+    }
+}
+
+enum class SnackbarLenght {
+    LENGTH_5,
+    LENGTH_10;
+
+    fun duration(): Int =
+        when (this) {
+            LENGTH_5 -> DURATION_WITHOUT_ACTION
+            LENGTH_10 -> DURATION_WITH_ACTION
+        }
+
+    companion object {
         private const val DURATION_WITH_ACTION = 10000
         private const val DURATION_WITHOUT_ACTION = 5000
-        private const val MAX_TEXT_LINES = 4
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
@@ -42,9 +42,9 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @JvmOverloads
-    open fun showInformative(snackbarLenght: SnackbarLenght = SnackbarLenght.SHORT): Snackbar {
+    open fun showInformative(snackbarLength: SnackbarLength = SnackbarLength.SHORT): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
-        val snackbar = createSnackbar(spannable, snackbarLenght)
+        val snackbar = createSnackbar(spannable, snackbarLength)
         setBackgroundColor(snackbar, R.attr.colorFeedbackInfoBackground)
         setActionTextColor(snackbar, R.attr.colorTextLinkSnackbar)
         snackbar.show()
@@ -52,9 +52,9 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @JvmOverloads
-    open fun showCritical(snackbarLenght: SnackbarLenght = SnackbarLenght.SHORT): Snackbar {
+    open fun showCritical(snackbarLength: SnackbarLength = SnackbarLength.SHORT): Snackbar {
         val spannable = getSpannable(R.attr.colorTextPrimaryInverse)
-        val snackbar = createSnackbar(spannable, snackbarLenght)
+        val snackbar = createSnackbar(spannable, snackbarLength)
         setBackgroundColor(snackbar, R.attr.colorFeedbackErrorBackground)
         setActionTextColor(snackbar, R.attr.colorTextPrimaryInverse)
         snackbar.show()
@@ -83,11 +83,11 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 
     @Suppress("DEPRECATION")
-    private fun createSnackbar(text: CharSequence, snackbarLenght: SnackbarLenght): Snackbar {
+    private fun createSnackbar(text: CharSequence, snackbarLength: SnackbarLength): Snackbar {
         val duration = when {
             areSticky() -> Snackbar.LENGTH_INDEFINITE
-            actionText != null -> SnackbarLenght.LONG.duration()
-            else -> snackbarLenght.duration()
+            actionText != null -> SnackbarLength.LONG.duration()
+            else -> snackbarLength.duration()
         }
         val snackbar = Snackbar.make(view, text, duration)
         setTextStyles(snackbar)
@@ -115,7 +115,7 @@ open class SnackbarBuilder(view: View?, text: String) {
     }
 }
 
-enum class SnackbarLenght {
+enum class SnackbarLength {
     SHORT,
     LONG;
 


### PR DESCRIPTION
### :goal_net: What's the goal?
Allow snackbar of 5 or 10 seconds if it does not have an action

### :construction: How do we do it?
* Add component property
* Add catalog option

### ☑️ Checks
- [X] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [X] Tested with dark mode.
- [X] Tested with API 21.

### :test_tube: How can I test this?
It can be tested in the dialog app

[mistica_10_result.webm](https://user-images.githubusercontent.com/36664452/203350341-802e3c61-a674-46e1-9229-6fc3bccc295f.webm)

