### PR TITLE
ANDROID-11516 remove jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,6 @@ org.gradle.jvmargs=-Xmx6656m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 
 kapt.incremental.apt=true
 


### PR DESCRIPTION
### :goal_net: What's the goal?
Remove jetifier

> Task :app:checkJetifier
Project ':app' does not use any legacy support libraries. If this is the case for all other projects, you can disable Jetifier by setting android.enableJetifier=false in gradle.properties.

> Task :catalog-compose:checkJetifier
Project ':catalog-compose' does not use any legacy support libraries. If this is the case for all other projects, you can disable Jetifier by setting android.enableJetifier=false in gradle.properties.

> Task :catalog:checkJetifier
Project ':catalog' does not use any legacy support libraries. If this is the case for all other projects, you can disable Jetifier by setting android.enableJetifier=false in gradle.properties.

> Task :library:checkJetifier
Project ':library' does not use any legacy support libraries. If this is the case for all other projects, you can disable Jetifier by setting android.enableJetifier=false in gradle.properties.

### :construction: How do we do it?
_Provide a description of the implementation. A list of steps would be ideal._
* _Step 1_
* _Step 2_
* _Step 3_

### ☑️ Checks
- [X] No documentation changes
- [X] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
Tested executing succesfully the app
