### PR TITLE
Remove compose bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        // Remember to update "ui_tooling_preview_version" when updating "compose_bom_version"
-        // according to https://mvnrepository.com/artifact/androidx.compose/compose-bom/
-        // For more info see https://github.com/Telefonica/mistica-android/pull/230
-        compose_bom_version = "2023.01.00"
-        ui_tooling_preview_version = "1.3.3"
+        compose_version = '1.3.1'
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.3.3'
+        compose_version = '1.3.1'
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.3.1'
+        compose_version = '1.3.3'
         compose_compiler_version = '1.3.2'
         kotlin_version = "1.7.20"
         androidx_appcompat_version = "1.5.1"

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -41,20 +41,19 @@ task sourceJar(type: Jar) {
 dependencies {
     implementation project(':library')
 
-    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.constraintlayout:constraintlayout-compose:$constraintComposeVersion"
-    implementation "androidx.compose.ui:ui-tooling-preview"
-    implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.2.1"
     implementation "androidx.navigation:navigation-compose:2.5.3"
     implementation "io.coil-kt:coil-compose:$coil_version"
 
     testImplementation 'junit:junit:4.13'
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,30 +63,27 @@ dependencies {
     api 'androidx.constraintlayout:constraintlayout:2.0.4'
     api 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
     api 'androidx.recyclerview:recyclerview:1.1.0'
-    def composeBom = platform("androidx.compose:compose-bom:$compose_bom_version")
-    api composeBom
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.material:material"
-    api "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    api "androidx.compose.runtime:runtime:$compose_version"
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:compose-theme-adapter:1.1.5"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "io.coil-kt:coil-compose:$coil_version"
     implementation "androidx.constraintlayout:constraintlayout-compose:$constraintComposeVersion"
-    implementation "androidx.compose.ui:ui-tooling-preview:$ui_tooling_preview_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.airbnb.android:lottie:3.2.2'
 
-    testImplementation composeBom
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "androidx.compose.ui:ui-test-junit4"
+    testImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
 
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"


### PR DESCRIPTION
### :goal_net: What's the goal?
Remove Compose BoM since it is right now giving us some dependency resolution problems at the time of importing Mistica in other projects (missing dependencies, not found classes after on release builds, etc).

### :construction: How do we do it?
Revert the commit 7c9b20518bae233e766e876ac77a0003cd8ed5cd where it was introduced and solve conflicts since then

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] Reviewed by Mistica design team (there isn't anything to review by them)
