### PR TITLE
ANDROID-13505 Add assignees to update design tokens PRs

### DIFF
--- a/.github/workflows/import-design-tokens.yml
+++ b/.github/workflows/import-design-tokens.yml
@@ -34,4 +34,5 @@ jobs:
           title: 'Update design tokens'
           body: 'This PR was automatically created by the import-design-tokens GitHub Action.'
           branch: 'import-design-tokens'
+          assignees: ${{ github.actor }}
           team-reviewers: 'Android,mistica-design'


### PR DESCRIPTION
### :goal_net: What's the goal?
Add workflow trigger author as assignee to "update design tokens" PRs

### :construction: How do we do it?
Use `assignees` field from the action we are already using to create the PR (https://github.com/peter-evans/create-pull-request)

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.
