### PR TITLE
Cancel ongoing debug_catalog.yml jobs

### DIFF
--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -1,6 +1,16 @@
 name: "Generate debug catalog app"
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+      - 'tokens/**'
+      - '.github/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   debug-catalog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### :goal_net: What's the goal?
Cancel ongoing debug_catalog.yml jobs

### :construction: How do we do it?
Add cancel-in-progress flag to debug_catalog.yml worflow and also avoid its execution when we have modified files that matches the following regex:
- `**.md`
- `doc/**`
- `tokens/**`
- `.github/**`

### ☑️ Checks
No checks needed

### :test_tube: How can I test this?
- Debug catalog action was not triggered when a file inside the discarded ones is modified

