### PR TITLE
Android-13531 Update list row icon

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
@@ -1,11 +1,13 @@
 package com.telefonica.mistica.catalog.ui.classic.components
 
 import android.annotation.SuppressLint
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.telefonica.mistica.catalog.R
@@ -353,6 +355,78 @@ class ListsCatalogFragment : Fragment() {
                 it.configureView(
                     withAsset = true,
                     withAssetType = TYPE_IMAGE,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_LARGE_ICON,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_SMALL_ICON,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_1_1,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_7_10,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_16_9,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = "fail_image_url",
+                    withErrorIcon =  AppCompatResources.getDrawable(it.context, R.drawable.ic_error)
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE,
                     withLongDescription = false,
                     withInverseBackground = withInverseBackground,
                 )
@@ -383,7 +457,8 @@ class ListsCatalogFragment : Fragment() {
             withSubtitleMaxLines: Int? = null,
             withBadgeDescription: String? = null,
             withInverseBackground: Boolean,
-            withUrlIcon: String? = null
+            withUrlIcon: String? = null,
+            withErrorIcon: Drawable? = null,
         ) {
             if (withHeadline) {
                 setHeadlineLayout(R.layout.list_row_tag_headline)
@@ -414,7 +489,7 @@ class ListsCatalogFragment : Fragment() {
 
             setAssetType(withAssetType)
             withUrlIcon?.let {
-                setAssetUrl(it)
+                setAssetUrl(it, errorDrawable = withErrorIcon)
             } ?: run {
                 setAssetResource(getAssetResource(withAsset, withAssetType))
             }

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
@@ -12,6 +12,9 @@ import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.list.ListRowView
 import com.telefonica.mistica.list.ListRowView.AssetType
 import com.telefonica.mistica.list.ListRowView.Companion.TYPE_IMAGE
+import com.telefonica.mistica.list.ListRowView.Companion.TYPE_IMAGE_16_9
+import com.telefonica.mistica.list.ListRowView.Companion.TYPE_IMAGE_1_1
+import com.telefonica.mistica.list.ListRowView.Companion.TYPE_IMAGE_7_10
 import com.telefonica.mistica.list.ListRowView.Companion.TYPE_LARGE_ICON
 import com.telefonica.mistica.list.ListRowView.Companion.TYPE_SMALL_ICON
 import com.telefonica.mistica.list.MisticaRecyclerView
@@ -265,11 +268,64 @@ class ListsCatalogFragment : Fragment() {
             {
                 it.configureView(
                     withAsset = true,
-                    withAssetType = TYPE_LARGE_ICON,
+                    withAssetType = TYPE_IMAGE_1_1,
                     withAction = true,
                     withSubtitle = true,
                     withHeadline = true,
                     withInverseBackground = withInverseBackground,
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_7_10,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_16_9,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_1_1,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = IMAGE_URL,
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_7_10,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = IMAGE_URL,
+                )
+            },
+            {
+                it.configureView(
+                    withAsset = true,
+                    withAssetType = TYPE_IMAGE_16_9,
+                    withAction = true,
+                    withSubtitle = true,
+                    withHeadline = true,
+                    withInverseBackground = withInverseBackground,
+                    withUrlIcon = IMAGE_URL,
                 )
             },
             {
@@ -327,6 +383,7 @@ class ListsCatalogFragment : Fragment() {
             withSubtitleMaxLines: Int? = null,
             withBadgeDescription: String? = null,
             withInverseBackground: Boolean,
+            withUrlIcon: String? = null
         ) {
             if (withHeadline) {
                 setHeadlineLayout(R.layout.list_row_tag_headline)
@@ -356,7 +413,11 @@ class ListsCatalogFragment : Fragment() {
             )
 
             setAssetType(withAssetType)
-            setAssetResource(getAssetResource(withAsset, withAssetType))
+            withUrlIcon?.let {
+                setAssetUrl(it)
+            } ?: run {
+                setAssetResource(getAssetResource(withAsset, withAssetType))
+            }
 
             if (withAction) {
                 setActionLayout(
@@ -379,12 +440,16 @@ class ListsCatalogFragment : Fragment() {
             }
         }
 
-        private fun getAssetResource(withAsset: Boolean, withAssetType: Int): Int? =
+        private fun getAssetResource(withAsset: Boolean, @AssetType withAssetType: Int): Int? =
             if (withAsset) {
-                if (withAssetType == TYPE_IMAGE) {
-                    R.drawable.highlighted_card_custom_background
-                } else {
-                    R.drawable.ic_lists
+                when (withAssetType) {
+                    TYPE_IMAGE -> R.drawable.highlighted_card_custom_background
+                    TYPE_IMAGE_1_1,
+                    TYPE_IMAGE_16_9,
+                    TYPE_IMAGE_7_10,
+                    -> R.drawable.highlighted_card_custom_background
+
+                    else -> R.drawable.ic_lists
                 }
             } else {
                 null
@@ -392,4 +457,9 @@ class ListsCatalogFragment : Fragment() {
     }
 
     class ListViewHolder(val rowView: ListRowView) : RecyclerView.ViewHolder(rowView)
+
+    private companion object {
+        const val IMAGE_URL = "https://www.fotoaparat.cz/imgs/a/26/2639/0n1wjdf0-cr-em13-09-1200x627x9.jpg"
+    }
+
 }

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
@@ -76,18 +77,18 @@ fun samples() = listOf(
 
     ListItem(
         title = TITLE,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
+        listRowIcon = ListRowIcon.CircleIcon(painterResource(id = R.drawable.ic_lists)),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
+        listRowIcon = ListRowIcon.CircleIcon(painterResource(id = R.drawable.ic_lists)),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
+        listRowIcon = ListRowIcon.CircleIcon(painterResource(id = R.drawable.ic_lists)),
     ),
     ListItem(
         title = TITLE,
@@ -95,7 +96,7 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -103,16 +104,7 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
-            backgroundColor = MisticaTheme.colors.backgroundAlternative
-        ),
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -121,7 +113,16 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        listRowIcon = ListRowIcon.CircleIcon(
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
         bottom = { CustomSlot() },
@@ -130,7 +131,7 @@ fun samples() = listOf(
     ListItem(
         title = TITLE,
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -138,7 +139,7 @@ fun samples() = listOf(
         title = TITLE,
         action = { Chevron() },
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -147,7 +148,7 @@ fun samples() = listOf(
         action = { Chevron() },
         isBadgeVisible = true,
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -157,7 +158,7 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -165,16 +166,7 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
-            backgroundColor = MisticaTheme.colors.backgroundAlternative
-        ),
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -183,7 +175,16 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        listRowIcon = ListRowIcon.CircleIcon(
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
         bottom = { CustomSlot() },
@@ -195,7 +196,7 @@ fun samples() = listOf(
         subtitle = SUBTITLE,
         action = { Chevron() },
         listRowIcon = ListRowIcon.CircleIcon(
-            iconResId = R.drawable.ic_lists,
+            painterResource(id = R.drawable.ic_lists),
             backgroundColor = MisticaTheme.colors.backgroundAlternative
         ),
     ),
@@ -207,7 +208,7 @@ fun samples() = listOf(
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
+        listRowIcon = ListRowIcon.SmallAsset(painter = painterResource(id = R.drawable.list_row_drawable)),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),
@@ -217,7 +218,7 @@ fun samples() = listOf(
         action = { Avatar(IMAGE_URL) },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
+        listRowIcon = ListRowIcon.SmallAsset(painter = painterResource(id = R.drawable.list_row_drawable)),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),
@@ -227,7 +228,7 @@ fun samples() = listOf(
         action = { Switch(checked = true, onCheckedChange = {}) },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
+        listRowIcon = ListRowIcon.SmallAsset(painter = painterResource(id = R.drawable.list_row_drawable)),
     ),
     ListItem(
         title = TITLE,
@@ -236,7 +237,7 @@ fun samples() = listOf(
         action = { Switch(checked = true, onCheckedChange = {}) },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.SmallAsset(iconUrl = IMAGE_URL),
+        listRowIcon = ListRowIcon.SmallAsset(painter = painterResource(id = R.drawable.list_row_drawable)),
         bottom = { CustomSlot() },
     ),
     ListItem(
@@ -247,7 +248,7 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         listRowIcon = ListRowIcon.LargeAsset(
-            iconResId = R.drawable.list_row_drawable,
+            painter = painterResource(id = R.drawable.list_row_drawable),
             aspectRatio = ListRowIcon.AspectRatio.RATIO_1_1
         ),
     ),
@@ -259,7 +260,7 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         listRowIcon = ListRowIcon.LargeAsset(
-            iconResId = R.drawable.list_row_drawable,
+            painter = painterResource(id = R.drawable.list_row_drawable),
             aspectRatio = ListRowIcon.AspectRatio.RATIO_16_9,
             contentScale = ContentScale.Crop
         ),
@@ -272,47 +273,10 @@ fun samples() = listOf(
         isBadgeVisible = true,
         badge = "1",
         listRowIcon = ListRowIcon.LargeAsset(
-            iconResId = R.drawable.list_row_drawable,
+            painter = painterResource(id = R.drawable.list_row_drawable),
             aspectRatio = ListRowIcon.AspectRatio.RATIO_7_10
         ),
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        description = DESCRIPTION,
-        action = { Switch(checked = true, onCheckedChange = {}) },
-        isBadgeVisible = true,
-        badge = "1",
-        listRowIcon = ListRowIcon.LargeAsset(
-            iconUrl = IMAGE_URL,
-            aspectRatio = ListRowIcon.AspectRatio.RATIO_1_1
-        ),
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        description = DESCRIPTION,
-        action = { Switch(checked = true, onCheckedChange = {}) },
-        isBadgeVisible = true,
-        badge = "1",
-        listRowIcon = ListRowIcon.LargeAsset(
-            iconUrl = IMAGE_URL,
-            aspectRatio = ListRowIcon.AspectRatio.RATIO_16_9,
-            contentScale = ContentScale.Crop
-        ),
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        description = DESCRIPTION,
-        action = { Switch(checked = true, onCheckedChange = {}) },
-        isBadgeVisible = true,
-        badge = "1",
-        listRowIcon = ListRowIcon.LargeAsset(
-            iconUrl = IMAGE_URL,
-            aspectRatio = ListRowIcon.AspectRatio.RATIO_7_10
-        ),
-    ),
+    )
 )
 
 const val IMAGE_URL = "https://www.fotoaparat.cz/imgs/a/26/2639/0n1wjdf0-cr-em13-09-1200x627x9.jpg"

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -10,30 +10,26 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.compose.list.BackgroundType
+import com.telefonica.mistica.compose.list.ListRowIcon
 import com.telefonica.mistica.compose.list.ListRowItem
 import com.telefonica.mistica.compose.shape.Chevron
-import com.telefonica.mistica.compose.shape.Circle
 import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
@@ -75,89 +71,89 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        bottom =  { CustomSlot() },
+        bottom = { CustomSlot() },
     ),
 
     ListItem(
         title = TITLE,
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
-        icon = { ListIcon() },
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        action = { Chevron() },
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        icon = { ListIcon() },
-        bottom =  { CustomSlot() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        bottom = { CustomSlot() },
     ),
 
     ListItem(
         title = TITLE,
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
-        icon = { ListIcon() },
-    ),
-    ListItem(
-        title = TITLE,
-        subtitle = SUBTITLE,
-        action = { Chevron() },
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        icon = { ListIcon() },
-        bottom =  { CustomSlot() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        action = { Chevron() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        bottom = { CustomSlot() },
     ),
 
     ListItem(
@@ -165,7 +161,7 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        icon = { ListIcon() },
+        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),
@@ -175,17 +171,17 @@ fun samples() = listOf(
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        icon = { Avatar() },
+        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),
         title = TITLE,
         subtitle = SUBTITLE,
         description = DESCRIPTION,
-        action = { Avatar("https://www.fotoaparat.cz/imgs/a/26/2639/0n1wjdf0-cr-em13-09-1200x627x9.jpg") },
+        action = { Avatar(IMAGE_URL) },
         isBadgeVisible = true,
         badge = "1",
-        icon = { Avatar() },
+        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),
@@ -195,7 +191,7 @@ fun samples() = listOf(
         action = { Switch(checked = true, onCheckedChange = {}) },
         isBadgeVisible = true,
         badge = "1",
-        icon = { Avatar() },
+        listRowIcon = ListRowIcon.SmallAsset(iconResId = R.drawable.list_row_drawable),
     ),
     ListItem(
         title = TITLE,
@@ -204,10 +200,86 @@ fun samples() = listOf(
         action = { Switch(checked = true, onCheckedChange = {}) },
         isBadgeVisible = true,
         badge = "1",
-        icon = { Avatar() },
-        bottom =  { CustomSlot() },
+        listRowIcon = ListRowIcon.SmallAsset(iconUrl = IMAGE_URL),
+        bottom = { CustomSlot() },
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconResId = R.drawable.list_row_drawable,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_1_1
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconResId = R.drawable.list_row_drawable,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_16_9,
+            contentScale = ContentScale.Crop
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconResId = R.drawable.list_row_drawable,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_7_10
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconUrl = IMAGE_URL,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_1_1
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconUrl = IMAGE_URL,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_16_9,
+            contentScale = ContentScale.Crop
+        ),
+    ),
+    ListItem(
+        title = TITLE,
+        subtitle = SUBTITLE,
+        description = DESCRIPTION,
+        action = { Switch(checked = true, onCheckedChange = {}) },
+        isBadgeVisible = true,
+        badge = "1",
+        listRowIcon = ListRowIcon.LargeAsset(
+            iconUrl = IMAGE_URL,
+            aspectRatio = ListRowIcon.AspectRatio.RATIO_7_10
+        ),
     ),
 )
+
+const val IMAGE_URL = "https://www.fotoaparat.cz/imgs/a/26/2639/0n1wjdf0-cr-em13-09-1200x627x9.jpg"
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -222,7 +294,7 @@ fun Lists() {
                 backgroundType = item.backgroundType,
                 badge = item.badge,
                 isBadgeVisible = item.isBadgeVisible,
-                icon = item.icon,
+                listRowIcon = item.listRowIcon,
                 headline = item.headline,
                 title = item.title,
                 subtitle = item.subtitle,
@@ -243,7 +315,7 @@ fun Lists() {
                 backgroundType = item.backgroundType,
                 badge = item.badge,
                 isBadgeVisible = item.isBadgeVisible,
-                icon = item.icon,
+                listRowIcon = item.listRowIcon,
                 headline = item.headline,
                 title = item.title,
                 subtitle = item.subtitle,
@@ -263,7 +335,7 @@ fun Lists() {
                 backgroundType = item.backgroundType,
                 badge = item.badge,
                 isBadgeVisible = item.isBadgeVisible,
-                icon = item.icon,
+                listRowIcon = item.listRowIcon,
                 headline = item.headline,
                 title = item.title,
                 subtitle = item.subtitle,
@@ -277,7 +349,7 @@ fun Lists() {
 }
 
 data class ListItem(
-    val icon: @Composable (() -> Unit)? = null,
+    val listRowIcon: ListRowIcon? = null,
     val title: String? = null,
     val subtitle: String? = null,
     val description: String? = null,
@@ -289,28 +361,6 @@ data class ListItem(
     val onClick: () -> Unit = {},
     val bottom: @Composable (() -> Unit)? = null,
 )
-
-@Composable
-fun ListIcon() {
-    Circle {
-        Icon(
-            painterResource(id = R.drawable.ic_lists),
-            contentDescription = null
-        )
-    }
-}
-
-@Composable
-fun Avatar() {
-    Image(
-        painter = painterResource(id = R.drawable.list_row_drawable),
-        contentDescription = null,
-        modifier = Modifier
-            .size(40.dp)
-            .clip(CircleShape),
-        contentScale = ContentScale.Crop,
-    )
-}
 
 @Composable
 fun Avatar(url: String) {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -94,65 +94,98 @@ fun samples() = listOf(
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
         bottom = { CustomSlot() },
     ),
 
     ListItem(
         title = TITLE,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         action = { Chevron() },
         isBadgeVisible = true,
         badge = "1",
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
         bottom = { CustomSlot() },
     ),
 
@@ -161,7 +194,10 @@ fun samples() = listOf(
         title = TITLE,
         subtitle = SUBTITLE,
         action = { Chevron() },
-        listRowIcon = ListRowIcon.CircleIcon(iconResId = R.drawable.ic_lists, backgroundColor = MisticaTheme.colors.backgroundAlternative),
+        listRowIcon = ListRowIcon.CircleIcon(
+            iconResId = R.drawable.ic_lists,
+            backgroundColor = MisticaTheme.colors.backgroundAlternative
+        ),
     ),
     ListItem(
         headline = Tag("PROMO").withStyle(TYPE_PROMO),

--- a/catalog/src/main/res/drawable/ic_error.xml
+++ b/catalog/src/main/res/drawable/ic_error.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
@@ -1,10 +1,8 @@
 package com.telefonica.mistica.compose.list
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
@@ -16,37 +14,32 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
 import com.telefonica.mistica.compose.shape.Circle
 
 sealed class ListRowIcon(val contentDescription: String?) {
 
     data class NormalIcon(
-        @DrawableRes val iconResId: Int? = null,
+        val painter: Painter? = null,
         private val description: String? = null,
     ) : ListRowIcon(description)
 
     data class CircleIcon(
-        @DrawableRes val iconResId: Int? = null,
-        private val description: String? = null,
+        val painter: Painter? = null,
         val backgroundColor: Color = Color.Transparent,
+        private val description: String? = null,
     ) : ListRowIcon(description)
 
     data class SmallAsset(
-        val iconUrl: String? = null,
-        @DrawableRes val iconResId: Int? = null,
+        val painter: Painter? = null,
         private val description: String? = null,
     ) : ListRowIcon(description)
 
     data class LargeAsset(
-        val iconUrl: String? = null,
-        @DrawableRes val iconResId: Int? = null,
+        val painter: Painter? = null,
         val aspectRatio: AspectRatio = AspectRatio.RATIO_1_1,
         val contentScale: ContentScale = ContentScale.Crop,
         private val description: String? = null,
@@ -75,9 +68,9 @@ sealed class ListRowIcon(val contentDescription: String?) {
                 .size(40.dp)
                 .wrapContentSize(align = Alignment.Center)
         ) {
-            iconResId?.let {
+            painter?.let {
                 Icon(
-                    painter = painterResource(id = iconResId),
+                    painter = painter,
                     modifier = Modifier.size(24.dp),
                     contentDescription = contentDescription
                 )
@@ -91,9 +84,9 @@ sealed class ListRowIcon(val contentDescription: String?) {
         Circle(
             color = backgroundColor,
         ) {
-            iconResId?.let {
+           painter?.let {
                 Icon(
-                    painter = painterResource(id = iconResId),
+                    painter = painter,
                     contentDescription = contentDescription
                 )
             }
@@ -102,16 +95,6 @@ sealed class ListRowIcon(val contentDescription: String?) {
 
     @Composable
     private fun SmallAsset.DrawSmallAsset() {
-        val painter = when {
-            iconResId != null -> painterResource(iconResId)
-            iconUrl != null -> rememberAsyncImagePainter(
-                ImageRequest.Builder(LocalContext.current)
-                    .data(iconUrl)
-                    .build()
-            )
-
-            else -> null
-        }
         painter?.let {
             Image(
                 painter = painter,
@@ -126,16 +109,6 @@ sealed class ListRowIcon(val contentDescription: String?) {
 
     @Composable
     private fun LargeAsset.DrawLargeAsset() {
-        val painter = when {
-            iconResId != null -> painterResource(iconResId)
-            iconUrl != null -> rememberAsyncImagePainter(
-                ImageRequest.Builder(LocalContext.current)
-                    .data(iconUrl)
-                    .build()
-            )
-
-            else -> null
-        }
         painter?.let {
             Image(
                 painter = painter,

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
@@ -1,0 +1,151 @@
+package com.telefonica.mistica.compose.list
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import com.telefonica.mistica.compose.shape.Circle
+
+sealed class ListRowIcon(val contentDescription: String?) {
+
+    data class NormalIcon(
+        @DrawableRes val iconResId: Int? = null,
+        private val description: String? = null,
+    ) : ListRowIcon(description)
+
+    data class CircleIcon(
+        @DrawableRes val iconResId: Int? = null,
+        private val description: String? = null,
+        val backgroundColor: Color = Color.Transparent,
+    ) : ListRowIcon(description)
+
+    data class SmallAsset(
+        val iconUrl: String? = null,
+        @DrawableRes val iconResId: Int? = null,
+        private val description: String? = null,
+    ) : ListRowIcon(description)
+
+    data class LargeAsset(
+        val iconUrl: String? = null,
+        @DrawableRes val iconResId: Int? = null,
+        val aspectRatio: AspectRatio = AspectRatio.RATIO_1_1,
+        val contentScale: ContentScale = ContentScale.Crop,
+        private val description: String? = null,
+    ) : ListRowIcon(description)
+
+    enum class AspectRatio(val width: Dp, val height: Dp) {
+        RATIO_1_1(80.dp, 80.dp),
+        RATIO_7_10(80.dp, 116.dp),
+        RATIO_16_9(138.dp, 80.dp)
+    }
+
+    @Composable
+    fun Draw() {
+        when (this) {
+            is NormalIcon -> DrawNormalIcon()
+            is CircleIcon -> DrawCircleIcon()
+            is SmallAsset -> DrawSmallAsset()
+            is LargeAsset -> DrawLargeAsset()
+        }
+    }
+
+    @Composable
+    private fun NormalIcon.DrawNormalIcon() {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .wrapContentSize(align = Alignment.Center)
+        ) {
+            iconResId?.let {
+                Icon(
+                    painter = painterResource(id = iconResId),
+                    modifier = Modifier.size(24.dp),
+                    contentDescription = contentDescription
+                )
+            }
+        }
+
+    }
+
+    @Composable
+    private fun CircleIcon.DrawCircleIcon() {
+        Circle(
+            color = backgroundColor,
+        ) {
+            iconResId?.let {
+                Icon(
+                    painter = painterResource(id = iconResId),
+                    contentDescription = contentDescription
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun SmallAsset.DrawSmallAsset() {
+        val painter = when {
+            iconResId != null -> painterResource(iconResId)
+            iconUrl != null -> rememberAsyncImagePainter(
+                ImageRequest.Builder(LocalContext.current)
+                    .data(iconUrl)
+                    .build()
+            )
+
+            else -> null
+        }
+        painter?.let {
+            Image(
+                painter = painter,
+                contentDescription = contentDescription,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+
+    @Composable
+    private fun LargeAsset.DrawLargeAsset() {
+        val painter = when {
+            iconResId != null -> painterResource(iconResId)
+            iconUrl != null -> rememberAsyncImagePainter(
+                ImageRequest.Builder(LocalContext.current)
+                    .data(iconUrl)
+                    .build()
+            )
+
+            else -> null
+        }
+        painter?.let {
+            Image(
+                painter = painter,
+                contentDescription = contentDescription,
+                modifier = Modifier
+                    .height(aspectRatio.height)
+                    .width(aspectRatio.width)
+                    .clip(RoundedCornerShape(4.dp)),
+                contentScale = contentScale,
+            )
+        }
+    }
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -76,6 +76,7 @@ fun ListRowItem(
 
 @ExperimentalMaterialApi
 @Composable
+@Deprecated(replaceWith = ReplaceWith("ListRowItem"), message = "Use new ListRowItem with ListRowIcon param instead")
 fun ListRowItem(
     modifier: Modifier = Modifier,
     icon: @Composable (() -> Unit)? = null,

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,7 +34,6 @@ import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.badge.Badge
 import com.telefonica.mistica.compose.shape.Chevron
-import com.telefonica.mistica.compose.shape.Circle
 import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
@@ -150,6 +148,7 @@ fun ListRowItemImp(
                 color = MisticaTheme.colors.backgroundContainer,
                 shape = RoundedCornerShape(MisticaTheme.radius.containerBorderRadius),
             )
+
         BackgroundType.TYPE_BOXED_INVERSE -> Modifier
             .background(
                 color = MisticaTheme.colors.backgroundBrand,
@@ -157,10 +156,12 @@ fun ListRowItemImp(
             )
     }
         .fillMaxWidth()
-        .defaultMinSize(minHeight = when(description) {
-            null -> 72.dp
-            else -> 80.dp
-        })
+        .defaultMinSize(
+            minHeight = when (description) {
+                null -> 72.dp
+                else -> 80.dp
+            }
+        )
         .padding(16.dp)
 
     val textColorPrimary = when (backgroundType) {
@@ -293,7 +294,7 @@ fun ListRowItemPreview() {
                 subtitle = "Subtitle",
                 description = "Description",
                 listRowIcon = ListRowIcon.NormalIcon(
-                    iconResId = R.drawable.icn_arrow,
+                    painter = painterResource(id = R.drawable.icn_arrow),
                     description = null
                 ),
                 trailing = { Chevron() }
@@ -303,7 +304,7 @@ fun ListRowItemPreview() {
                 subtitle = "Subtitle",
                 description = "Description",
                 listRowIcon = ListRowIcon.CircleIcon(
-                    iconResId = R.drawable.icn_arrow,
+                    painter = painterResource(id = R.drawable.icn_arrow),
                     backgroundColor = MisticaTheme.colors.neutralLow,
                     description = null
                 ),

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -44,6 +44,74 @@ import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 @Composable
 fun ListRowItem(
     modifier: Modifier = Modifier,
+    listRowIcon: ListRowIcon? = null,
+    title: String? = null,
+    subtitle: String? = null,
+    description: String? = null,
+    backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
+    badge: String? = null,
+    isBadgeVisible: Boolean = false,
+    headline: Tag? = null,
+    trailing: @Composable (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    bottom: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+) {
+    ListRowItemImp(
+        modifier = modifier,
+        icon = { listRowIcon?.Draw() },
+        title = title,
+        subtitle = subtitle,
+        description = description,
+        backgroundType = backgroundType,
+        badge = badge,
+        isBadgeVisible = isBadgeVisible,
+        headline = headline,
+        trailing = trailing,
+        onClick = onClick,
+        bottom = bottom,
+        contentPadding = contentPadding
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+fun ListRowItem(
+    modifier: Modifier = Modifier,
+    icon: @Composable (() -> Unit)? = null,
+    title: String? = null,
+    subtitle: String? = null,
+    description: String? = null,
+    backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
+    badge: String? = null,
+    isBadgeVisible: Boolean = false,
+    headline: Tag? = null,
+    trailing: @Composable (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    bottom: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+) {
+    ListRowItemImp(
+        modifier = modifier,
+        icon = icon,
+        title = title,
+        subtitle = subtitle,
+        description = description,
+        backgroundType = backgroundType,
+        badge = badge,
+        isBadgeVisible = isBadgeVisible,
+        headline = headline,
+        trailing = trailing,
+        onClick = onClick,
+        bottom = bottom,
+        contentPadding = contentPadding
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+fun ListRowItemImp(
+    modifier: Modifier = Modifier,
     icon: @Composable (() -> Unit)? = null,
     title: String? = null,
     subtitle: String? = null,
@@ -209,6 +277,7 @@ fun ListRowItemPreview() {
         val checkedState = remember { mutableStateOf(true) }
         Column {
             ListRowItem(
+                listRowIcon = null,
                 headline = Tag("Promo"),
                 isBadgeVisible = true,
                 title = "Title",
@@ -222,26 +291,21 @@ fun ListRowItemPreview() {
                 badge = "2",
                 subtitle = "Subtitle",
                 description = "Description",
-                icon = {
-                    Icon(
-                        painterResource(id = R.drawable.icn_arrow),
-                        contentDescription = null
-                    )
-                },
+                listRowIcon = ListRowIcon.NormalIcon(
+                    iconResId = R.drawable.icn_arrow,
+                    description = null
+                ),
                 trailing = { Chevron() }
             )
             ListRowItem(
                 title = "Title",
                 subtitle = "Subtitle",
                 description = "Description",
-                icon = {
-                    Circle {
-                        Icon(
-                            painterResource(id = R.drawable.icn_arrow),
-                            contentDescription = null
-                        )
-                    }
-                },
+                listRowIcon = ListRowIcon.CircleIcon(
+                    iconResId = R.drawable.icn_arrow,
+                    backgroundColor = MisticaTheme.colors.neutralLow,
+                    description = null
+                ),
                 trailing = {
                     Checkbox(
                         checked = checkedState.value,
@@ -254,9 +318,7 @@ fun ListRowItemPreview() {
                 title = "Title",
                 subtitle = "Subtitle",
                 description = "Description",
-                icon = {
-                    Circle {}
-                },
+                listRowIcon = ListRowIcon.CircleIcon(backgroundColor = MisticaTheme.colors.neutralLow),
                 trailing = {
                     Checkbox(
                         checked = checkedState.value,

--- a/library/src/main/java/com/telefonica/mistica/compose/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/README.md
@@ -42,7 +42,13 @@ enum class BackgroundType {
 Following the order in the image, the types are: normal, boxed and boxed-inverse. Take into account that `normal` is full width.
 
 ## Icon
-Any `@Composable` could be used as `icon` but the system design specifications only allow as legal uses including here icons or rounded images.
+Image to be showed at the first section of list row.
+There are 4 types of icons:
+- `NormalIcon`: it's a normal icon, it should be a `Drawable` with a `description` parameter.
+- `CircleIcon`: it's a circle icon, it should be a `Drawable` with a `description` parameter. It's possible to define the `backgroundColor` of the circle.
+- `SmallAsset`: it's a circle icon, it could be a `Drawable` resource or a external url with a `description` parameter inside.
+- `LargeAsset`: it's a custom image, it could be a `Drawable` resource or a external url with a `description` parameter inside. It's possible to define the
+  `aspectRatio` of the image and the `contentScale` type
 
 ![image](https://user-images.githubusercontent.com/944814/143047368-3494885c-6324-4b4b-bcc0-4177525208bf.png)
 
@@ -50,14 +56,10 @@ Any `@Composable` could be used as `icon` but the system design specifications o
 ```kotlin
   ListRowItem(
       title = "Title",
-      icon = {
-        Circle {
-          Icon(
-            painterResource(id = R.drawable.ic_lists),
-            contentDescription = null
-          )
-       }
-     }
+      listRowIcon = ListRowIcon.NormalIcon(
+          iconResId = R.drawable.icn_arrow,
+          description = null
+      )
   )
 ```
 ## Headline
@@ -69,14 +71,11 @@ Any `@Composable` could be used as `headline`.
   ListRowItem(
       title = "Title",
       headline = { Tag() },
-      icon = {
-        Circle {
-          Icon(
-            painterResource(id = R.drawable.ic_lists),
-            contentDescription = null
-          )
-       }
-     }
+      listRowIcon = ListRowIcon.CircleIcon(
+        iconResId = R.drawable.icn_arrow,
+        backgroundColor = MisticaTheme.colors.neutralLow,
+        description = null
+      )
   )
 ```
 

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -227,14 +227,37 @@ class ListRowView @JvmOverloads constructor(
         setAssetDrawable(resource?.let { AppCompatResources.getDrawable(context, it) })
     }
 
-    fun setAssetUrl(url: String) {
-        assetRoundedImageView.load(url) {
-            listener(onSuccess = { _, _ ->
-                assetImageLayout.visibility = VISIBLE
-                updateIconVisibility()
-            }, onError = { _, _ ->
-                assetImageLayout.visibility = GONE
-            })
+    fun setAssetUrl(
+        url: String,
+        scaleType: ImageView.ScaleType = ImageView.ScaleType.CENTER_CROP,
+        placeholder: Drawable? = null,
+        errorDrawable: Drawable? = null,
+        onSuccess: (() -> Unit)? = null,
+        onError: (() -> Unit)? = null,
+    ) {
+        assetImageLayout.visibility = VISIBLE
+        updateIconVisibility()
+
+        when (assetType) {
+            TYPE_IMAGE -> assetCircularImageView
+            TYPE_IMAGE_1_1,
+            TYPE_IMAGE_7_10,
+            TYPE_IMAGE_16_9 -> assetRoundedImageView
+            else -> assetImageView
+        }.also { imageView ->
+            imageView.load(url) {
+                listener(
+                    onSuccess = { _, _ ->
+                        imageView.scaleType = scaleType
+                        onSuccess?.invoke()
+                    }, onError = { _, _ ->
+                        imageView.setImageDrawable(errorDrawable)
+                        imageView.scaleType = ImageView.ScaleType.FIT_CENTER
+                        onError?.invoke()
+                    }, onStart = {
+                        imageView.setImageDrawable(placeholder)
+                    })
+            }
         }
     }
 

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -5,7 +5,6 @@ import android.content.res.TypedArray
 import android.graphics.drawable.Drawable
 import android.text.TextUtils
 import android.util.AttributeSet
-import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -23,7 +22,6 @@ import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
-import coil.Coil
 import coil.load
 import com.telefonica.mistica.R
 import com.telefonica.mistica.badge.Badge

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -26,6 +26,9 @@ Implemented as a custom view, `com.telefonica.mistica.ListRowView` can be used i
 		<enum name="image" value="0" />
 		<enum name="smallIcon" value="1" />
 		<enum name="largeIcon" value="2" />
+		<enum name="image_1_1" value="3" />
+		<enum name="image_7_10" value="4" />
+		<enum name="image_16_9" value="5" />
 	</attr>
 	<attr name="listRowBackgroundType" format="enum">
 		<enum name="normal" value="0" />

--- a/library/src/main/res/layout/list_row_item.xml
+++ b/library/src/main/res/layout/list_row_item.xml
@@ -26,10 +26,22 @@
 				android:layout_height="40dp"
 				android:layout_gravity="center"
 				android:importantForAccessibility="no"
+				android:scaleType="centerCrop"
 				android:visibility="gone"
 				tools:src="@tools:sample/avatars"
 				tools:visibility="visible"
 				/>
+
+		<com.google.android.material.imageview.ShapeableImageView
+				android:id="@+id/row_asset_rounded_image"
+				android:layout_width="80dp"
+				android:layout_height="80dp"
+				android:layout_gravity="center"
+				android:importantForAccessibility="no"
+				android:scaleType="centerCrop"
+				android:visibility="gone"
+				app:shapeAppearance="@style/RoundedImageView"
+				tools:src="@tools:sample/avatars"/>
 
 		<com.google.android.material.imageview.ShapeableImageView
 				android:id="@+id/row_asset_circular_image"
@@ -41,7 +53,6 @@
 				android:visibility="gone"
 				app:shapeAppearance="@style/CircleImageView"
 				tools:src="@tools:sample/avatars"
-				tools:visibility="gone"
 				/>
 
 	</FrameLayout>

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -70,6 +70,9 @@
             <enum name="image" value="0" />
             <enum name="smallIcon" value="1" />
             <enum name="largeIcon" value="2" />
+            <enum name="image_1_1" value="3" />
+            <enum name="image_7_10" value="4" />
+            <enum name="image_16_9" value="5" />
         </attr>
         <!-- {@deprecated This attribute is deprecated. Use <code>listRowBackgroundType</code> instead } -->
         <attr name="listRowIsBoxed" format="boolean" />

--- a/library/src/main/res/values/styles_images.xml
+++ b/library/src/main/res/values/styles_images.xml
@@ -5,4 +5,9 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>
+
+    <style name="RoundedImageView" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">4dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Update list row icon to don't let developers add any kind of views.
Add new list spec
* load url image
* asset image with aspect ratio 1:1
* asset image with aspect ratio 16:9
* asset image with aspect ratio 7:10

### :construction: How do we do it?
* Update compose views 
* * Create new sealed class with all image types
* * Create draw function foreach new image types
* Update xml views
* * Add new aspect ratio images to current implementation
* Update Catalog

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...

https://github.com/Telefonica/mistica-android/assets/42326032/7d0865d1-08a8-4c23-b3c5-aeb37e631fc1

