### PR TITLE
ANDROID-13561 Tokenize SnackBar and LoadErrorFeedback

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/feedback/error/LoadErrorFeedback.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/feedback/error/LoadErrorFeedback.kt
@@ -33,7 +33,7 @@ fun LoadErrorFeedback(
                 modifier = Modifier.padding(8.dp),
                 text = it,
                 textAlign = TextAlign.Center,
-                style = MisticaTheme.typography.preset4Light,
+                style = MisticaTheme.typography.presetCardTitle,
                 color = MisticaTheme.colors.textPrimary
             )
         }

--- a/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/SnackbarBuilder.kt
@@ -106,7 +106,7 @@ open class SnackbarBuilder(view: View?, text: String) {
         text.maxLines = MAX_TEXT_LINES
         text.setTextAppearance(text.context, R.style.AppTheme_TextAppearance_Preset2)
         val action = snackbar.view.findViewById<TextView>(R.id.snackbar_action)
-        action.setTextAppearance(action.context, R.style.AppTheme_TextAppearance_Preset3_Medium)
+        action.setTextAppearance(action.context, R.style.AppTheme_TextAppearance_PresetLink)
         action.isAllCaps = false
     }
 

--- a/library/src/main/res/layout/load_error_feedback.xml
+++ b/library/src/main/res/layout/load_error_feedback.xml
@@ -7,7 +7,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:gravity="center"
-        android:textAppearance="@style/AppTheme.TextAppearance.Preset4.Light"
+        android:textAppearance="@style/AppTheme.TextAppearance.PresetCardTitle"
         android:textColor="?colorTextPrimary"
         android:visibility="gone" />
 


### PR DESCRIPTION
### :goal_net: What's the goal?
Use "tokenized" presets for Snackbar and LoadErrorFeedback components.

### :construction: How do we do it?
- Use "PresetLink" for Snackbar action
- Use "PresetCardTitle" for LoadErrorFeedback title component

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
