### PR TITLE
Fix generate snapshot workflow and get rid of self hosted runners

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -6,7 +6,7 @@ on:
     types: [closed]
 jobs:
   catalog:
-    runs-on: self-hosted-novum
+    runs-on: ubuntu-latest
     steps:
     - name: Check pull request status
       if: "!github.event.pull_request.merged == true"
@@ -18,8 +18,6 @@ jobs:
 
     - name: Publish catalog
       if: github.event.pull_request.merged == true
-      uses: docker://docker.tuenti.io/android/novum_android_api31:2
       env:
         APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
-      with:
-        args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'
+      run: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -3,17 +3,16 @@ on:
   pull_request:
 jobs:
   debug-catalog:
-    runs-on: self-hosted-novum
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Publish catalog
-        uses: docker://docker.tuenti.io/android/novum_android_api31:2
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
-        with:
-          args: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ github.sha }}"'
+        run: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica-Catalog -Dappcenter_notify=false 
+          -Dappcenter_notes="Testing catalog for PR #${{ github.event.number }} ${{ github.sha }}"'
 
       - name: Get version ID
         id: id-request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
         run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
 
       - name: Release library
-        uses: docker://docker.tuenti.io/android/novum_android_api31:2
         env:
           MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
           MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,13 @@ on:
     types: [published]
 jobs:
   promote:
-    runs-on: self-hosted-novum
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
       - name: Build library
-        uses: docker://docker.tuenti.io/android/novum_android_api31:2
-        with:
-          args: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
+        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
 
       - name: Release library
         uses: docker://docker.tuenti.io/android/novum_android_api31:2
@@ -22,7 +20,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        with:
-          args: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
           :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
           --max-workers 1 closeAndReleaseStagingRepository"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,4 +22,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }} publishNoopPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}"
+        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
+          :catalog:publishCatalogPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
+          --max-workers 1 closeAndReleaseStagingRepository"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,13 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-novum
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
     
     - name: "Build Android project"
+      uses: docker://docker.tuenti.io/android/novum_android_api31:2
       run : 'bash ./gradlew clean check assemble'
 
     - name: Upload Lint results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,15 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-novum
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
     
     - name: "Build Android project"
-      run: 'bash ./gradlew clean check assemble'
+      uses: docker://docker.tuenti.io/android/novum_android_api31:2
+      with:
+        args: 'bash ./gradlew clean check assemble'
 
     - name: Upload Lint results
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
     
     - name: "Build Android project"
       uses: docker://docker.tuenti.io/android/novum_android_api31:2
-      run : 'bash ./gradlew clean check assemble'
+      with:
+        args: 'bash ./gradlew clean check assemble'
 
     - name: Upload Lint results
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,20 @@
 name: "Run tests"
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
-    runs-on: self-hosted-novum
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
     
     - name: "Build Android project"
-      uses: docker://docker.tuenti.io/android/novum_android_api31:2
-      with:
-        args: 'bash ./gradlew clean check assemble'
+      run: 'bash ./gradlew clean check assemble'
 
     - name: Upload Lint results
       uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
### :goal_net: What's the goal?
- Snapshot workflow is not working right now because there is no such task as `publishNoopPublicationToSonatypeRepository`. I'm fixing it.
- I'm also replacing `self-hosted-novum` runner with `ubuntu-latest` in some of the workflows because we actually don't need `novum_android_api31` docker image at all.

### :construction: How do we do it?
- Use the same command as in `release.yml` workflow but with `SNAPSHOT_VERSION` param
- Remove every unneeded usage of `self-hosted-novum` and use `ubuntu-latest` instead
- Remove every unneeded usage of `novum_android_api31` docker image

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- No need to be reviewed by design team
- Checked that `tests.yml` and `debug_catalog.yml` are executed successfully