### PR TITLE
ANDROID-13681 Revert using JvmOverloads in Button

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/button/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/Button.kt
@@ -6,11 +6,17 @@ import com.google.android.material.button.MaterialButton
 import com.telefonica.mistica.util.setAlpha
 
 // This should be deprecated soon, when it's confirmed no problem appears when using button2.Button instead
-class Button @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0,
-) : MaterialButton(context, attrs, defStyleAttr) {
+class Button : MaterialButton {
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    )
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix the problem that has appeared with the buttons that have no style associated.

### :construction: How do we do it?
Reverting the button.Button last change of using @JvmOverloads as that clearly breaks it.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
Before:
![before](https://github.com/Telefonica/mistica-android/assets/13270085/3daa699e-191f-474c-b412-64453929a55a)
After:
![after](https://github.com/Telefonica/mistica-android/assets/13270085/d5e03ebf-e589-4518-878c-73f6636aa241)
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
