### PR TITLE
ANDROID-13350 Wrong TextInput label position when fixed height

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -4,20 +4,15 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.VisualTransformation
@@ -116,14 +111,11 @@ private fun TextBox(
         value = value,
         onValueChange = onValueChange,
         label = {
-            Box(modifier = Modifier.fillMaxSize()) {
-                TextInputLabel(
-                    text = label,
-                    isMinimized = interactionSource.collectIsFocusedAsState().value,
-                    isError = isError,
-                    modifier = Modifier.align(Alignment.TopStart),
-                )
-            }
+            TextInputLabel(
+                text = label,
+                isMinimized = interactionSource.collectIsFocusedAsState().value,
+                isError = isError,
+            )
         },
         interactionSource = interactionSource,
         keyboardOptions = keyboardOptions,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -15,11 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.telefonica.mistica.compose.common.ui.alpha
 import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.ui.alpha
 import androidx.compose.foundation.text.KeyboardOptions as FoundationKeyboardOptions
 
 @Composable
@@ -100,6 +101,7 @@ private fun TextBox(
 
     TextField(
         modifier = modifier
+            .testTag(TextInputTestTags.TEXT_INPUT)
             .fillMaxWidth()
             .border(
                 width = 1.dp,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
@@ -1,0 +1,5 @@
+package com.telefonica.mistica.compose.input
+
+object TextInputTestTags {
+    const val TEXT_INPUT = "text_input"
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/ui/ModifierExt.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/ui/ModifierExt.kt
@@ -1,4 +1,4 @@
-package com.telefonica.mistica.compose.common.ui
+package com.telefonica.mistica.compose.ui
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha


### PR DESCRIPTION
### :goal_net: What's the goal?
The label of an compose TextInput has a wrong position when the input field has a fixed height 

```kotlin
TextInput(
  modifier = modifier
    .fillMaxWidth()
    .size(84.dp) // <-- Fixed height
  ,
  value = text,
  onValueChange = {
    text = it
  },
  label = "Type Something",
  enabled = enabled,
)
```

The label is placed on the very top of the composable:

![bad_label_input](https://github.com/Telefonica/mistica-android/assets/47142570/ba987d43-ef90-42e0-ae45-27335955ff29)


### :construction: How do we do it?
Remove aparenttly unneeded Box and alignment for given label

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [x] 🖼️ Screenshots/Videos

![Captura de Pantalla 2023-06-02 a las 13 17 21](https://github.com/Telefonica/mistica-android/assets/47142570/6f9fca5b-0cf1-4b9d-9931-5fd1a3134287)

