### PR TITLE
fix: catalog app version code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 static def versionCodeDate() {
-    return (new Date().toTimestamp().getTime() / 60).toInteger()
+    return (new Date().getTime() / 1000).toInteger()
 }
 
 appcenter {


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix catalog app version code

After January 31st, the version code is causing an error:
Cause: android.defaultConfig.versionCode is set to -2145093261, but it should be a positive integer.
See https://developer.android.com/studio/publish/versioning#appversioning for more information.

### :construction: How do we do it?
Use time in milliseconds