### PR TITLE
POC roborazzi screenshot tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.android' version '1.5.21' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
+    id "io.github.takahirom.roborazzi" version "1.4.0" apply false
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri May 19 13:07:06 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'maven-publish'
+    id 'io.github.takahirom.roborazzi'
 }
 
 android {
@@ -51,6 +52,12 @@ android {
         sarifReport true
         checkDependencies true
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 task sourceJar(type: Jar) {
@@ -87,6 +94,11 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'androidx.compose.ui:ui-test-junit4:1.0.5'
+    testImplementation 'androidx.compose.ui:ui-test-manifest:1.0.5'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi:1.4.0'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.4.0'
     testImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
 

--- a/library/src/test/java/com/telefonica/mistica/compose/input/PasswordInputKtTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/compose/input/PasswordInputKtTest.kt
@@ -1,0 +1,96 @@
+package com.telefonica.mistica.compose.input
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+internal class PasswordInputKtTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `check the password is initially not visible`() = test {
+        `when PasswordInput`()
+
+        `then screenshot is OK`()
+        `then the password is not visible`()
+    }
+
+    @Test
+    fun `check the password is visible after the visibility button is clicked`() = test {
+        `given PasswordInput`()
+
+        `when the visibility button is clicked`()
+
+        `then screenshot is OK`()
+        `then the password is visible`()
+    }
+
+    @Test
+    fun `check the password is not visible after toggling twice the visibility button`() = test {
+        `given PasswordInput`()
+
+        `when the visibility button is clicked`(times = 2)
+
+        `then screenshot is OK`()
+        `then the password is not visible`()
+    }
+
+    private fun TestScope.`given PasswordInput`() {
+        `when PasswordInput`()
+    }
+
+    private fun TestScope.`when PasswordInput`() {
+        composeTestRule.setContent {
+            MisticaTheme(brand = MovistarBrand) {
+                PasswordInput(
+                    value = textValue,
+                    onValueChange = onValueChanged,
+                    label = "label",
+                )
+            }
+        }
+    }
+
+    private fun `when the visibility button is clicked`(times: Int = 1) {
+        repeat(times) {
+            composeTestRule.onNodeWithTag(TextInputTestTags.PASSWORD_VISIBILITY_TOGGLE).performClick()
+        }
+    }
+
+    private fun TestScope.`then the password is not visible`() {
+        composeTestRule.onNodeWithText(textValue).assertDoesNotExist()
+    }
+
+    private fun TestScope.`then the password is visible`() {
+        composeTestRule.onNodeWithText(textValue).assertIsDisplayed()
+    }
+
+    private fun `then screenshot is OK`() {
+        composeTestRule.onRoot()
+            .captureRoboImage()
+    }
+
+    private fun test(block: TestScope.() -> Unit) {
+        TestScope().block()
+    }
+
+    private class TestScope {
+        val textValue = "textValue"
+        var valueChanged = false
+        val onValueChanged: (String) -> Unit = { valueChanged = true }
+    }
+}


### PR DESCRIPTION
### :goal_net: What's the goal?
POC Roborazzi tests

### :construction: How do we do it?
- Adding Roboelectric
- Adding Roborazzi following the README instructions.

### What is missing:
- Perhaps we want to store the screenshots inside the codebase instead of what they do for demonstration, we could check if passing the fileName is ok or if we have other problems then.
- Github integration, there is https://github.com/takahirom/roborazzi-compare-on-github-comment-sample we could play with it and check if that's ok or do we need something more.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
