### PR TITLE
ANDROID-11916 Text Area in Compose

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
@@ -28,6 +28,7 @@ import com.telefonica.mistica.compose.input.DropDownInput
 import com.telefonica.mistica.compose.input.EmailInput
 import com.telefonica.mistica.compose.input.PasswordInput
 import com.telefonica.mistica.compose.input.PhoneInput
+import com.telefonica.mistica.compose.input.TextAreaInput
 import com.telefonica.mistica.compose.input.TextInput
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
@@ -64,6 +65,8 @@ fun Inputs() {
         EmailInputWithValidation()
         Title("Phone input with validation")
         PhoneInputWithValidation()
+        Title("Text Area input")
+        TextAreaInputSample()
         Title("Dropdown")
         DropDownSample()
         Title("Disable Dropdown")
@@ -326,6 +329,26 @@ private fun ColumnScope.PhoneInputWithValidation() {
             isError = text.isEmpty()
         },
         buttonStyle = ButtonStyle.PRIMARY_SMALL
+    )
+}
+
+@Composable
+fun TextAreaInputSample() {
+    var text by remember {
+        mutableStateOf("")
+    }
+
+    TextAreaInput(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp),
+        value = text,
+        onValueChange = {
+            text = it
+        },
+        label = "Type Something",
+        helperText = "Helper Text",
+        maxChars = 200,
     )
 }
 

--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Inputs.kt
@@ -26,6 +26,7 @@ import com.telefonica.mistica.compose.button.Button
 import com.telefonica.mistica.compose.button.ButtonStyle
 import com.telefonica.mistica.compose.input.DropDownInput
 import com.telefonica.mistica.compose.input.EmailInput
+import com.telefonica.mistica.compose.input.LimitCharacters
 import com.telefonica.mistica.compose.input.PasswordInput
 import com.telefonica.mistica.compose.input.PhoneInput
 import com.telefonica.mistica.compose.input.TextAreaInput
@@ -348,7 +349,7 @@ fun TextAreaInputSample() {
         },
         label = "Type Something",
         helperText = "Helper Text",
-        maxChars = 200,
+        maxChars = LimitCharacters.Limited(200),
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
@@ -1,0 +1,23 @@
+package com.telefonica.mistica.compose.input
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.telefonica.mistica.compose.theme.MisticaTheme
+
+@Composable
+internal fun CharsCounter(current: Int, max: LimitCharacters.Limited, modifier: Modifier = Modifier) {
+    Text(
+        text = "$current/${max.characterLimit}",
+        color = MisticaTheme.colors.textSecondary,
+        textAlign = TextAlign.End,
+        style = MisticaTheme.typography.preset1,
+        modifier = modifier,
+    )
+}
+
+sealed interface LimitCharacters {
+    object Unlimited : LimitCharacters
+    data class Limited(val characterLimit: Int) : LimitCharacters
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
@@ -7,10 +7,15 @@ import androidx.compose.ui.text.style.TextAlign
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
 @Composable
-internal fun CharsCounter(current: Int, max: LimitCharacters.Limited, modifier: Modifier = Modifier) {
+internal fun CharsCounter(
+    current: Int,
+    max: LimitCharacters.Limited,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+) {
     Text(
         text = "$current/${max.characterLimit}",
-        color = MisticaTheme.colors.textSecondary,
+        color = if (isError) MisticaTheme.colors.error else MisticaTheme.colors.textSecondary,
         textAlign = TextAlign.End,
         style = MisticaTheme.typography.preset1,
         modifier = modifier,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/README.md
@@ -10,8 +10,8 @@ Current Composable input types:
 * `PhoneInput`
 * `EmailInput`
 * `PasswordInput`
+* `TextAreaInput`
 * `DropDownInput` (Implemented with `AndroidView`)
 
 **Note**: not every input component is migrated yet to compose. Those components that need to be migrated at some point are:
-* Text area (from `com.telefonica.mistica.input.TextInput` with `inputType="textArea"`)
 * Check Box Input (from `com.telefonica.mistica.input.CheckBoxInput`)

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -25,7 +25,7 @@ fun TextAreaInput(
     enabled: Boolean = true,
     readOnly: Boolean = false,
     onClick: (() -> Unit)? = null,
-    maxChars: Int = Int.MAX_VALUE,
+    maxChars: LimitCharacters = LimitCharacters.Unlimited,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
@@ -37,9 +37,7 @@ fun TextAreaInput(
         modifier = modifier,
         value = value,
         onValueChange = { newValue ->
-            val text = if (newValue.length > maxChars) newValue.substring(startIndex = 0, endIndex = maxChars) else newValue
-            currentChars = text.length
-            onValueChange(text)
+            currentChars = doOnValueChange(maxChars, newValue, onValueChange)
         },
         label = label,
         helperText = helperText,
@@ -53,13 +51,32 @@ fun TextAreaInput(
         isTextArea = true,
         visualTransformation = visualTransformation,
         underlineEnd = {
-            if (maxChars < Int.MAX_VALUE) {
+            if (maxChars is LimitCharacters.Limited) {
                 CharsCounter(current = currentChars, max = maxChars)
             }
         },
         keyboardOptions = keyboardOptions.copy(imeAction = ImeAction.None)
             .toFoundationKeyboardOptions(KeyboardType.Text),
     )
+}
+
+private fun doOnValueChange(
+    maxChars: LimitCharacters,
+    newValue: String,
+    onValueChange: (String) -> Unit,
+): Int {
+    return if (maxChars is LimitCharacters.Limited) {
+        val text = if (newValue.length > maxChars.characterLimit) {
+            newValue.substring(startIndex = 0, endIndex = maxChars.characterLimit)
+        } else {
+            newValue
+        }
+        onValueChange(text)
+        text.length
+    } else {
+        onValueChange(newValue)
+        newValue.length
+    }
 }
 
 @Preview(showBackground = true)

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -52,7 +52,11 @@ fun TextAreaInput(
         visualTransformation = visualTransformation,
         underlineEnd = {
             if (maxChars is LimitCharacters.Limited) {
-                CharsCounter(current = currentChars, max = maxChars)
+                CharsCounter(
+                    current = currentChars,
+                    max = maxChars,
+                    isError = isError
+                )
             }
         },
         keyboardOptions = keyboardOptions.copy(imeAction = ImeAction.None)

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -1,0 +1,84 @@
+package com.telefonica.mistica.compose.input
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun TextAreaInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    isError: Boolean = false,
+    errorText: String? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isInverse: Boolean = false,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    maxChars: Int = Int.MAX_VALUE,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+) {
+    var currentChars by remember {
+        mutableStateOf(0)
+    }
+
+    TextInputImpl(
+        modifier = modifier,
+        value = value,
+        onValueChange = { newValue ->
+            val text = if (newValue.length > maxChars) newValue.substring(startIndex = 0, endIndex = maxChars) else newValue
+            currentChars = text.length
+            onValueChange(text)
+        },
+        label = label,
+        helperText = helperText,
+        isError = isError,
+        errorText = errorText,
+        trailingIcon = trailingIcon,
+        isInverse = isInverse,
+        enabled = enabled,
+        readOnly = readOnly,
+        onClick = onClick,
+        isTextArea = true,
+        visualTransformation = visualTransformation,
+        underlineEnd = {
+            if (maxChars < Int.MAX_VALUE) {
+                CharsCounter(current = currentChars, max = maxChars)
+            }
+        },
+        keyboardOptions = keyboardOptions.copy(imeAction = ImeAction.None)
+            .toFoundationKeyboardOptions(KeyboardType.Text),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewEmptyTextAreaInput() {
+    TextAreaInput(
+        value = "",
+        onValueChange = {},
+        label = "empty",
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTextAreaInput() {
+    TextAreaInput(
+        value = "value",
+        onValueChange = {},
+        label = "label",
+        helperText = "helper",
+    )
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -55,7 +55,7 @@ fun TextAreaInput(
                 CharsCounter(
                     current = currentChars,
                     max = maxChars,
-                    isError = isError
+                    isError = isError,
                 )
             }
         },

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -185,7 +185,7 @@ private fun Underline(
         Spacer(modifier = Modifier.weight(1f))
         underlineEnd?.let {
             Box(Modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp)) {
-                underlineEnd.invoke()
+                underlineEnd()
             }
         }
     }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -11,9 +11,13 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions as FoundationKeyboardOptions
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -23,13 +27,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.common.ui.alpha
 import com.telefonica.mistica.compose.theme.MisticaTheme
+import androidx.compose.foundation.text.KeyboardOptions as FoundationKeyboardOptions
 
 @Composable
 internal fun TextInputImpl(
@@ -44,9 +51,11 @@ internal fun TextInputImpl(
     isInverse: Boolean,
     enabled: Boolean,
     readOnly: Boolean,
+    isTextArea: Boolean = false,
     onClick: (() -> Unit)?,
     visualTransformation: VisualTransformation,
     keyboardOptions: FoundationKeyboardOptions,
+    underlineEnd: @Composable (() -> Unit)? = null,
 ) {
     val colors = if (isInverse) {
         TextInputColors(
@@ -74,12 +83,21 @@ internal fun TextInputImpl(
                 readOnly = readOnly,
                 onClick = onClick,
                 visualTransformation = visualTransformation,
-                keyboardOptions = keyboardOptions
+                keyboardOptions = keyboardOptions,
+                isMultiLine = isTextArea,
+                modifier = Modifier.then(
+                    if (isTextArea) {
+                        Modifier.height(152.dp)
+                    } else {
+                        Modifier
+                    },
+                ),
             )
             Underline(
                 isError = isError,
                 errorText = errorText,
-                helperText = helperText
+                helperText = helperText,
+                underlineEnd = underlineEnd,
             )
         }
     }
@@ -88,6 +106,7 @@ internal fun TextInputImpl(
 @Composable
 private fun TextBox(
     value: String,
+    modifier: Modifier = Modifier,
     onValueChange: (String) -> Unit,
     label: String,
     isError: Boolean,
@@ -97,6 +116,7 @@ private fun TextBox(
     onClick: (() -> Unit)?,
     visualTransformation: VisualTransformation,
     keyboardOptions: FoundationKeyboardOptions,
+    isMultiLine: Boolean = false,
 ) {
     val interactionSource = remember {
         MutableInteractionSource()
@@ -107,7 +127,7 @@ private fun TextBox(
     }
 
     TextField(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .border(width = 1.dp, color = MisticaTheme.colors.border, shape = RoundedCornerShape(8.dp)),
         enabled = enabled,
@@ -115,11 +135,14 @@ private fun TextBox(
         value = value,
         onValueChange = onValueChange,
         label = {
-            TextInputLabel(
-                text = label,
-                isMinimized = interactionSource.collectIsFocusedAsState().value,
-                isError = isError
-            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                TextInputLabel(
+                    text = label,
+                    isMinimized = interactionSource.collectIsFocusedAsState().value,
+                    isError = isError,
+                    modifier = Modifier.align(Alignment.TopStart),
+                )
+            }
         },
         interactionSource = interactionSource,
         keyboardOptions = keyboardOptions,
@@ -134,8 +157,8 @@ private fun TextBox(
             errorIndicatorColor = Color.Transparent,
             errorCursorColor = MisticaTheme.colors.controlActive,
         ),
-        singleLine = true,
-        maxLines = 1,
+        singleLine = !isMultiLine,
+        maxLines = if (isMultiLine) Int.MAX_VALUE else 1,
         visualTransformation = visualTransformation,
     )
 }
@@ -145,18 +168,25 @@ private fun Underline(
     isError: Boolean,
     errorText: String?,
     helperText: String?,
+    underlineEnd: @Composable (() -> Unit)?,
 ) {
-    Box {
-        UnderlineTextAnimatedVisibility(
-            visible = !isError && helperText != null,
-            text = helperText,
-            color = LocalTextInputColors.current.helperTextColor
-        )
-        UnderlineTextAnimatedVisibility(
-            visible = isError && errorText != null,
-            text = errorText,
-            color = LocalTextInputColors.current.errorTextColor
-        )
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Box {
+            UnderlineTextAnimatedVisibility(
+                visible = !isError && helperText != null,
+                text = helperText,
+                color = LocalTextInputColors.current.helperTextColor,
+            )
+            UnderlineTextAnimatedVisibility(
+                visible = isError && errorText != null,
+                text = errorText,
+                color = LocalTextInputColors.current.errorTextColor,
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Box(Modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp)) {
+            underlineEnd?.invoke()
+        }
     }
 }
 
@@ -191,18 +221,31 @@ private fun UnderlineText(
 }
 
 @Composable
+fun CharsCounter(current: Int, max: Int, modifier: Modifier = Modifier) {
+    Text(
+        text = "$current/$max",
+        color = MisticaTheme.colors.textSecondary,
+        textAlign = TextAlign.End,
+        style = MisticaTheme.typography.preset1,
+        modifier = modifier,
+    )
+}
+
+@Composable
 private fun TextInputLabel(
     text: String,
     isMinimized: Boolean,
-    isError: Boolean
+    isError: Boolean,
+    modifier: Modifier = Modifier
 ) {
     Text(
         text = text,
         color = when {
-            isError && isMinimized-> MisticaTheme.colors.error
+            isError && isMinimized -> MisticaTheme.colors.error
             isMinimized -> MisticaTheme.colors.controlActive
             else -> MisticaTheme.colors.textSecondary
-        }
+        },
+        modifier = modifier,
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -83,7 +83,7 @@ internal fun TextInputImpl(
                 onClick = onClick,
                 visualTransformation = visualTransformation,
                 keyboardOptions = keyboardOptions,
-                isMultiLine = isTextArea,
+                singleLine = !isTextArea,
                 modifier = Modifier.then(
                     if (isTextArea) {
                         Modifier.height(152.dp)
@@ -115,7 +115,7 @@ private fun TextBox(
     onClick: (() -> Unit)?,
     visualTransformation: VisualTransformation,
     keyboardOptions: FoundationKeyboardOptions,
-    isMultiLine: Boolean = false,
+    singleLine: Boolean = false,
 ) {
     val interactionSource = remember {
         MutableInteractionSource()
@@ -156,8 +156,8 @@ private fun TextBox(
             errorIndicatorColor = Color.Transparent,
             errorCursorColor = MisticaTheme.colors.controlActive,
         ),
-        singleLine = !isMultiLine,
-        maxLines = if (isMultiLine) Int.MAX_VALUE else 1,
+        singleLine = singleLine,
+        maxLines = if (singleLine) 1 else  Int.MAX_VALUE,
         visualTransformation = visualTransformation,
     )
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -183,8 +183,10 @@ private fun Underline(
             )
         }
         Spacer(modifier = Modifier.weight(1f))
-        Box(Modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp)) {
-            underlineEnd?.invoke()
+        underlineEnd?.let {
+            Box(Modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp)) {
+                underlineEnd.invoke()
+            }
         }
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -157,7 +157,7 @@ private fun TextBox(
             errorCursorColor = MisticaTheme.colors.controlActive,
         ),
         singleLine = singleLine,
-        maxLines = if (singleLine) 1 else  Int.MAX_VALUE,
+        maxLines = if (singleLine) 1 else Int.MAX_VALUE,
         visualTransformation = visualTransformation,
     )
 }
@@ -218,17 +218,6 @@ private fun UnderlineText(
         text = text,
         style = MisticaTheme.typography.preset1,
         color = color
-    )
-}
-
-@Composable
-fun CharsCounter(current: Int, max: Int, modifier: Modifier = Modifier) {
-    Text(
-        text = "$current/$max",
-        color = MisticaTheme.colors.textSecondary,
-        textAlign = TextAlign.End,
-        style = MisticaTheme.typography.preset1,
-        modifier = modifier,
     )
 }
 


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-11916](https://jira.tid.es/browse/ANDROID-11916)

### :goal_net: What's the goal?
Add a TextArea component as the one there is in the gallery that it's using traditional views.

### :construction: How do we do it?
- Created new TextAreaInput composable.
- Created new CharsCounter composable.
- Updated TextInputImpl so that it allows multiline when isTextArea
- Added underlineEnd slot to TextInputImpl so we can pass a CharsCounter when it's a textarea, this would allow any input to have CharsCounter or another composable on the bottomright if needed.

![EmptyTextarea](https://user-images.githubusercontent.com/13270085/230914982-d399434b-3aeb-4a2a-b0ed-25195c576e56.png)

![SelectedTextarea](https://user-images.githubusercontent.com/13270085/230915005-30890959-c7e6-4212-ac2c-02cc7000ad78.png)

![Lorem Ipsum](https://user-images.githubusercontent.com/13270085/230915035-28b5cd3a-313b-4b2d-b1b7-8ccb3fbe237d.png)

![LoremIpsumTruncated](https://user-images.githubusercontent.com/13270085/230915049-006b90e3-9d75-4dcc-954d-1de76e5e168b.png)

https://user-images.githubusercontent.com/13270085/230917350-d1325bd9-ea48-46ae-af3e-6bb76d0c1e15.mov

### ☑️ Checks
- [ ] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
