### PR TITLE
ANDROID-11767 Fix debug catalog posted link

### DIFF
--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -23,10 +23,6 @@ jobs:
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
-      - name: Show ID Response
-        run: |
-          echo ${{ steps.id-request.outputs.response }}
-
       - name: Get version URL
         id: url-request
         uses: fjogeleit/http-request-action@v1
@@ -34,10 +30,6 @@ jobs:
           url: 'https://api.appcenter.ms/v0.1/apps/Tuenti-Organization/Mistica-Catalog/releases/${{ fromJson(steps.id-request.outputs.response)[0].id }}'
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
-
-      - name: Show version Response
-        run: |
-          echo ${{ steps.url-request.outputs.response }}
 
       - name: Post comment with catalog URL
         uses: actions/github-script@v6

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -23,6 +23,10 @@ jobs:
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
+      - name: Show Response
+          run: |
+            echo ${{ steps.url-request.outputs.response }}
+
       - name: Post comment with catalog URL
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -15,15 +15,27 @@ jobs:
         with:
           args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ github.sha }}"'
 
+      - name: Get version ID
+        id: id-request
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.appcenter.ms/v0.1/apps/Tuenti-Organization/Mistica-Catalog/releases?published_only=true&top=1'
+          method: 'GET'
+          customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
+
+      - name: Show ID Response
+        run: |
+          echo ${{ steps.id-request.outputs.response }}
+
       - name: Get version URL
         id: url-request
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.appcenter.ms/v0.1/sdk/apps/41f5c96b-1f56-440a-9119-410e160e81de/releases/private/latest'
+          url: 'https://api.appcenter.ms/v0.1/apps/Tuenti-Organization/Mistica-Catalog/releases/${{ fromJson(steps.id-request.outputs.response)[0].id }}'
           method: 'GET'
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
-      - name: Show Response
+      - name: Show version Response
         run: |
           echo ${{ steps.url-request.outputs.response }}
 

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -24,8 +24,8 @@ jobs:
           customHeaders: '{"X-API-Token": "${{ secrets.APPCENTER_API_TOKEN }}"}'
 
       - name: Show Response
-          run: |
-            echo ${{ steps.url-request.outputs.response }}
+        run: |
+          echo ${{ steps.url-request.outputs.response }}
 
       - name: Post comment with catalog URL
         uses: actions/github-script@v6


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix debug catalog posted link. We were not posting the link of the last generated version.

To fix it I've changed the API that we were using. Now we do two requests, in the first one we get the last uploaded version ID and in the second one we get the link to download that version.
