### PR TITLE
ANDROID-13391 Define error feedback icon resource for vivo

### DIFF
--- a/library/src/main/res/values/themes_vivo.xml
+++ b/library/src/main/res/values/themes_vivo.xml
@@ -16,6 +16,7 @@
 		<item name="feedbackScreenSuccessWithGradient">false</item>
 		<item name="feedbackScreenSuccessInverse">true</item>
 		<item name="feedbackScreenSuccessAnimation">@raw/feedback_success_vivo</item>
+		<item name="feedbackScreenErrorAnimation">@raw/feedback_error</item>
 
 		<!-- Stepper -->
 		<item name="stepperFinishedStepAnimation">@raw/feedback_success</item>

--- a/library/src/main/res/values/themes_vivo.xml
+++ b/library/src/main/res/values/themes_vivo.xml
@@ -17,6 +17,7 @@
 		<item name="feedbackScreenSuccessInverse">true</item>
 		<item name="feedbackScreenSuccessAnimation">@raw/feedback_success_vivo</item>
 		<item name="feedbackScreenErrorAnimation">@raw/feedback_error</item>
+		<item name="feedbackScreenInfoIcon">@drawable/feedback_info</item>
 
 		<!-- Stepper -->
 		<item name="stepperFinishedStepAnimation">@raw/feedback_success</item>


### PR DESCRIPTION
### :goal_net: What's the goal?
The feedback error icon for Vivo is not defined in theme_vivo as it is already for other brand themes.

### :construction: How do we do it?
Define the correct value for "feedbackScreenErrorAnimation" attribute, which is "@raw/feedback_error".
I've done the same for "feedbackScreenInfoIcon" icon attribute with the value "@drawable/feedback_info".

It is not being reproduced with the existing Catalog probably because Vivo is not the only theme used in runtime and a previous value may remain for this attribute.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos

| Error | Info |
| --- | --- |
|![Captura de Pantalla 2023-06-07 a las 16 30 29](https://github.com/Telefonica/mistica-android/assets/47142570/b1bd5d6a-5651-4a4c-94ea-3ccf86143ab5)|![Captura de Pantalla 2023-06-07 a las 16 31 34](https://github.com/Telefonica/mistica-android/assets/47142570/999c7f16-e8e0-463e-8c9d-4d978eb6518d)|


