### PR TITLE
ANDROID-11659 Update TextSecondaryInverse colours for all brands (light mode)

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
@@ -92,7 +92,7 @@ object BlauBrand : Brand {
         textPrimary = BlauPaletteColor.blau_color_grey_6,
         textPrimaryInverse = BlauPaletteColor.blau_color_white,
         textSecondary = BlauPaletteColor.blau_color_grey_5,
-        textSecondaryInverse = BlauPaletteColor.blau_color_white,
+        textSecondaryInverse = BlauPaletteColor.blau_color_blue_primary20,
         errorHigh = BlauPaletteColor.blau_color_red_70,
         promoHigh = BlauPaletteColor.blau_color_purple,
         successHigh = BlauPaletteColor.blau_color_green_70,

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
@@ -92,7 +92,7 @@ object O2Brand : Brand {
         textPrimary = O2PaletteColor.o2_color_grey_6,
         textPrimaryInverse = O2PaletteColor.o2_color_white,
         textSecondary = O2PaletteColor.o2_color_grey_5,
-        textSecondaryInverse = O2PaletteColor.o2_color_white,
+        textSecondaryInverse = O2PaletteColor.o2_color_blue_primary_15,
         errorHigh = O2PaletteColor.o2_color_pepper_60,
         promoHigh = O2PaletteColor.o2_color_purple,
         successHigh = O2PaletteColor.o2_color_green_80,

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
@@ -92,7 +92,7 @@ object TelefonicaBrand : Brand {
         textPrimary = TelefonicaPaletteColor.telefonica_color_grey_9,
         textPrimaryInverse = TelefonicaPaletteColor.telefonica_color_white,
         textSecondary = TelefonicaPaletteColor.telefonica_color_grey_5,
-        textSecondaryInverse = TelefonicaPaletteColor.telefonica_color_white,
+        textSecondaryInverse = TelefonicaPaletteColor.telefonica_color_blue_10,
         errorHigh = TelefonicaPaletteColor.telefonica_color_coral_70,
         promoHigh = TelefonicaPaletteColor.telefonica_color_orchid_70,
         successHigh = TelefonicaPaletteColor.telefonica_color_turquoise_70,
@@ -193,6 +193,7 @@ object TelefonicaBrand : Brand {
 
 private object TelefonicaPaletteColor {
     val telefonica_color_blue = Color(0xFF0066FF)
+    val telefonica_color_blue_10 = Color(0xFFE5F0FF)
     val telefonica_color_blue_30 = Color(0xFF80B3FF)
     val telefonica_color_blue_70 = Color(0xFF0356C9)
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
@@ -92,7 +92,7 @@ object VivoBrand : Brand {
         textPrimary = VivoPaletteColor.vivo_color_grey_6,
         textPrimaryInverse = VivoPaletteColor.vivo_color_white,
         textSecondary = VivoPaletteColor.vivo_color_grey_5,
-        textSecondaryInverse = VivoPaletteColor.vivo_color_white,
+        textSecondaryInverse = VivoPaletteColor.vivo_color_purple_light20,
         errorHigh = VivoPaletteColor.vivo_color_pepper_dark_80,
         promoHigh = VivoPaletteColor.vivo_color_purple,
         successHigh = VivoPaletteColor.vivo_color_green_dark,

--- a/library/src/main/res/values/colors_telefonica.xml
+++ b/library/src/main/res/values/colors_telefonica.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <resources>
     <color name="telefonica_color_blue">#0066FF</color>
+    <color name="telefonica_color_blue_10">#E5F0FF</color>
     <color name="telefonica_color_blue_30">#80B3FF</color>
     <color name="telefonica_color_blue_70">#0356C9</color>
 

--- a/library/src/main/res/values/themes_blau.xml
+++ b/library/src/main/res/values/themes_blau.xml
@@ -100,7 +100,7 @@
 		<item name="colorTextPrimary">@color/blau_color_grey_6</item>
 		<item name="colorTextPrimaryInverse">@color/blau_color_white</item>
 		<item name="colorTextSecondary">@color/blau_color_grey_5</item>
-		<item name="colorTextSecondaryInverse">@color/blau_color_white</item>
+		<item name="colorTextSecondaryInverse">@color/blau_color_blue_primary20</item>
 
 		<!-- State colors -->
 		<item name="colorError">@color/blau_color_red</item>

--- a/library/src/main/res/values/themes_o2.xml
+++ b/library/src/main/res/values/themes_o2.xml
@@ -102,7 +102,7 @@
         <item name="colorTextPrimary">@color/o2_color_grey_6</item>
         <item name="colorTextPrimaryInverse">@color/o2_color_white</item>
         <item name="colorTextSecondary">@color/o2_color_grey_5</item>
-        <item name="colorTextSecondaryInverse">@color/o2_color_white</item>
+        <item name="colorTextSecondaryInverse">@color/o2_color_blue_primary_15</item>
 
         <!-- State colors -->
         <item name="colorError">@color/o2_color_pepper</item>

--- a/library/src/main/res/values/themes_telefonica.xml
+++ b/library/src/main/res/values/themes_telefonica.xml
@@ -102,7 +102,7 @@
         <item name="colorTextPrimary">@color/telefonica_color_grey_9</item>
         <item name="colorTextPrimaryInverse">@color/telefonica_color_white</item>
         <item name="colorTextSecondary">@color/telefonica_color_grey_5</item>
-        <item name="colorTextSecondaryInverse">@color/telefonica_color_white</item>
+        <item name="colorTextSecondaryInverse">@color/telefonica_color_blue_10</item>
 
         <!-- State colors -->
         <item name="colorError">@color/telefonica_color_coral</item>

--- a/library/src/main/res/values/themes_vivo.xml
+++ b/library/src/main/res/values/themes_vivo.xml
@@ -104,7 +104,7 @@
         <item name="colorTextPrimary">@color/vivo_color_grey_6</item>
         <item name="colorTextPrimaryInverse">@color/vivo_color_white</item>
         <item name="colorTextSecondary">@color/vivo_color_grey_5</item>
-        <item name="colorTextSecondaryInverse">@color/vivo_color_white</item>
+        <item name="colorTextSecondaryInverse">@color/vivo_color_purple_light20</item>
 
         <!-- State colors -->
         <item name="colorError">@color/vivo_color_pepper</item>


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-11659](https://jira.tid.es/browse/ANDROID-11659)

### :goal_net: What's the goal?
Update textSecondaryInverse (light mode) for all brands. Requested by design.

Movistar: movistarBlue10 (this one was OK)
Vivo: vivoPurpleLight20
O2: o2BluePrimary15
Blau: blauBluePrimary20
Telefónica: telefonicaBlue10

### :construction: How do we do it?
Updating the TextSecondaryInverse colour of all brands in compose as in xml.

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
