### PR TITLE
ANDROID-11435 Allow custom bottom section in ListRowItem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,20 @@
 name: "Run tests"
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
-    runs-on: self-hosted-novum
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
     
     - name: "Build Android project"
-      uses: docker://docker.tuenti.io/android/novum_android_api31:2
-      with:
-        args: 'bash ./gradlew clean check assemble'
+      run : 'bash ./gradlew clean check assemble'
 
     - name: Upload Lint results
       uses: github/codeql-action/upload-sarif@v2

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -75,7 +75,7 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        bottom =  { CustomFragment() },
+        bottom =  { CustomSlot() },
     ),
 
     ListItem(
@@ -116,7 +116,7 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         icon = { ListIcon() },
-        bottom =  { CustomFragment() },
+        bottom =  { CustomSlot() },
     ),
 
     ListItem(
@@ -157,7 +157,7 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         icon = { ListIcon() },
-        bottom =  { CustomFragment() },
+        bottom =  { CustomSlot() },
     ),
 
     ListItem(
@@ -205,7 +205,7 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         icon = { Avatar() },
-        bottom =  { CustomFragment() },
+        bottom =  { CustomSlot() },
     ),
 )
 

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -1,19 +1,27 @@
 package com.telefonica.mistica.catalog.ui.compose.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.Switch
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -63,6 +71,12 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
     ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        bottom =  { CustomFragment() },
+    ),
 
     ListItem(
         title = TITLE,
@@ -97,6 +111,13 @@ fun samples() = listOf(
         action = { Chevron() },
         icon = { ListIcon() },
     ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        icon = { ListIcon() },
+        bottom =  { CustomFragment() },
+    ),
 
     ListItem(
         title = TITLE,
@@ -130,6 +151,13 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         icon = { ListIcon() },
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        icon = { ListIcon() },
+        bottom =  { CustomFragment() },
     ),
 
     ListItem(
@@ -169,8 +197,17 @@ fun samples() = listOf(
         badge = "1",
         icon = { Avatar() },
     ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        icon = { Avatar() },
+        bottom =  { CustomFragment() },
+    ),
 )
-
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -192,6 +229,7 @@ fun Lists() {
                 description = item.description,
                 trailing = item.action,
                 onClick = item.onClick,
+                bottom = item.bottom,
             )
             Divider(
                 modifier = Modifier.padding(horizontal = 16.dp),
@@ -212,6 +250,7 @@ fun Lists() {
                 description = item.description,
                 trailing = item.action,
                 onClick = item.onClick,
+                bottom = item.bottom,
             )
         }
         items(samples.map {
@@ -231,6 +270,7 @@ fun Lists() {
                 description = item.description,
                 trailing = item.action,
                 onClick = item.onClick,
+                bottom = item.bottom,
             )
         }
     }
@@ -247,6 +287,7 @@ data class ListItem(
     val headline: Tag? = null,
     val action: @Composable (() -> Unit)? = null,
     val onClick: () -> Unit = {},
+    val bottom: @Composable (() -> Unit)? = null,
 )
 
 @Composable
@@ -283,4 +324,28 @@ fun Avatar(url: String) {
         contentDescription = null,
         modifier = Modifier.size(40.dp)
     )
+}
+
+@Composable
+private fun CustomFragment() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = MisticaTheme.colors.border,
+                shape = RoundedCornerShape(MisticaTheme.values.containerBorderRadius)
+            )
+            .background(
+                color = Color.LightGray,
+                shape = RoundedCornerShape(MisticaTheme.values.containerBorderRadius)
+            )
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(vertical = 16.dp, horizontal = 8.dp)
+                .align(Alignment.Center),
+            text = "Custom Fragment"
+        )
+    }
 }

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -327,7 +327,7 @@ fun Avatar(url: String) {
 }
 
 @Composable
-private fun CustomFragment() {
+private fun CustomSlot() {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -345,7 +345,7 @@ private fun CustomFragment() {
             modifier = Modifier
                 .padding(vertical = 16.dp, horizontal = 8.dp)
                 .align(Alignment.Center),
-            text = "Custom Fragment"
+            text = "Custom Slot"
         )
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -220,7 +221,7 @@ fun ListRowItemPreview() {
                 description = "Description",
                 icon = {
                     Icon(
-                        painterResource(id = R.drawable.list_row_background),
+                        painterResource(id = R.drawable.icn_arrow),
                         contentDescription = null
                     )
                 },
@@ -242,6 +243,29 @@ fun ListRowItemPreview() {
                     Checkbox(
                         checked = checkedState.value,
                         onCheckedChange = { checkedState.value = it }
+                    )
+                }
+            )
+            ListRowItem(
+                backgroundType = BackgroundType.TYPE_BOXED,
+                title = "Title",
+                subtitle = "Subtitle",
+                description = "Description",
+                icon = {
+                    Circle {}
+                },
+                trailing = {
+                    Checkbox(
+                        checked = checkedState.value,
+                        onCheckedChange = { checkedState.value = it }
+                    )
+                },
+                bottom = {
+                    Box(
+                        modifier = Modifier
+                            .height(40.dp)
+                            .fillMaxWidth()
+                            .background(Color.Green)
                     )
                 }
             )

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.absolutePadding
@@ -51,6 +53,8 @@ fun ListRowItem(
     headline: Tag? = null,
     trailing: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
+    bottom: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
 ) {
     val badgeVisible by remember { mutableStateOf(isBadgeVisible) }
 
@@ -58,8 +62,7 @@ fun ListRowItem(
         BackgroundType.TYPE_NORMAL -> modifier
         BackgroundType.TYPE_BOXED,
         BackgroundType.TYPE_BOXED_INVERSE,
-        -> modifier
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+        -> modifier.padding(contentPadding)
     }
         .fillMaxWidth()
         .clip(shape = RoundedCornerShape(MisticaTheme.values.containerBorderRadius))
@@ -71,6 +74,10 @@ fun ListRowItem(
             .border(
                 width = 1.dp,
                 color = MisticaTheme.colors.border,
+                shape = RoundedCornerShape(MisticaTheme.values.containerBorderRadius),
+            )
+            .background(
+                color = MisticaTheme.colors.backgroundContainer,
                 shape = RoundedCornerShape(MisticaTheme.values.containerBorderRadius),
             )
         BackgroundType.TYPE_BOXED_INVERSE -> Modifier
@@ -104,7 +111,7 @@ fun ListRowItem(
         modifier = boxModifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM)
     ) {
         Row(
-            modifier = rowModifier
+            modifier = rowModifier.height(IntrinsicSize.Min)
         ) {
             if (icon != null) {
                 icon()
@@ -150,6 +157,10 @@ fun ListRowItem(
                             .padding(vertical = 2.dp)
                             .defaultMinSize(minHeight = 20.dp),
                     )
+                }
+                bottom?.let {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    bottom()
                 }
             }
 


### PR DESCRIPTION
### :goal_net: What's the goal?

Include the custom and optional bottom fragment in the ListRowItem according to the specs

:warning: By now it is only implemented in the Compose version of the component. It will be implemented on demand for the xml version. :warning:

![Captura de Pantalla 2023-05-17 a las 12 50 20](https://github.com/Telefonica/mistica-android/assets/47142570/4508d31b-13bc-4c94-aa76-a6654c255cc2)

### :construction: How do we do it?
Add a new composable called `bottom` as param to the ListRowItem composable.

Other changes in this PR:
- Set `height(IntrinsicSize.Min)` to the whole row so `trailing` content can use `fillMaxHeight`
- Fix background color for boxed rows according to the specs (`backgroundContainer `)

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] Reviewed by Mistica design team
- [x] [Mistica App download link](https://appcenter-filemanagement-distrib5ede6f06e.azureedge.net/9752b206-3ae1-43db-bc0e-10e003abe526/MisticaCatalog-debug-1684319563.apk?sv=2019-02-02&sr=c&sig=jSzQFzC6aNlbCl%2Bhs%2BAe2lQxU51KE0yWWJBwtqL8Gnw%3D&se=2023-05-18T10%3A35%3A09Z&sp=r)
- [x] 🖼️ Screenshots/Videos

![Captura de Pantalla 2023-05-17 a las 12 59 06](https://github.com/Telefonica/mistica-android/assets/47142570/f4bb27eb-0e36-4b84-be0d-cdd26c8b141f)

![Captura de Pantalla 2023-05-17 a las 12 59 22](https://github.com/Telefonica/mistica-android/assets/47142570/adfb1a07-9807-439b-9155-d62f2098aed8)

![Captura de Pantalla 2023-05-17 a las 12 59 34](https://github.com/Telefonica/mistica-android/assets/47142570/4b5f6c64-0f18-4f74-8802-b083eef3433f)

![Captura de Pantalla 2023-05-17 a las 13 01 18](https://github.com/Telefonica/mistica-android/assets/47142570/9fe609f4-baa6-4b32-9f10-8af8d467ad12)

![Captura de Pantalla 2023-05-17 a las 13 01 47](https://github.com/Telefonica/mistica-android/assets/47142570/31914c60-36b3-4ac8-b74d-e6ed85d26beb)

![Captura de Pantalla 2023-05-17 a las 13 02 04](https://github.com/Telefonica/mistica-android/assets/47142570/c5ea6dbf-c59d-48ec-aef9-534c8067e2f4)

![Captura de Pantalla 2023-05-17 a las 13 03 00](https://github.com/Telefonica/mistica-android/assets/47142570/185d8283-7c9c-425b-b0b4-16d3ed20ba90)

