### PR TITLE
ANDROID-13761 Adding semantics to the popover

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/popover/PopOver.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/popover/PopOver.kt
@@ -22,11 +22,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import com.skydoves.balloon.ArrowPositionRules
 import com.skydoves.balloon.BalloonAnimation
@@ -42,6 +45,7 @@ import com.telefonica.mistica.compose.popover.Popover.TestTag.POPOVER_SUBTITLE
 import com.telefonica.mistica.compose.popover.Popover.TestTag.POPOVER_TITLE
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PopOver(
     modifier: Modifier = Modifier,
@@ -83,6 +87,7 @@ fun PopOver(
                         .fillMaxWidth()
                         .padding(start = 16.dp, top = 8.dp, end = 8.dp, bottom = 16.dp)
                         .background(Color.Transparent)
+                        .semantics { testTagsAsResourceId = true }
                         .testTag(POPOVER_CONTENT),
                 ) {
                     Row(


### PR DESCRIPTION
### :goal_net: What's the goal?
Ticket: https://jira.tid.es/browse/ANDROID-13761

### :construction: How do we do it?
Popovers in compose are made with a custom library called balloon. It renders a composeView inside some view hierarchy.

So it is needed to set the semantics at this point.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
![image](https://github.com/Telefonica/mistica-android/assets/4595241/6d4b0a81-0ac0-4989-a484-aa5cee212185)
![image](https://github.com/Telefonica/mistica-android/assets/4595241/8f2827f1-f860-46c9-b5a6-b024b0f289a5)
