### PR TITLE
Fix compose bom releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.3.1'
+        compose_bom_version = "2023.01.00"
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_bom_version = "2023.01.00" // Remember to update ui-tooling-preview version as well.
+        // Remember to update "ui_tooling_preview_version" when updating "compose_bom_version"
+        // according to https://mvnrepository.com/artifact/androidx.compose/compose-bom/
+        // For more info see https://github.com/Telefonica/mistica-android/pull/230
+        compose_bom_version = "2023.01.00"
+        ui_tooling_preview_version = "1.3.3"
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_bom_version = "2023.01.00"
+        compose_bom_version = "2023.01.00" // Remember to update ui-tooling-preview version as well.
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/catalog-compose/build.gradle
+++ b/catalog-compose/build.gradle
@@ -40,21 +40,20 @@ android {
 
 dependencies {
     implementation project(':library')
-
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"
     implementation "com.google.android.material:compose-theme-adapter:1.2.1"
     implementation "androidx.navigation:navigation-compose:2.5.3"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
+
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+
+    debugImplementation "androidx.compose.ui:ui-tooling"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,12 +63,14 @@ dependencies {
     api 'androidx.constraintlayout:constraintlayout:2.0.4'
     api 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
     api 'androidx.recyclerview:recyclerview:1.1.0'
+    def composeBom = platform("androidx.compose:compose-bom:$compose_bom_version")
+    api composeBom
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    api "androidx.compose.runtime:runtime:$compose_version"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    api "androidx.compose.runtime:runtime"
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
@@ -78,8 +80,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'
 
+    testImplementation composeBom
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    testImplementation "androidx.compose.ui:ui-test-junit4"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
 
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     testImplementation "androidx.compose.ui:ui-test-junit4"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
 
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    debugImplementation "androidx.compose.ui:ui-tooling"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -76,8 +76,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
 
-    // 1.3.3 is the version included in the currently used Compose BoM (https://mvnrepository.com/artifact/androidx.compose/compose-bom/2023.01.00)
-    implementation "androidx.compose.ui:ui-tooling-preview:1.3.3"
+    implementation "androidx.compose.ui:ui-tooling-preview:$ui_tooling_preview_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -69,13 +69,15 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.material:material"
-    implementation "androidx.compose.ui:ui-tooling-preview"
     api "androidx.compose.runtime:runtime"
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
+
+    // 1.3.3 is the version included in the currently used Compose BoM (https://mvnrepository.com/artifact/androidx.compose/compose-bom/2023.01.00)
+    implementation "androidx.compose.ui:ui-tooling-preview:1.3.3"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'


### PR DESCRIPTION
### :goal_net: What's the goal?
When Compose BoM was included on Mistica (Version 7.3.1). The compilation failed on every project that didn't use Compose and Mistica dependency is added. This is the error:
```
* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all files for configuration ':app:movistarESDebugCompileClasspath'.
   > Could not find androidx.compose.ui:ui-tooling-preview:.
     Required by:
         project :app > com.telefonica:mistica:7.3.1
```

### :construction: How do we do it?

The BoM usage was temporarily reverted in #228, so I reverted the revert

![](https://media.tenor.com/iAg_Uol6bCMAAAAC/snip-snap-the-office.gif)

I haven't find the real reason behind this but setting the explicit version on Mistica for that package does the trick. It allows the version to be included in the `pom.xml` published to Maven. 

On the other hand, we haven't seen the error occur for other packages from the BoM so I hope that this is an error that may be fixed in future.

I added a small comment in `build.gradle` referencing to this same PR to remember ourselves in the future that `ui-tooling-preview` version should be updated when the BoM is updated as well.

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
- Pubished a local snapshot in maven local and tested that all dependencies are successfully resolved
