### PR TITLE
ANDROID-11931 Set default title style per brand

### DIFF
--- a/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Titles.kt
+++ b/catalog-compose/src/main/java/com/telefonica/mistica/compose/catalog/ui/components/Titles.kt
@@ -20,38 +20,63 @@ fun Titles() {
             .verticalScroll(scrollState)
             .padding(16.dp)
     ) {
+        DefaultTitles()
         TitleStyle.values().forEach {
-            Titles(it)
+            TitlesWithStyleOverridden(it)
         }
     }
 }
 
 @Composable
-private fun Titles(
-    style: TitleStyle
+private fun DefaultTitles() {
+    Title(
+        modifier = Modifier.padding(bottom = 8.dp),
+        text = "Short default title",
+    )
+    Title(
+        modifier = Modifier.padding(bottom = 8.dp),
+        text = "Short default title",
+        linkText = "Some link",
+        onLinkClicked = {}
+    )
+    Title(
+        modifier = Modifier.padding(bottom = 8.dp),
+        text = "Some default title that can get really long and almost fill the whole line",
+    )
+    Title(
+        modifier = Modifier.padding(bottom = 8.dp),
+        text = "Some default title that can get really long and almost fill the whole line",
+        linkText = "Some link",
+        onLinkClicked = {}
+    )
+}
+
+@Composable
+private fun TitlesWithStyleOverridden(
+    style: TitleStyle,
 ) {
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
         style = style,
-        text = "Short title",
+        text = "Short title $style",
     )
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
         style = style,
-        text = "Short title",
+        text = "Short title $style",
         linkText = "Some link",
         onLinkClicked = {}
     )
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
         style = style,
-        text = "Some title that can get really long and almost fill the whole line",
+        text = "Some title $style that can get really long and almost fill the whole line",
     )
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
         style = style,
         linkText = "Some link",
-        text = "Some title that can get really long and almost fill the whole line",
+        text = "Some title $style that can get really long and almost fill the whole line",
         onLinkClicked = {}
     )
 }

--- a/catalog/src/main/res/layout/title_catalog.xml
+++ b/catalog/src/main/res/layout/title_catalog.xml
@@ -18,15 +18,14 @@
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
-				app:title="Short Title 1" />
-
+				app:title="Short default Title" />
 
 		<com.telefonica.mistica.title.TitleView
 				android:id="@+id/long_title"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
-				app:title="Some title 1 that can get really long and almost fill the whole line" />
+				app:title="Some default title that can get really long and almost fill the whole line" />
 
 		<com.telefonica.mistica.title.TitleView
 				android:id="@+id/short_title_with_link"
@@ -34,7 +33,7 @@
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
 				app:link="Some.link"
-				app:title="Short Title 1" />
+				app:title="Short default Title" />
 
 		<com.telefonica.mistica.title.TitleView
 				android:id="@+id/long_title_with_link"
@@ -42,6 +41,36 @@
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
 				app:link="Some link"
+				app:title="Some default title that can get really long and almost fill the whole line" />
+
+		<com.telefonica.mistica.title.TitleView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="8dp"
+				app:titleStyle="title1"
+				app:title="Some title 1" />
+
+		<com.telefonica.mistica.title.TitleView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="8dp"
+				app:link="Some link"
+				app:titleStyle="title1"
+				app:title="Some title 1" />
+
+		<com.telefonica.mistica.title.TitleView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="8dp"
+				app:titleStyle="title1"
+				app:title="Some title 1 that can get really long and almost fill the whole line" />
+
+		<com.telefonica.mistica.title.TitleView
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="8dp"
+				app:link="Some link"
+				app:titleStyle="title1"
 				app:title="Some title 1 that can get really long and almost fill the whole line" />
 
 		<com.telefonica.mistica.title.TitleView

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
@@ -19,6 +19,8 @@ import com.telefonica.mistica.compose.theme.color.LocalMisticaColors
 import com.telefonica.mistica.compose.theme.color.MisticaColors
 import com.telefonica.mistica.compose.theme.text.LocalMisticaTypography
 import com.telefonica.mistica.compose.theme.text.MisticaTypography
+import com.telefonica.mistica.compose.theme.values.LocalMisticaValues
+import com.telefonica.mistica.compose.theme.values.MisticaValues
 
 @Composable
 fun MisticaTheme(
@@ -55,9 +57,18 @@ fun MisticaTheme(
         )
     }
 
+    val values = remember {
+        MisticaValues()
+    }.apply {
+        updateWith(
+            titleStyle = brand.titleStyle
+        )
+    }
+
     CompositionLocalProvider(
         LocalMisticaColors provides rememberedColors,
         LocalMisticaTypography provides typography,
+        LocalMisticaValues provides values
     ) {
         MaterialTheme(
             colors = if (darkTheme) {
@@ -72,7 +83,7 @@ fun MisticaTheme(
                 background = LocalMisticaColors.current.background,
                 error = LocalMisticaColors.current.error,
 
-            ),
+                ),
             typography = Typography(
                 body1 = LocalMisticaTypography.current.preset3
             ),
@@ -98,4 +109,9 @@ object MisticaTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalMisticaTypography.current
+
+    val values: MisticaValues
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalMisticaValues.current
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.compose.theme.brand
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import com.telefonica.mistica.compose.theme.color.MisticaColors
+import com.telefonica.mistica.compose.title.TitleStyle
 
 interface Brand {
     val compatibilityTheme: Int
@@ -18,4 +19,6 @@ interface Brand {
         get() = FontWeight.Light
     val preset8FontWeight: FontWeight
         get() = FontWeight.Light
+    val titleStyle: TitleStyle
+        get() = TitleStyle.TITLE_1
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.theme.color.MisticaColors
+import com.telefonica.mistica.compose.title.TitleStyle
 
 object MovistarBrand : Brand {
 
@@ -190,6 +191,9 @@ object MovistarBrand : Brand {
 
     override val preset8FontWeight: FontWeight
         get() = FontWeight.Bold
+
+    override val titleStyle: TitleStyle
+        get() = TitleStyle.TITLE_2
 }
 
 private object MovistarPaletteColor {

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/values/MisticaValues.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/values/MisticaValues.kt
@@ -1,0 +1,22 @@
+package com.telefonica.mistica.compose.theme.values
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.structuralEqualityPolicy
+import com.telefonica.mistica.compose.title.TitleStyle
+
+class MisticaValues {
+
+    var titleStyle by mutableStateOf(TitleStyle.TITLE_1, structuralEqualityPolicy())
+        private set
+
+    fun updateWith(
+        titleStyle: TitleStyle,
+    ) {
+        this.titleStyle = titleStyle
+    }
+}
+
+internal val LocalMisticaValues = staticCompositionLocalOf { MisticaValues() }

--- a/library/src/main/java/com/telefonica/mistica/compose/title/Title.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/title/Title.kt
@@ -14,10 +14,10 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 @Composable
 fun Title(
     modifier: Modifier = Modifier,
-    style: TitleStyle,
+    style: TitleStyle = MisticaTheme.values.titleStyle,
     text: String,
     linkText: String? = null,
-    onLinkClicked: (() -> Unit)? = null
+    onLinkClicked: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier,
@@ -77,7 +77,7 @@ private fun TitleText(
 private fun Link(
     modifier: Modifier,
     text: String,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
 ) {
     val linkModifier = if (onClick != null) {
         modifier.then(Modifier.clickable { onClick() })

--- a/library/src/main/res/values/themes_blau.xml
+++ b/library/src/main/res/values/themes_blau.xml
@@ -142,5 +142,8 @@
 
 		<!-- Compose -->
 		<item name="composeBrand">blau</item>
+
+		<!-- Title -->
+		<item name="titleStyle">title1</item>
 	</style>
 </resources>

--- a/library/src/main/res/values/themes_movistar.xml
+++ b/library/src/main/res/values/themes_movistar.xml
@@ -154,6 +154,9 @@
 
 		<!-- Compose -->
 		<item name="composeBrand">movistar</item>
+
+		<!-- Title -->
+		<item name="titleStyle">title2</item>
 	</style>
 
 </resources>

--- a/library/src/main/res/values/themes_o2.xml
+++ b/library/src/main/res/values/themes_o2.xml
@@ -143,6 +143,9 @@
 
         <!-- Compose -->
         <item name="composeBrand">o2</item>
+
+        <!-- Title -->
+        <item name="titleStyle">title1</item>
     </style>
 
 </resources>

--- a/library/src/main/res/values/themes_telefonica.xml
+++ b/library/src/main/res/values/themes_telefonica.xml
@@ -143,6 +143,9 @@
 
         <!-- Compose -->
         <item name="composeBrand">telefonica</item>
+
+        <!-- Title -->
+        <item name="titleStyle">title1</item>
     </style>
 
 </resources>

--- a/library/src/main/res/values/themes_vivo.xml
+++ b/library/src/main/res/values/themes_vivo.xml
@@ -143,6 +143,9 @@
 
         <!-- Compose -->
         <item name="composeBrand">vivo</item>
+
+        <!-- Title -->
+        <item name="titleStyle">title1</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Set default title style per brand. It has to be `title2` in Movistar and `title1` in the rest of the brands.

### ☑️ Checks
- [x] I updated the documentation (readmes, wikis, etc). If no need to update documentation explain why.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [ ] 🖼️ Screenshots/Videos
- [ ] Reviewed by Mistica design team
