### PR TITLE
Revert Compose BOM usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_bom_version = "2023.01.00"
+        compose_version = '1.3.1'
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/catalog-compose/build.gradle
+++ b/catalog-compose/build.gradle
@@ -40,20 +40,21 @@ android {
 
 dependencies {
     implementation project(':library')
-    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
+
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.material:material"
-    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"
     implementation "com.google.android.material:compose-theme-adapter:1.2.1"
     implementation "androidx.navigation:navigation-compose:2.5.3"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
-
     testImplementation 'junit:junit:4.13.2'
-
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,14 +63,12 @@ dependencies {
     api 'androidx.constraintlayout:constraintlayout:2.0.4'
     api 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
     api 'androidx.recyclerview:recyclerview:1.1.0'
-    def composeBom = platform("androidx.compose:compose-bom:$compose_bom_version")
-    api composeBom
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.material:material"
-    implementation "androidx.compose.ui:ui-tooling-preview"
-    api "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    api "androidx.compose.runtime:runtime:$compose_version"
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
@@ -80,18 +78,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'
 
-    testImplementation composeBom
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "androidx.compose.ui:ui-test-junit4"
+    testImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-
-    androidTestImplementation composeBom
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
-    androidTestImplementation("androidx.compose.ui:ui-test-manifest")
-
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"


### PR DESCRIPTION
### :goal_net: What's the goal?
After having introduced Compose BOM, we are no longer able to import this library on other repositories. We are reverting the commit in which that BOM was included and investigating the issue in the meantime.

### :construction: How do we do it?
Revert https://github.com/Telefonica/mistica-android/commit/87a39686dca4dc448cc447cdb91572655e5ef93e

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- Published to maven local and tested that it can be included on any project
