### PR TITLE
ANDROID-11727 Fix BOM dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,13 +63,15 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.material:material"
-    implementation "androidx.compose.ui:ui-tooling-preview"
     api "androidx.compose.runtime:runtime"
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
+
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling-preview"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'
@@ -78,14 +80,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "androidx.compose.ui:ui-test-junit4"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-
-    androidTestImplementation composeBom
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
-    androidTestImplementation("androidx.compose.ui:ui-test-manifest")
-
-    debugImplementation "androidx.compose.ui:ui-tooling"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"


### PR DESCRIPTION
### :goal_net: What's the goal?
When trying to import latest Mistica versioN (7.3.1) on any project, compilation fails with this error:
```
* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all files for configuration ':app:movistarESDebugCompileClasspath'.
   > Could not find androidx.compose.ui:ui-tooling-preview:.
     Required by:
         project :app > com.telefonica:mistica:7.3.1
```

### :construction: How do we do it?
It looks like `ui-tooling` and `ui-tooling-preview` are two libraries that are related, using debugImplementation for both of them instead of just for `ui-tooling` seems to fix the error.

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- Not a UI change, there is no need for this change to be reviewed by any member from Design team.
- I published a snapshot version with this changes and the error is gone
