### PR TITLE
ANDROID-11728 Generate catalog when the PR is created

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Publish catalog
       if: github.event.pull_request.merged == true
       uses: docker://docker.tuenti.io/android/novum_android_api31:2
-      with:
-        args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug'
       env:
         APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
+      with:
+        args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -23,20 +23,13 @@ jobs:
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
-      - name: Print response
-        run: |
-          echo ${{ steps.url-request.outputs.response }}
-          echo ${{ fromJson(steps.url-request.outputs.response).download_url }}
-
       - name: Post comment with catalog URL
         uses: actions/github-script@v6
         with:
           script: |
-            const body = `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}`;
-
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}`
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         with:
-          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }}"'
+          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ env.GITHUB_SHA }}"'
 
       - name: Get version URL
         id: url-request
@@ -21,7 +21,7 @@ jobs:
         with:
           url: 'https://api.appcenter.ms/v0.1/sdk/apps/41f5c96b-1f56-440a-9119-410e160e81de/releases/private/latest'
           method: 'GET'
-          customHeaders: '{"X-API-Token": ${{ secrets.APPCENTER_API_TOKEN }}}'
+          customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
       - name: Post comment with catalog URL
         uses: actions/github-script@v6

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -2,18 +2,18 @@ name: "Generate debug catalog app"
 on:
   pull_request:
 jobs:
-  catalog:
+  debug-catalog:
     runs-on: self-hosted-novum
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Publish catalog
         uses: docker://docker.tuenti.io/android/novum_android_api31:2
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         with:
-          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes='Testing catalog for PR #${{ github.event.number }}''
+          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }}"'
 
       - name: Post comment with catalog URL
         uses: actions/github-script@v6

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -19,10 +19,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const body = `📱 New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public
+            Check PR number in the release notes #${{ github.event.number }}
+            `;
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📱 New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public
-            Check PR number in the release notes #${{ github.event.number }}'
+              body: body
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -23,5 +23,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public'
+              body: '📱 New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public
+            Check PR number in the release notes #${{ github.event.number }}'
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         with:
-          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notes=Testing catalog for PR #${{ github.event.number }}'
+          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes='Testing catalog for PR #${{ github.event.number }}''
 
       - name: Post comment with catalog URL
         uses: actions/github-script@v6

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -15,13 +15,19 @@ jobs:
         with:
           args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }}"'
 
+      - name: Get version URL
+        id: url-request
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.appcenter.ms/v0.1/sdk/apps/41f5c96b-1f56-440a-9119-410e160e81de/releases/private/latest'
+          method: 'GET'
+          customHeaders: '{"X-API-Token": ${{ secrets.APPCENTER_API_TOKEN }}}'
+
       - name: Post comment with catalog URL
         uses: actions/github-script@v6
         with:
           script: |
-            const body = `📱 New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public
-            Check PR number in the release notes #${{ github.event.number }}
-            `;
+            const body = `📱 New catalog for testing generated: ${{ steps.url-request.response.download_url }}}`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -1,0 +1,27 @@
+name: "Generate debug catalog app"
+on:
+  pull_request:
+jobs:
+  catalog:
+    runs-on: self-hosted-novum
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Publish catalog
+        uses: docker://docker.tuenti.io/android/novum_android_api31:2
+        env:
+          APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
+        with:
+          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notes=Testing catalog for PR #${{ github.event.number }}'
+
+      - name: Post comment with catalog URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'New catalog generated: https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public'
+            })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         with:
-          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ env.GITHUB_SHA }}"'
+          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ github.sha }}"'
 
       - name: Get version URL
         id: url-request
@@ -23,11 +23,16 @@ jobs:
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
+      - name: Print response
+        run: |
+          echo ${{ steps.url-request.outputs.response }}
+          echo ${{ fromJson(steps.url-request.outputs.response).download_url }}
+
       - name: Post comment with catalog URL
         uses: actions/github-script@v6
         with:
           script: |
-            const body = `📱 New catalog for testing generated: ${{ steps.url-request.response.download_url }}}`;
+            const body = `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/app/appcenter_projects.properties
+++ b/app/appcenter_projects.properties
@@ -1,0 +1,2 @@
+Mistica=a913f0ba-f8fe-4637-8d15-4966daecae0c
+Mistica-Catalog=41f5c96b-1f56-440a-9119-410e160e81de

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ appcenter {
     apiToken = System.env.APPCENTER_API_TOKEN ?: ""
     ownerName = "Tuenti-Organization"
     distributionGroups = ["Public"]
-    releaseNotes = System.getProperty("appcenter_notes", "# Library version: ${version} \\n See https://github.com/Telefonica/mistica-android/releases for more info.")
+    releaseNotes = System.getProperty("appcenter_notes", "# Library version: ${version} \n See https://github.com/Telefonica/mistica-android/releases for more info.")
 
     notifyTesters = System.getProperty("appcenter_notify", "true")
     apps {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ appcenter {
     distributionGroups = ["Public"]
     releaseNotes = System.getProperty("appcenter_notes", "# Library version: ${version} \\n See https://github.com/Telefonica/mistica-android/releases for more info.")
 
-    notifyTesters = true
+    notifyTesters = System.getProperty("appcenter_notify", "true")
     apps {
         debug {
             appName = System.getProperty("appcenter_app_name", "")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,9 @@ plugins {
     id 'com.betomorrow.appcenter'
 }
 
+def appCenterProjects = new Properties()
+file("appcenter_projects.properties").withInputStream { appCenterProjects.load(it) }
+
 android {
     compileSdkVersion 33
 
@@ -14,7 +17,9 @@ android {
         versionCode versionCodeDate()
         versionName "1.0.0"
 
-        buildConfigField "String", "APPCENTER_KEY", "\"" + System.env.APPCENTER_KEY + "\""
+        buildConfigField "String", "APPCENTER_KEY", "\"" +
+                appCenterProjects.getProperty(System.getProperty("appcenter_app_name", "")) +
+                "\""
     }
 
     lintOptions {
@@ -30,12 +35,12 @@ appcenter {
     apiToken = System.env.APPCENTER_API_TOKEN ?: ""
     ownerName = "Tuenti-Organization"
     distributionGroups = ["Public"]
-    releaseNotes = "# Library version: ${version} \n See https://github.com/Telefonica/mistica-android/releases for more info."
+    releaseNotes = System.getProperty("appcenter_notes", "# Library version: ${version} \\n See https://github.com/Telefonica/mistica-android/releases for more info.")
 
     notifyTesters = true
     apps {
         debug {
-            appName = "mistica"
+            appName = System.getProperty("appcenter_app_name", "")
         }
     }
     uploadMappingFiles = false


### PR DESCRIPTION
### :goal_net: What's the goal?
Generate debug catalog when the PR is created or a new commit is pushed

### :construction: How do we do it?
* Parameterize app center app name in `build.gradle` to be able to select the project.
* Create new Github Action `debug_catalog` to generate and upload the catalog automatically.
