### PR TITLE
Expose password toggle test tag

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
@@ -1,6 +1,5 @@
 package com.telefonica.mistica.compose.input
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.material.Icon
 import androidx.compose.material.IconToggleButton
 import androidx.compose.runtime.Composable
@@ -16,10 +15,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import com.telefonica.mistica.R
-import java.lang.reflect.Modifier.PRIVATE
-
-@VisibleForTesting(otherwise = PRIVATE)
-internal const val TOGGLE_VISIBILITY_TEST_TAG = "ToggleVisibility"
 
 @Composable
 fun PasswordInput(
@@ -75,7 +70,7 @@ private fun PasswordVisibleIcon(
     IconToggleButton(
         checked = passwordVisible,
         onCheckedChange = onIconClicked,
-        modifier = Modifier.testTag(TOGGLE_VISIBILITY_TEST_TAG),
+        modifier = Modifier.testTag(TextInputTestTags.PASSWORD_VISIBILITY_TOGGLE),
     ) {
         Icon(
             painter = if (passwordVisible) {

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
@@ -2,4 +2,5 @@ package com.telefonica.mistica.compose.input
 
 object TextInputTestTags {
     const val TEXT_INPUT = "text_input"
+    const val PASSWORD_VISIBILITY_TOGGLE = "password_toggle_visibility"
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
@@ -2,5 +2,5 @@ package com.telefonica.mistica.compose.input
 
 object TextInputTestTags {
     const val TEXT_INPUT = "text_input"
-    const val PASSWORD_VISIBILITY_TOGGLE = "password_toggle_visibility"
+    const val PASSWORD_VISIBILITY_TOGGLE = "password_visibility_toggle"
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Expose the constant used as the testTag for the "show/hide password" icon button

### :construction: How do we do it?
Make it public

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] Nothing to test here
