### PR TITLE
Preset sizes changes

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
@@ -98,7 +98,7 @@ class MisticaTypography(
         fontWeight: FontWeight = FontWeight.Light
     ) =
         buildBaseStyle().copy(
-            fontSize = 22.sp,
+            fontSize = 20.sp,
             lineHeight = 24.sp,
             fontWeight = fontWeight,
         )

--- a/library/src/main/res/values/colors_telefonica.xml
+++ b/library/src/main/res/values/colors_telefonica.xml
@@ -18,7 +18,7 @@
     <color name="telefonica_color_orchid">#C466EF</color>
     <color name="telefonica_color_orchid_10">#F9F0FD</color>
     <color name="telefonica_color_orchid_40">#D694F4</color>
-    <color name="telefonica_color_orchid_70">#8947A7</color>
+    <color name="telefonica_color_orchid_70">#8A1A93</color>
 
     <color name="telefonica_color_turquoise">#59C2C9</color>
     <color name="telefonica_color_turquoise_10">#EEF9FA</color>

--- a/library/src/main/res/values/styles_fonts.xml
+++ b/library/src/main/res/values/styles_fonts.xml
@@ -27,7 +27,7 @@
     </style>
 
     <style name="AppTheme.TextAppearance.Preset5">
-        <item name="android:textSize">22sp</item>
+        <item name="android:textSize">20sp</item>
         <item name="lineHeight">24sp</item>
         <item name="android:fontFamily">?preset5Font</item>
         <item name="android:textStyle">?preset5Style</item>


### PR DESCRIPTION
### :goal_net: What's the goal?
_Provide a description of the overall goal. The description in the Jira ticket may help._
We update the sizes of typography in text-presets for all brands

text-preset-5 from 22 to 20

### ☑️ Checks
- [ ] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [x] Reviewed by Mistica design team
