### PR TITLE
ANDROID-11911 Add public appcenter link

### DIFF
--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -39,7 +39,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}
+              body: `📱 New catalog for testing generated: [Download](${{ fromJson(steps.url-request.outputs.response).download_url }})
             
-              :exclamation:If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and download the version for PR #${{ github.event.number }}`
+              :exclamation:If the URL returns an error, go to [here](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public) and download the version for PR #${{ github.event.number }}`
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -39,5 +39,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}`
+              body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}
+            
+              If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and 
+              download the version for PR #${{ github.event.number }}`
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -41,6 +41,5 @@ jobs:
               repo: context.repo.repo,
               body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}
             
-              :exclamation: If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and 
-              download the version for PR #${{ github.event.number }}`
+              :exclamation:If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and download the version for PR #${{ github.event.number }}`
             })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -41,6 +41,6 @@ jobs:
               repo: context.repo.repo,
               body: `📱 New catalog for testing generated: ${{ fromJson(steps.url-request.outputs.response).download_url }}
             
-              If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and 
+              :exclamation: If the URL returns an error, go to https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public and 
               download the version for PR #${{ github.event.number }}`
             })


### PR DESCRIPTION
### :goal_net: What's the goal?
Add public appcenter link to be able to download the testing catalog if the download link has expired.

You can see the result in the comment.