### PR TITLE
Migrate HighLighted Cards to Compose ANDROID-11507

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Just set your App or any specific activity to use any of the following:
 * [Tabs](library/src/main/java/com/telefonica/mistica/tabs)
 * [Tags](library/src/main/java/com/telefonica/mistica/tag)
 * [Title](library/src/main/java/com/telefonica/mistica/title)
+* [HighLightedCard (Compose version)](library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard)
 
 ## Text Presets Styles
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         androidx_activity_compose_version = "1.6.0"
         accompanist_version = "0.28.0"
         coil_version = '2.2.2'
+        constraintComposeVersion = '1.0.1'
     }
     repositories {
         google()

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
-
+    implementation "androidx.constraintlayout:constraintlayout-compose:$constraintComposeVersion"
     implementation "androidx.compose.ui:ui-tooling-preview:$ui_tooling_preview_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -3,8 +3,6 @@ package com.telefonica.mistica.compose.card.highlightedcard
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,15 +19,12 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
-import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.button.Button
 import com.telefonica.mistica.compose.button.ButtonStyle
 import com.telefonica.mistica.compose.theme.MisticaTheme
-import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
 enum class HighLightCardImageConfig {
     FIT,
@@ -276,213 +271,3 @@ private fun HighLightCardButton(
         )
     }
 }
-
-//region Previews
-
-@Preview(name = "Only Title and text")
-@Composable
-fun PreviewHighLightedCardOnlyTitleAndText(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue"
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button")
-@Composable
-fun PreviewHighLightedCardTitleTextAndCloseButton(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Primary")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
-            )
-        }
-    }
-}
-
-@Preview(name = "[Inverse] Only Title,Text, Close Button, Action Button Primary")
-@Composable
-fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                inverseDisplay = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Secondary")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
-            )
-        }
-    }
-}
-
-@Preview(name = "Inverse Only Title,Text, Close Button, Action Button Secondary")
-@Composable
-fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                inverseDisplay = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Link")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonAndButtonLink(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Link")
-@Composable
-fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonLink(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                inverseDisplay = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fit")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFit(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY),
-                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FIT)
-            )
-        }
-    }
-}
-
-@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFill(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
-                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FILL)
-            )
-        }
-    }
-}
-@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill, Background")
-@Composable
-fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFillBackground(){
-    MisticaTheme(brand = MovistarBrand) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)) {
-            HighLightedCard(
-                modifier = Modifier.fillMaxWidth(),
-                title = "Solve Technical issue",
-                message = "use our tools to solve technical issue",
-                showCloseButton = true,
-                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
-                image = HighLightCardImageSettings(
-                    drawableResource = R.drawable.icn_creditcard,
-                    config = HighLightCardImageConfig.FILL
-                ),
-                customBackground = HighLightCardCustomBackgroundSettings(
-                    drawableResource = R.drawable.icn_visibility
-                )
-            )
-        }
-    }
-}
-
-//endregion

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -155,7 +155,7 @@ fun HighLightedCard(
                             end.linkTo(parent.end, 8.dp)
                         },
                     backgroundColor = if(customBackground.withCustomBackground || inverseDisplay)
-                            MisticaTheme.colors.closeButtonOverlay
+                            MisticaTheme.colors.closeButtonOverlay.copy(alpha = 0.7f)
                         else
                             Color.Transparent,
                     elevation = FloatingActionButtonDefaults.elevation(0.dp),

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -143,7 +143,7 @@ fun HighLightedCard(
                     MisticaTheme.colors.textSecondaryInverse
                 else
                     MisticaTheme.colors.textSecondary,
-                text = title
+                text = message
             )
 
             if (showCloseButton){

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -26,53 +26,6 @@ import com.telefonica.mistica.compose.button.Button
 import com.telefonica.mistica.compose.button.ButtonStyle
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
-enum class HighLightCardImageConfig {
-    FIT,
-    FILL,
-    NONE,
-}
-
-data class HighLightCardButtonSettings(
-    val buttonText: String = "",
-    val buttonStyle: ButtonStyle? = null
-){
-    fun getButtonStyle(inverse: Boolean): ButtonStyle? {
-        return buttonStyle?.let { style ->
-            return if (!inverse) {
-                style
-            } else {
-                when (style){
-                    ButtonStyle.PRIMARY -> ButtonStyle.PRIMARY_INVERSE
-                    ButtonStyle.PRIMARY_SMALL -> ButtonStyle.PRIMARY_SMALL_INVERSE
-                    ButtonStyle.SECONDARY -> ButtonStyle.SECONDARY_INVERSE
-                    ButtonStyle.SECONDARY_SMALL -> ButtonStyle.SECONDARY_SMALL_INVERSE
-                    ButtonStyle.LINK -> ButtonStyle.LINK_INVERSE
-                    else -> style
-                }
-            }
-        }
-    }
-}
-
-data class HighLightCardImageSettings(
-    val imageVector: ImageVector? = null,
-    val bitmap: ImageBitmap? = null,
-    @DrawableRes val drawableResource: Int? = null,
-    val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
-){
-    val withImage: Boolean
-        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
-}
-
-data class HighLightCardCustomBackgroundSettings(
-    val imageVector: ImageVector? = null,
-    val bitmap: ImageBitmap? = null,
-    @DrawableRes val drawableResource: Int? = null,
-){
-    val withCustomBackground: Boolean
-        get() = this.imageVector != null || this.bitmap != null || this.drawableResource != null
-}
-
 @Composable
 fun HighLightedCard(
     modifier: Modifier = Modifier,
@@ -271,3 +224,51 @@ private fun HighLightCardButton(
         )
     }
 }
+
+enum class HighLightCardImageConfig {
+    FIT,
+    FILL,
+    NONE,
+}
+
+data class HighLightCardButtonSettings(
+    val buttonText: String = "",
+    val buttonStyle: ButtonStyle? = null
+){
+    fun getButtonStyle(inverse: Boolean): ButtonStyle? {
+        return buttonStyle?.let { style ->
+            return if (!inverse) {
+                style
+            } else {
+                when (style){
+                    ButtonStyle.PRIMARY -> ButtonStyle.PRIMARY_INVERSE
+                    ButtonStyle.PRIMARY_SMALL -> ButtonStyle.PRIMARY_SMALL_INVERSE
+                    ButtonStyle.SECONDARY -> ButtonStyle.SECONDARY_INVERSE
+                    ButtonStyle.SECONDARY_SMALL -> ButtonStyle.SECONDARY_SMALL_INVERSE
+                    ButtonStyle.LINK -> ButtonStyle.LINK_INVERSE
+                    else -> style
+                }
+            }
+        }
+    }
+}
+
+data class HighLightCardImageSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+    val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
+){
+    val withImage: Boolean
+        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
+}
+
+data class HighLightCardCustomBackgroundSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+){
+    val withCustomBackground: Boolean
+        get() = this.imageVector != null || this.bitmap != null || this.drawableResource != null
+}
+

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -256,8 +256,6 @@ sealed class HighLightedCardImage{
     object None: HighLightedCardImage()
     data class CardBitmap(val bitmap: ImageBitmap): HighLightedCardImage()
     data class CardImageVector(val imageVector: ImageVector): HighLightedCardImage()
-
-
     data class CardResource(@DrawableRes val resourceId: Int): HighLightedCardImage()
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -184,24 +184,23 @@ private fun HighLightCardBackground(modifier: Modifier, backgroundSettings: High
 @Composable
 private fun HighLightCardImage(modifier: Modifier, imageSettings: HighLightCardImageSettings){
     if (imageSettings.withImage){
-        if (imageSettings.imageVector != null){
-            Image(
+        when (imageSettings.picture){
+            is HighLightedCardImage.CardImageVector -> Image(
                 modifier = modifier,
-                imageVector = imageSettings.imageVector,
+                imageVector = imageSettings.picture.imageVector,
                 contentDescription = null
             )
-        } else if(imageSettings.bitmap != null){
-            Image(
+            is HighLightedCardImage.CardBitmap -> Image(
                 modifier = modifier,
-                bitmap = imageSettings.bitmap,
+                bitmap = imageSettings.picture.bitmap,
                 contentDescription = null
             )
-        }else if (imageSettings.drawableResource != null){
-            Image(
+            is HighLightedCardImage.CardResource -> Image(
                 modifier = modifier,
-                painter = painterResource(id = imageSettings.drawableResource),
+                painter = painterResource(id = imageSettings.picture.resourceId),
                 contentDescription = null
             )
+            else -> {}
         }
     }
 }
@@ -253,14 +252,21 @@ data class HighLightCardButtonSettings(
     }
 }
 
+sealed class HighLightedCardImage{
+    object None: HighLightedCardImage()
+    data class CardBitmap(val bitmap: ImageBitmap): HighLightedCardImage()
+    data class CardImageVector(val imageVector: ImageVector): HighLightedCardImage()
+
+
+    data class CardResource(@DrawableRes val resourceId: Int): HighLightedCardImage()
+}
+
 data class HighLightCardImageSettings(
-    val imageVector: ImageVector? = null,
-    val bitmap: ImageBitmap? = null,
-    @DrawableRes val drawableResource: Int? = null,
+    val picture: HighLightedCardImage = HighLightedCardImage.None,
     val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
 ){
     val withImage: Boolean
-        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
+        get() = this.config != HighLightCardImageConfig.NONE
 }
 
 data class HighLightCardCustomBackgroundSettings(

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -77,7 +77,7 @@ data class HighLightCardCustomBackgroundSettings(
 fun HighLightedCard(
     modifier: Modifier = Modifier,
     title: String = "",
-    message: String = "",
+    content: String = "",
     button: HighLightCardButtonSettings = HighLightCardButtonSettings(),
     image: HighLightCardImageSettings = HighLightCardImageSettings(),
     customBackground: HighLightCardCustomBackgroundSettings = HighLightCardCustomBackgroundSettings(),
@@ -143,7 +143,7 @@ fun HighLightedCard(
                     MisticaTheme.colors.textSecondaryInverse
                 else
                     MisticaTheme.colors.textSecondary,
-                text = message
+                text = content
             )
 
             if (showCloseButton){

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -1,0 +1,488 @@
+package com.telefonica.mistica.compose.card.highlightedcard
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.FloatingActionButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.telefonica.mistica.R
+import com.telefonica.mistica.compose.button.Button
+import com.telefonica.mistica.compose.button.ButtonStyle
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+
+enum class HighLightCardImageConfig {
+    FIT,
+    FILL,
+    NONE,
+}
+
+data class HighLightCardButtonSettings(
+    val buttonText: String = "",
+    val buttonStyle: ButtonStyle? = null
+){
+    fun getButtonStyle(inverse: Boolean): ButtonStyle? {
+        return buttonStyle?.let { style ->
+            return if (!inverse) {
+                style
+            } else {
+                when (style){
+                    ButtonStyle.PRIMARY -> ButtonStyle.PRIMARY_INVERSE
+                    ButtonStyle.PRIMARY_SMALL -> ButtonStyle.PRIMARY_SMALL_INVERSE
+                    ButtonStyle.SECONDARY -> ButtonStyle.SECONDARY_INVERSE
+                    ButtonStyle.SECONDARY_SMALL -> ButtonStyle.SECONDARY_SMALL_INVERSE
+                    ButtonStyle.LINK -> ButtonStyle.LINK_INVERSE
+                    else -> style
+                }
+            }
+        }
+    }
+}
+
+data class HighLightCardImageSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+    val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
+){
+    val withImage: Boolean
+        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
+}
+
+data class HighLightCardCustomBackgroundSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+){
+    val withCustomBackground: Boolean
+        get() = this.imageVector != null || this.bitmap != null || this.drawableResource != null
+}
+
+@Composable
+fun HighLightedCard(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    message: String = "",
+    button: HighLightCardButtonSettings = HighLightCardButtonSettings(),
+    image: HighLightCardImageSettings = HighLightCardImageSettings(),
+    customBackground: HighLightCardCustomBackgroundSettings = HighLightCardCustomBackgroundSettings(),
+    showCloseButton: Boolean = false,
+    inverseDisplay: Boolean = false,
+    onCloseButton: () -> Unit = {},
+    onButtonClick: () -> Unit = {}
+){
+    androidx.compose.material.Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        elevation = 0.dp,
+        backgroundColor = if (inverseDisplay)
+            MisticaTheme.colors.buttonPrimaryBackground
+        else
+            MisticaTheme.colors.buttonPrimaryBackgroundInverse,
+        border = BorderStroke(width = 1.dp, color = MisticaTheme.colors.border)
+    ) {
+        ConstraintLayout(
+            modifier = modifier.padding(bottom = if(button.buttonStyle != null) 0.dp else 16.dp)
+        ) {
+            val (
+                titleComposable,
+                messageComposable,
+                closeButtonComposable,
+                actionButtonComposable,
+                pictureComposable,
+                backgroundComposable,
+            ) = createRefs()
+
+            HighLightCardBackground(
+                modifier = modifier.constrainAs(backgroundComposable){
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                },
+                backgroundSettings = customBackground
+            )
+
+            Text(
+                modifier = Modifier.constrainAs(titleComposable){
+                    top.linkTo(parent.top, 16.dp)
+                    start.linkTo(parent.start, 16.dp)
+                },
+                style = MisticaTheme.typography.preset4Light,
+                color = if(inverseDisplay)
+                    MisticaTheme.colors.textPrimaryInverse
+                else
+                    MisticaTheme.colors.textPrimary,
+                text = title
+            )
+
+            Text(
+                modifier = Modifier.constrainAs(messageComposable){
+                    top.linkTo(titleComposable.bottom)
+                    start.linkTo(titleComposable.start)
+                },
+                style = MisticaTheme.typography.preset2,
+                color = if(inverseDisplay)
+                    MisticaTheme.colors.textSecondaryInverse
+                else
+                    MisticaTheme.colors.textSecondary,
+                text = title
+            )
+
+            if (showCloseButton){
+                FloatingActionButton(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .constrainAs(closeButtonComposable) {
+                            top.linkTo(parent.top, 8.dp)
+                            end.linkTo(parent.end, 8.dp)
+                        },
+                    backgroundColor = if(customBackground.withCustomBackground || inverseDisplay)
+                            MisticaTheme.colors.closeButtonOverlay
+                        else
+                            Color.Transparent,
+                    elevation = FloatingActionButtonDefaults.elevation(0.dp),
+                    onClick = onCloseButton
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                        tint = MisticaTheme.colors.neutralHigh
+                    )
+                }
+            }
+
+            HighLightCardButton(
+                modifier = Modifier
+                    .constrainAs(actionButtonComposable) {
+                        top.linkTo(messageComposable.bottom, 16.dp)
+                        start.linkTo(titleComposable.start)
+                        bottom.linkTo(parent.bottom)
+                    }
+                    .padding(bottom = 16.dp),
+                inverseDisplay = inverseDisplay,
+                buttonConfig = button,
+                onButtonClick = onButtonClick
+            )
+
+            HighLightCardImage(
+                modifier = Modifier.constrainAs(pictureComposable){
+                    top.linkTo(
+                        if (image.config == HighLightCardImageConfig.FIT && showCloseButton)
+                            closeButtonComposable.bottom
+                        else
+                            parent.top
+                    )
+                    bottom.linkTo(parent.bottom)
+                    end.linkTo(parent.end)
+                    height = Dimension.fillToConstraints
+                },
+                imageSettings = image
+            )
+        }
+    }
+}
+
+@Composable
+private fun HighLightCardBackground(modifier: Modifier, backgroundSettings: HighLightCardCustomBackgroundSettings){
+    if (backgroundSettings.withCustomBackground){
+        if (backgroundSettings.imageVector != null){
+            Image(
+                modifier = modifier,
+                contentScale = ContentScale.FillBounds,
+                imageVector = backgroundSettings.imageVector,
+                contentDescription = null
+            )
+        } else if(backgroundSettings.bitmap != null){
+            Image(
+                modifier = modifier,
+                contentScale = ContentScale.FillBounds,
+                bitmap = backgroundSettings.bitmap,
+                contentDescription = null
+            )
+        }else if (backgroundSettings.drawableResource != null){
+            Image(
+                modifier = modifier,
+                contentScale = ContentScale.FillBounds,
+                painter = painterResource(id = backgroundSettings.drawableResource),
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun HighLightCardImage(modifier: Modifier, imageSettings: HighLightCardImageSettings){
+    if (imageSettings.withImage){
+        if (imageSettings.imageVector != null){
+            Image(
+                modifier = modifier,
+                imageVector = imageSettings.imageVector,
+                contentDescription = null
+            )
+        } else if(imageSettings.bitmap != null){
+            Image(
+                modifier = modifier,
+                bitmap = imageSettings.bitmap,
+                contentDescription = null
+            )
+        }else if (imageSettings.drawableResource != null){
+            Image(
+                modifier = modifier,
+                painter = painterResource(id = imageSettings.drawableResource),
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun HighLightCardButton(
+    modifier: Modifier,
+    inverseDisplay: Boolean,
+    buttonConfig: HighLightCardButtonSettings,
+    onButtonClick: () -> Unit = {}
+){
+    val buttonStyle = buttonConfig.getButtonStyle(inverseDisplay)
+
+    if (buttonStyle != null){
+        Button(
+            modifier = modifier,
+            text = buttonConfig.buttonText,
+            buttonStyle = buttonStyle,
+            onClickListener = onButtonClick
+        )
+    }
+}
+
+//region Previews
+
+@Preview(name = "Only Title and text")
+@Composable
+fun PreviewHighLightedCardOnlyTitleAndText(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue"
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button")
+@Composable
+fun PreviewHighLightedCardTitleTextAndCloseButton(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Primary")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "[Inverse] Only Title,Text, Close Button, Action Button Primary")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Secondary")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Inverse Only Title,Text, Close Button, Action Button Secondary")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonLink(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonLink(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fit")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFit(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY),
+                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FIT)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFill(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
+                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FILL)
+            )
+        }
+    }
+}
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill, Background")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFillBackground(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
+                image = HighLightCardImageSettings(
+                    drawableResource = R.drawable.icn_creditcard,
+                    config = HighLightCardImageConfig.FILL
+                ),
+                customBackground = HighLightCardCustomBackgroundSettings(
+                    drawableResource = R.drawable.icn_visibility
+                )
+            )
+        }
+    }
+}
+
+//endregion

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
@@ -54,7 +54,7 @@ data class HighLightCardCustomBackgroundSettings(
 
 ```
 
-Its use is very simple, below is a series of composables (Preview) in which we can see each of its uses (the most common)
+Use HighlightedCard composable. There are some examples below
 
 ```kotlin
 @Preview(name = "Only Title and text")

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
@@ -1,0 +1,266 @@
+# HighLightedCard (Compose version)
+
+This composable is the migration of the component based on classic views highLightedCard, presenting the same functionality and styles (based on Mistica).
+
+In addition, several classes and enums are added that will be useful when configuring different aspects of the UI (image position, backgrounds, etc. Its definition (its use can be seen in the example code of use)
+
+```kotlin
+enum class HighLightCardImageConfig {
+    FIT,
+    FILL,
+    NONE,
+}
+
+data class HighLightCardButtonSettings(
+    val buttonText: String = "",
+    val buttonStyle: ButtonStyle? = null
+){
+    fun getButtonStyle(inverse: Boolean): ButtonStyle? {
+        return buttonStyle?.let { style ->
+            return if (!inverse) {
+                style
+            } else {
+                when (style){
+                    ButtonStyle.PRIMARY -> ButtonStyle.PRIMARY_INVERSE
+                    ButtonStyle.PRIMARY_SMALL -> ButtonStyle.PRIMARY_SMALL_INVERSE
+                    ButtonStyle.SECONDARY -> ButtonStyle.SECONDARY_INVERSE
+                    ButtonStyle.SECONDARY_SMALL -> ButtonStyle.SECONDARY_SMALL_INVERSE
+                    ButtonStyle.LINK -> ButtonStyle.LINK_INVERSE
+                    else -> style
+                }
+            }
+        }
+    }
+}
+
+data class HighLightCardImageSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+    val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
+){
+    val withImage: Boolean
+        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
+}
+
+data class HighLightCardCustomBackgroundSettings(
+    val imageVector: ImageVector? = null,
+    val bitmap: ImageBitmap? = null,
+    @DrawableRes val drawableResource: Int? = null,
+){
+    val withCustomBackground: Boolean
+        get() = this.imageVector != null || this.bitmap != null || this.drawableResource != null
+}
+
+```
+
+Its use is very simple, below is a series of composables (Preview) in which we can see each of its uses (the most common)
+
+```kotlin
+@Preview(name = "Only Title and text")
+@Composable
+fun PreviewHighLightedCardOnlyTitleAndText(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue"
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button")
+@Composable
+fun PreviewHighLightedCardTitleTextAndCloseButton(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Primary")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "[Inverse] Only Title,Text, Close Button, Action Button Primary")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonPrimary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.PRIMARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Secondary")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Inverse Only Title,Text, Close Button, Action Button Secondary")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonSecondary(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonAndButtonLink(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link")
+@Composable
+fun PreviewInverseHighLightedCardTitleTextCloseButtonAndButtonLink(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                inverseDisplay = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fit")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFit(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY),
+                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FIT)
+            )
+        }
+    }
+}
+
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFill(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
+                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FILL)
+            )
+        }
+    }
+}
+@Preview(name = "Only Title,Text, Close Button, Action Button Link, Image Fill, Background")
+@Composable
+fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFillBackground(){
+    MisticaTheme(brand = MovistarBrand) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)) {
+            HighLightedCard(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Solve Technical issue",
+                message = "use our tools to solve technical issue",
+                showCloseButton = true,
+                button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
+                image = HighLightCardImageSettings(
+                    drawableResource = R.drawable.icn_creditcard,
+                    config = HighLightCardImageConfig.FILL
+                ),
+                customBackground = HighLightCardCustomBackgroundSettings(
+                    drawableResource = R.drawable.icn_visibility
+                )
+            )
+        }
+    }
+}
+
+```

--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/README.md
@@ -33,14 +33,19 @@ data class HighLightCardButtonSettings(
     }
 }
 
+sealed class HighLightedCardImage{
+    object None: HighLightedCardImage()
+    data class CardBitmap(val bitmap: ImageBitmap): HighLightedCardImage()
+    data class CardImageVector(val imageVector: ImageVector): HighLightedCardImage()
+    data class CardResource(@DrawableRes val resourceId: Int): HighLightedCardImage()
+}
+
 data class HighLightCardImageSettings(
-    val imageVector: ImageVector? = null,
-    val bitmap: ImageBitmap? = null,
-    @DrawableRes val drawableResource: Int? = null,
+    val picture: HighLightedCardImage = HighLightedCardImage.None,
     val config: HighLightCardImageConfig = HighLightCardImageConfig.NONE,
 ){
     val withImage: Boolean
-        get() = this.config != HighLightCardImageConfig.NONE && (this.imageVector != null || this.bitmap != null || this.drawableResource != null)
+        get() = this.config != HighLightCardImageConfig.NONE
 }
 
 data class HighLightCardCustomBackgroundSettings(
@@ -214,7 +219,7 @@ fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFit(){
                 message = "use our tools to solve technical issue",
                 showCloseButton = true,
                 button = HighLightCardButtonSettings("Start tests", ButtonStyle.SECONDARY),
-                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FIT)
+                image = HighLightCardImageSettings(HighLightedCardImage.CardResource(R.drawable.icn_creditcard), config = HighLightCardImageConfig.FIT)
             )
         }
     }
@@ -233,7 +238,7 @@ fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFill(){
                 message = "use our tools to solve technical issue",
                 showCloseButton = true,
                 button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
-                image = HighLightCardImageSettings(drawableResource = R.drawable.icn_creditcard, config = HighLightCardImageConfig.FILL)
+                image = HighLightCardImageSettings(HighLightedCardImage.CardResource(R.drawable.icn_creditcard), config = HighLightCardImageConfig.FILL)
             )
         }
     }
@@ -252,7 +257,7 @@ fun PreviewHighLightedCardTitleTextCloseButtonButtonLinkAndImageFillBackground()
                 showCloseButton = true,
                 button = HighLightCardButtonSettings("Start tests", ButtonStyle.LINK),
                 image = HighLightCardImageSettings(
-                    drawableResource = R.drawable.icn_creditcard,
+                    HighLightedCardImage.CardResource(R.drawable.icn_creditcard),
                     config = HighLightCardImageConfig.FILL
                 ),
                 customBackground = HighLightCardCustomBackgroundSettings(

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
@@ -104,6 +104,7 @@ object BlauBrand : Brand {
         warningHigh = BlauPaletteColor.blau_color_yellow_70,
         warningHighInverse = BlauPaletteColor.blau_color_yellow_70,
         warning = BlauPaletteColor.blau_color_yellow,
+        closeButtonOverlayColor = BlauPaletteColor.blau_color_blue_primary30
     )
 
     override val darkColors = lightColors.copy(
@@ -174,6 +175,7 @@ object BlauBrand : Brand {
         successHighInverse = BlauPaletteColor.blau_color_green_70,
         warningHigh = BlauPaletteColor.blau_color_yellow_40,
         warningHighInverse = BlauPaletteColor.blau_color_yellow_70,
+        closeButtonOverlay = BlauPaletteColor.blau_color_blue_primary30
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -106,6 +106,7 @@ object MovistarBrand : Brand {
         warningHigh = MovistarPaletteColor.movistar_color_egg_80,
         warningHighInverse = MovistarPaletteColor.movistar_color_egg_80,
         warning = MovistarPaletteColor.movistar_color_egg,
+        closeButtonOverlayColor = MovistarPaletteColor.movistar_color_blue_30
     )
 
     override val darkColors =
@@ -178,6 +179,7 @@ object MovistarBrand : Brand {
             successHighInverse = MovistarPaletteColor.movistar_color_green_70,
             warningHigh = MovistarPaletteColor.movistar_color_egg_40,
             warningHighInverse = MovistarPaletteColor.movistar_color_egg_80,
+            closeButtonOverlay = MovistarPaletteColor.movistar_color_blue_30
         )
 
     override val preset5FontWeight: FontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
@@ -104,6 +104,7 @@ object O2Brand : Brand {
         warningHigh = O2PaletteColor.o2_color_orange_75,
         warningHighInverse = O2PaletteColor.o2_color_orange_75,
         warning = O2PaletteColor.o2_color_orange,
+        closeButtonOverlayColor = O2PaletteColor.o2_color_blue_primary_30
     )
 
     override val darkColors = lightColors.copy(
@@ -179,6 +180,7 @@ object O2Brand : Brand {
         successHighInverse = O2PaletteColor.o2_color_green_80,
         warningHigh = O2PaletteColor.o2_color_orange_40,
         warningHighInverse = O2PaletteColor.o2_color_orange_75,
+        closeButtonOverlay = O2PaletteColor.o2_color_blue_primary_30
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
@@ -104,6 +104,7 @@ object TelefonicaBrand : Brand {
         warningHigh = TelefonicaPaletteColor.telefonica_color_ambar_70,
         warningHighInverse = TelefonicaPaletteColor.telefonica_color_ambar_70,
         warning = TelefonicaPaletteColor.telefonica_color_ambar,
+        closeButtonOverlayColor = TelefonicaPaletteColor.telefonica_color_blue_30
     )
 
     override val darkColors = MisticaColors(
@@ -200,6 +201,7 @@ object TelefonicaBrand : Brand {
         warningHigh = TelefonicaPaletteColor.telefonica_color_ambar_40,
         warningHighInverse = TelefonicaPaletteColor.telefonica_color_ambar_70,
         warning = TelefonicaPaletteColor.telefonica_color_ambar,
+        closeButtonOverlayColor = TelefonicaPaletteColor.telefonica_color_blue_30
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
@@ -104,6 +104,7 @@ object VivoBrand : Brand {
         warningHigh = VivoPaletteColor.vivo_color_orange_dark,
         warningHighInverse = VivoPaletteColor.vivo_color_orange_dark,
         warning = VivoPaletteColor.vivo_color_orange,
+        closeButtonOverlayColor = VivoPaletteColor.vivo_color_purple_light20_25_alpha
     )
 
     override val darkColors = lightColors.copy(
@@ -178,6 +179,7 @@ object VivoBrand : Brand {
         successHighInverse = VivoPaletteColor.vivo_color_green_dark,
         warningHigh = VivoPaletteColor.vivo_color_orange_light40,
         warningHighInverse = VivoPaletteColor.vivo_color_orange_dark,
+        closeButtonOverlay = VivoPaletteColor.vivo_color_purple_light20_40_alpha
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/color/MisticaColors.kt
@@ -102,6 +102,7 @@ class MisticaColors(
     warningHigh: Color = Color.Unspecified,
     warningHighInverse: Color = Color.Unspecified,
     warning: Color = Color.Unspecified,
+    closeButtonOverlayColor: Color = Color.Unspecified
 ) {
     var appBarBackground by mutableStateOf(appBarBackground, structuralEqualityPolicy())
         internal set
@@ -292,6 +293,8 @@ class MisticaColors(
     var carouselIndicatorInactiveColor by mutableStateOf(carouselIndicatorInactiveColor, structuralEqualityPolicy())
         internal set
 
+    var closeButtonOverlay by mutableStateOf(closeButtonOverlayColor, structuralEqualityPolicy())
+        internal set
     fun copy(
         appBarBackground: Color = this.appBarBackground,
         background: Color = this.background,
@@ -387,6 +390,7 @@ class MisticaColors(
         warningHigh: Color = this.warningHigh,
         warningHighInverse: Color = this.warningHighInverse,
         warning: Color = this.warning,
+        closeButtonOverlay: Color = this.closeButtonOverlay
     ): MisticaColors = MisticaColors(
         appBarBackground = appBarBackground,
         background = background,
@@ -482,6 +486,7 @@ class MisticaColors(
         warningHigh = warningHigh,
         warningHighInverse = warningHighInverse,
         warning = warning,
+        closeButtonOverlayColor = closeButtonOverlay
     )
 
     internal fun updateColorsFrom(other: MisticaColors) {
@@ -579,6 +584,7 @@ class MisticaColors(
         warningHigh = other.warningHigh
         warningHighInverse = other.warningHighInverse
         warning = other.warning
+        closeButtonOverlay = other.closeButtonOverlay
     }
 }
 


### PR DESCRIPTION
### :tickets: Jira tickets
[Task](https://jira.tid.es/browse/ANDROID-11507)
### :goal_net: What's the goal?
Migrate XML HighLightedCard implementation to Compose

### :construction: How do we do it?
Added new HighLightedCard composable with all settings posibilites made like other compose implementations (settings data classes to minifly the number of parameters.

### ☑️ Checks
- [X] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [X] Tested with API 23.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [X] 🖼️ Screenshots/Videos
![image](https://user-images.githubusercontent.com/125036040/235092382-7712b1c2-4954-4556-a607-86d04c5954eb.png)

- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
