### PR TITLE
ANDROID-11721 remove prominent style

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Mistica provides an Android theme for each brand supported by telefonica.
 Just set your App or any specific activity to use any of the following:
 
 * MisticaTheme.Movistar
-* MisticaTheme.Movistar.Prominent
 * MisticaTheme.O2
 * MisticaTheme.O2Classic
 * MisticaTheme.Vivo
@@ -58,14 +57,6 @@ Just set your App or any specific activity to use any of the following:
         ...
         android:theme="@style/MisticaTheme.Movistar" />
 </manifest>
-```
-
-```xml
-...
-<activity
-    ...
-    android:theme="@style/MisticaTheme.Movistar.Prominent" />
-...
 ```
 
 ## Components

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/CatalogMainActivity.kt
@@ -58,7 +58,6 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.BlauBrand
 import com.telefonica.mistica.compose.theme.brand.Brand
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
-import com.telefonica.mistica.compose.theme.brand.MovistarProminentBrand
 import com.telefonica.mistica.compose.theme.brand.O2Brand
 import com.telefonica.mistica.compose.theme.brand.O2ClassicBrand
 import com.telefonica.mistica.compose.theme.brand.TelefonicaBrand
@@ -299,7 +298,6 @@ fun ComponentRowPreview() {
 
 val BRANDS = listOf(
     MovistarBrand,
-    MovistarProminentBrand,
     TelefonicaBrand,
     VivoBrand,
     BlauBrand,

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/CatalogMainActivity.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/CatalogMainActivity.kt
@@ -36,7 +36,6 @@ class CatalogMainActivity : AppCompatActivity() {
 
         val styles: List<Pair<String, Int>> = listOf(
             "Movistar" to R.style.MisticaTheme_Movistar,
-            "Movistar Priority" to R.style.MisticaTheme_Movistar_Prominent,
             "O2" to R.style.MisticaTheme_O2,
             "O2 Classic" to R.style.MisticaTheme_O2Classic,
             "Vivo" to R.style.MisticaTheme_Vivo,

--- a/library/src/main/java/com/telefonica/mistica/compose/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/README.md
@@ -122,7 +122,6 @@ which ones are migrated.
 | Brand              | Available |
 |--------------------|-----------|
 | Movistar           | ✅         |
-| Movistar Prominent | ✅         |
 | O2                 | ✅         |
 | O2 Classic         | ✅         |
 | Vivo               | ✅         |

--- a/library/src/main/java/com/telefonica/mistica/compose/composeview/AbstractMisticaComposeView.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/composeview/AbstractMisticaComposeView.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.platform.AbstractComposeView
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_BLAU
 import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_MOVISTAR
-import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_MOVISTAR_PROMINENT
 import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_O2
 import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_O2_CLASSIC
 import com.telefonica.mistica.compose.composeview.AbstractMisticaComposeView.Companion.BRAND_VALUE_TELEFONICA
@@ -17,7 +16,6 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.BlauBrand
 import com.telefonica.mistica.compose.theme.brand.Brand
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
-import com.telefonica.mistica.compose.theme.brand.MovistarProminentBrand
 import com.telefonica.mistica.compose.theme.brand.O2Brand
 import com.telefonica.mistica.compose.theme.brand.O2ClassicBrand
 import com.telefonica.mistica.compose.theme.brand.TelefonicaBrand
@@ -37,7 +35,6 @@ abstract class AbstractMisticaComposeView @JvmOverloads constructor(
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(
         BRAND_VALUE_MOVISTAR,
-        BRAND_VALUE_MOVISTAR_PROMINENT,
         BRAND_VALUE_O2,
         BRAND_VALUE_O2_CLASSIC,
         BRAND_VALUE_VIVO,
@@ -67,17 +64,15 @@ abstract class AbstractMisticaComposeView @JvmOverloads constructor(
 
     companion object {
         const val BRAND_VALUE_MOVISTAR = 0
-        const val BRAND_VALUE_MOVISTAR_PROMINENT = 1
-        const val BRAND_VALUE_O2 = 2
-        const val BRAND_VALUE_O2_CLASSIC = 3
-        const val BRAND_VALUE_VIVO = 4
-        const val BRAND_VALUE_TELEFONICA = 5
-        const val BRAND_VALUE_BLAU = 6
+        const val BRAND_VALUE_O2 = 1
+        const val BRAND_VALUE_O2_CLASSIC = 2
+        const val BRAND_VALUE_VIVO = 3
+        const val BRAND_VALUE_TELEFONICA = 4
+        const val BRAND_VALUE_BLAU = 5
     }
 }
 fun Int.mapToComposeBrand(): Brand = when (this) {
     BRAND_VALUE_MOVISTAR -> MovistarBrand
-    BRAND_VALUE_MOVISTAR_PROMINENT -> MovistarProminentBrand
     BRAND_VALUE_O2 -> O2Brand
     BRAND_VALUE_O2_CLASSIC -> O2ClassicBrand
     BRAND_VALUE_VIVO -> VivoBrand

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -176,42 +176,6 @@ object MovistarBrand : Brand {
         get() = FontWeight.Bold
 }
 
-object MovistarProminentBrand : Brand {
-
-    override val compatibilityTheme: Int
-        get() = R.style.MisticaTheme_Movistar_Prominent
-
-    override val lightColors = MovistarBrand.lightColors.copy(
-        brand = MovistarPaletteColor.movistar_prominent_color_blue,
-        backgroundBrand = MovistarPaletteColor.movistar_prominent_color_blue,
-        navigationBarBackground = MovistarPaletteColor.movistar_prominent_color_blue,
-        brandHigh = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-        dividerInverse = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-        gradientBackgroundFirst = MovistarPaletteColor.movistar_prominent_color_blue,
-        gradientBackgroundSecond = MovistarPaletteColor.movistar_prominent_color_blue,
-        gradientBackgroundThird = MovistarPaletteColor.movistar_prominent_color_blue,
-        gradientBackgroundFourth = MovistarPaletteColor.movistar_prominent_color_blue,
-        loginLoadingGradientFirst = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-        loginLoadingGradientSecond = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-        loginLoadingGradientThird = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-        loginLoadingGradientFourth = MovistarPaletteColor.movistar_prominent_color_blue_dark,
-    )
-
-    override val darkColors: MisticaColors = MovistarBrand.darkColors
-
-    override val preset5FontWeight: FontWeight
-        get() = MovistarBrand.preset5FontWeight
-
-    override val preset6FontWeight: FontWeight
-        get() = MovistarBrand.preset6FontWeight
-
-    override val preset7FontWeight: FontWeight
-        get() = MovistarBrand.preset7FontWeight
-
-    override val preset8FontWeight: FontWeight
-        get() = MovistarBrand.preset8FontWeight
-}
-
 private object MovistarPaletteColor {
     val movistar_color_blue = Color(0xFF019DF4)
     val movistar_color_blue_10 = Color(0xFFE6F5FD)
@@ -255,15 +219,6 @@ private object MovistarPaletteColor {
     val movistar_color_grey_5 = Color(0xFF86888C)
     val movistar_color_grey_6 = Color(0xFF313235)
     val movistar_color_white = Color(0xFFFFFFFF)
-
-    // Prominent Color Palette
-    val movistar_prominent_color_blue = Color(0xFF0B2739)
-    val movistar_prominent_color_blue_10 = Color(0xFFE6F5FD)
-    val movistar_prominent_color_blue_40 = Color(0xFF4DBAF7)
-    val movistar_prominent_color_blue_dark = Color(0xFF081F2D)
-    val movistar_prominent_color_blue_light_20 = Color(0xFFCED3D7)
-    val movistar_prominent_color_blue_light_50 = Color(0xFF85939C)
-    val movistar_prominent_color_blue_light_70 = Color(0xFF546874)
 
     // Android specific palette for colors with custom alpha
     val movistar_color_white_5_alpha = Color(0x0DFFFFFF)

--- a/library/src/main/res/values-night/themes_movistar.xml
+++ b/library/src/main/res/values-night/themes_movistar.xml
@@ -85,10 +85,4 @@
 
     </style>
 
-    <!-- Prominent in dark mode has exactly the same colors as non prominent theme -->
-    <style name="MisticaMovistarProminentOverride" />
-
-    <!-- Just a copy of the above. As themes do not support multiple inheritance. -->
-    <style name="MisticaTheme.Movistar.Prominent" />
-
 </resources>

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -291,7 +291,6 @@
     <declare-styleable name="AbstractMisticaComposeView">
         <attr name="composeBrand" format="enum">
             <enum name="movistar" value="0" />
-            <enum name="movistar_prominent" value="1" />
             <enum name="o2" value="2" />
             <enum name="o2_classic" value="3" />
             <enum name="vivo" value="4" />

--- a/library/src/main/res/values/colors_movistar.xml
+++ b/library/src/main/res/values/colors_movistar.xml
@@ -42,13 +42,6 @@
 
     <color name="movistar_color_white">#FFFFFF</color>
 
-    <!-- Prominent Color Palette -->
-    <color name="movistar_prominent_color_blue">#0B2739</color>
-    <color name="movistar_prominent_color_blue_dark">#081F2D</color>
-    <color name="movistar_prominent_color_blue_light_20">#CED3D7</color>
-    <color name="movistar_prominent_color_blue_light_50">#85939C</color>
-    <color name="movistar_prominent_color_blue_light_70">#546874</color>
-
     <!--  Android specific palette for colors with custom alpha -->
     <color name="movistar_color_white_5_alpha">#0DFFFFFF</color>
     <color name="movistar_color_white_20_alpha">#33FFFFFF</color>

--- a/library/src/main/res/values/themes_movistar.xml
+++ b/library/src/main/res/values/themes_movistar.xml
@@ -149,30 +149,4 @@
 		<item name="composeBrand">movistar</item>
 	</style>
 
-	<style name="MisticaMovistarProminentOverride">
-		<!-- General -->
-		<item name="colorPrimary">@color/movistar_prominent_color_blue</item>
-		<item name="colorPrimaryDark">@color/movistar_prominent_color_blue_dark</item>
-		<item name="colorBrand">@color/movistar_prominent_color_blue</item>
-		<item name="colorBackgroundBrand">@color/movistar_prominent_color_blue</item>
-		<item name="colorNavigationBarBackground">@color/movistar_prominent_color_blue</item>
-		<item name="colorBrandHigh">@color/movistar_prominent_color_blue_dark</item>
-		<item name="colorDividerInverse">@color/movistar_prominent_color_blue_dark</item>
-	</style>
-
-	<!-- Just a copy of the above. As themes do not support multiple inheritance. -->
-	<style name="MisticaTheme.Movistar.Prominent">
-		<!-- General -->
-		<item name="colorPrimary">@color/movistar_prominent_color_blue</item>
-		<item name="colorPrimaryDark">@color/movistar_prominent_color_blue_dark</item>
-		<item name="colorBrand">@color/movistar_prominent_color_blue</item>
-		<item name="colorBackgroundBrand">@color/movistar_prominent_color_blue</item>
-		<item name="colorNavigationBarBackground">@color/movistar_prominent_color_blue</item>
-		<item name="colorBrandHigh">@color/movistar_prominent_color_blue_dark</item>
-		<item name="colorDividerInverse">@color/movistar_prominent_color_blue_dark</item>
-
-		<!-- Compose -->
-		<item name="composeBrand">movistar_prominent</item>
-	</style>
-
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Remove Movistar Prominent Theme

### :construction: How do we do it?
Remove Prominent Theme and related colors and references in the Catalog

### ☑️ Checks
- [X] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [X] Tested with dark mode.
- [X] Tested with API 21.

### :test_tube: How can I test this?

<img width="262" alt="image" src="https://user-images.githubusercontent.com/36664452/221613429-c14dcb94-f64b-4591-91f8-cf2aa2ecd70d.png">

