### PR TITLE
ANDROID-11566 hide popover without animation

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/PopOverCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/fragment/PopOverCatalogFragment.kt
@@ -19,10 +19,12 @@ class PopOverCatalogFragment : Fragment() {
 
     lateinit var dropDownInput: DropDownInput
 
+    private var mainPopover: PopOver? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         return layoutInflater.inflate(R.layout.screen_popovers_catalog, container, false)
@@ -34,6 +36,7 @@ class PopOverCatalogFragment : Fragment() {
         val inputTitle: TextInput = view.findViewById(R.id.input_popover_title)
         val inputMessage: TextInput = view.findViewById(R.id.input_popover_message)
         val createButton: Button = view.findViewById(R.id.button_create_popover)
+        val hideButton: Button = view.findViewById(R.id.button_hide_no_animation)
         val createButtonOnTop: Button = view.findViewById(R.id.button_create_popover_on_top)
         val addImage: CheckBoxInput = view.findViewById(R.id.input_popover_checkbox_image)
         dropDownInput = view.findViewById(R.id.popover_position)
@@ -45,6 +48,9 @@ class PopOverCatalogFragment : Fragment() {
                 inputMessage,
                 addImage
             )
+        }
+        hideButton.setOnClickListener {
+            mainPopover?.hide(animated = false)
         }
         createButtonOnTop.setOnClickListener {
             createPopOverOnView(
@@ -71,19 +77,18 @@ class PopOverCatalogFragment : Fragment() {
         it: View,
         inputTitle: TextInput,
         inputMessage: TextInput,
-        addImage: CheckBoxInput
+        addImage: CheckBoxInput,
     ) {
         it.hideKeyboard()
-        val popover = PopOver(requireActivity(), it)
+        mainPopover = PopOver(requireActivity(), it)
             .setTitle(inputTitle.text.toString())
             .setDescription(inputMessage.text.toString())
             .setPosition(getPositionFromDropDown())
-
-        if (addImage.isChecked()) {
-            popover.setImage(R.drawable.ic_popovers)
-        }
-
-        popover.show(requireActivity())
+            .apply {
+                if (addImage.isChecked()) {
+                    setImage(R.drawable.ic_popovers)
+                }
+            }.show(requireActivity())
     }
 
     private fun getPositionFromDropDown(): PopOverView.Position {

--- a/catalog/src/main/res/layout/screen_popovers_catalog.xml
+++ b/catalog/src/main/res/layout/screen_popovers_catalog.xml
@@ -49,6 +49,13 @@
         android:text="Test" />
 
     <com.telefonica.mistica.button.Button
+        android:id="@+id/button_hide_no_animation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Hide no animation" />
+
+    <com.telefonica.mistica.button.Button
         android:id="@+id/button_create_popover_on_top"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/library/src/main/java/com/telefonica/mistica/feedback/popover/PopOver.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/popover/PopOver.kt
@@ -58,18 +58,24 @@ open class PopOver(
     open fun setDismissButtonContentDescription(contentDescription: String): PopOver =
         apply { popOverData = popOverData.copy(dismissButtonContentDescription = contentDescription) }
 
-    open fun hide() {
+    @JvmOverloads
+    open fun hide(animated: Boolean = true) {
         if (popOverView == null) {
             return
         }
-        val animator = ObjectAnimator.ofFloat<View>(popOverView, View.ALPHA, 1f, 0f)
-        animator.addListener(object : AnimatorListenerAdapter() {
-            override fun onAnimationEnd(animation: Animator) {
-                popOverView?.removeWithoutAnimation()
-                popOverView = null
-            }
-        })
-        animator.start()
+        if (animated) {
+            val animator = ObjectAnimator.ofFloat<View>(popOverView, View.ALPHA, 1f, 0f)
+            animator.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    popOverView?.removeWithoutAnimation()
+                    popOverView = null
+                }
+            })
+            animator.start()
+        } else {
+            popOverView?.removeWithoutAnimation()
+            popOverView = null
+        }
     }
 
     open fun updateCurrentTooltip(targetView: View) {


### PR DESCRIPTION
### :goal_net: What's the goal?
Allow `popover` component to be hidden without animation

### :construction: How do we do it?
Allow `animated` parameter which defaults to `true` to use an animation or not when `Popover` component is hidden
This behaviour allows it to he hidden from outside the component, for example, when initializing a recycled view

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?

[device-2023-02-06-165822.webm](https://user-images.githubusercontent.com/36664452/218767018-c49a2a2d-ceff-45f7-a3aa-cdadf5e06286.webm)


