### PR TITLE
Android-13783 Improve Callout buttons margin

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
@@ -38,7 +38,7 @@ class CalloutsCatalogFragment : Fragment() {
                     CalloutButtonsConfig.values().map { it.name },
                 )
             )
-            setText(CalloutButtonsConfig.BUTTONS_CONFIG_PRIMARY.name)
+            setText(CalloutButtonsConfig.PRIMARY.name)
         }
         view.findViewById<Button>(R.id.update_button).setOnClickListener {
             updateCalloutView(view)
@@ -87,12 +87,12 @@ class CalloutsCatalogFragment : Fragment() {
     }
 
     private enum class CalloutButtonsConfig(@CalloutView.ButtonsConfig val buttonsConfig: Int) {
-        BUTTONS_CONFIG_NONE(CalloutView.BUTTONS_CONFIG_NONE),
-        BUTTONS_CONFIG_PRIMARY(CalloutView.BUTTONS_CONFIG_PRIMARY),
-        BUTTONS_CONFIG_PRIMARY_LINK(CalloutView.BUTTONS_CONFIG_PRIMARY_LINK),
-        BUTTONS_CONFIG_PRIMARY_SECONDARY(CalloutView.BUTTONS_CONFIG_PRIMARY_SECONDARY),
-        BUTTONS_CONFIG_SECONDARY(CalloutView.BUTTONS_CONFIG_SECONDARY),
-        BUTTONS_CONFIG_SECONDARY_LINK(CalloutView.BUTTONS_CONFIG_SECONDARY_LINK),
-        BUTTONS_CONFIG_LINK(CalloutView.BUTTONS_CONFIG_LINK),
+        NONE(CalloutView.BUTTONS_CONFIG_NONE),
+        PRIMARY(CalloutView.BUTTONS_CONFIG_PRIMARY),
+        PRIMARY_AND_LINK(CalloutView.BUTTONS_CONFIG_PRIMARY_LINK),
+        PRIMARY_AND_SECONDARY(CalloutView.BUTTONS_CONFIG_PRIMARY_SECONDARY),
+        SECONDARY(CalloutView.BUTTONS_CONFIG_SECONDARY),
+        SECONDARY_AND_LINK(CalloutView.BUTTONS_CONFIG_SECONDARY_LINK),
+        LINK(CalloutView.BUTTONS_CONFIG_LINK),
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
@@ -84,7 +84,7 @@ fun Button(
                 }
                 .height(size.height)
                 .applyWidth(originalWidth),
-            contentPadding = PaddingValues(horizontal = size.contentPadding, vertical = 0.dp),
+            contentPadding = PaddingValues(horizontal = size.horizontalPadding, vertical = 0.dp),
             onClick = onClickListener,
             enabled = enabled,
             colors = style.buttonColors,

--- a/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
@@ -50,7 +50,7 @@ import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
 private val iconSpacing = 10.dp
 private val easing = CubicBezierEasing(0.77f, 0f, 0.175f, 1f)
-private const val CHEVRON_ASPECT_RATIO = 8f/20f
+private const val CHEVRON_ASPECT_RATIO = 8f / 20f
 
 @Composable
 fun Button(
@@ -62,6 +62,7 @@ fun Button(
     enabled: Boolean = true,
     @DrawableRes icon: Int? = null,
     withChevron: Boolean = false,
+    invalidatePaddings: Boolean = false,
     onClickListener: () -> Unit,
 ) {
 
@@ -84,7 +85,7 @@ fun Button(
                 }
                 .height(size.height)
                 .applyWidth(originalWidth),
-            contentPadding = PaddingValues(horizontal = size.horizontalPadding, vertical = 0.dp),
+            contentPadding = PaddingValues(horizontal = if (invalidatePaddings) 0.dp else size.horizontalPadding, vertical = 0.dp),
             onClick = onClickListener,
             enabled = enabled,
             colors = style.buttonColors,

--- a/library/src/main/java/com/telefonica/mistica/compose/button/ButtonSizes.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/button/ButtonSizes.kt
@@ -24,10 +24,9 @@ internal fun ButtonStyle.getButtonSizeCompose(): ButtonSizeConfig =
         ButtonStyle.PRIMARY_SMALL,
         ButtonStyle.SECONDARY_SMALL_INVERSE,
         ButtonStyle.SECONDARY_SMALL,
-        -> getSmallButtonSizeConfig()
         ButtonStyle.LINK,
         ButtonStyle.LINK_INVERSE,
-        -> getSmallButtonSizeConfig().copy(horizontalPadding = 0.dp)
+        -> getSmallButtonSizeConfig()
         else -> getDefaultButtonSizeConfig()
     }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/button/ButtonSizes.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/button/ButtonSizes.kt
@@ -6,14 +6,14 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
-internal class ButtonSizeConfig(
+internal data class ButtonSizeConfig(
     val textStyle: TextStyle,
     val height: Dp,
     val minWidth: Dp,
     val iconSize: Dp,
     val progressBarSize: Dp,
     val progressBarStroke: Dp,
-    val contentPadding: Dp,
+    val horizontalPadding: Dp,
 )
 
 @Composable
@@ -24,9 +24,10 @@ internal fun ButtonStyle.getButtonSizeCompose(): ButtonSizeConfig =
         ButtonStyle.PRIMARY_SMALL,
         ButtonStyle.SECONDARY_SMALL_INVERSE,
         ButtonStyle.SECONDARY_SMALL,
+        -> getSmallButtonSizeConfig()
         ButtonStyle.LINK,
         ButtonStyle.LINK_INVERSE,
-        -> getSmallButtonSizeConfig()
+        -> getSmallButtonSizeConfig().copy(horizontalPadding = 0.dp)
         else -> getDefaultButtonSizeConfig()
     }
 
@@ -38,7 +39,7 @@ private fun getDefaultButtonSizeConfig() = ButtonSizeConfig(
     iconSize = 24.dp,
     progressBarSize = 20.dp,
     progressBarStroke = 2.dp,
-    contentPadding = 16.dp
+    horizontalPadding = 16.dp
 )
 
 @Composable
@@ -49,5 +50,5 @@ private fun getSmallButtonSizeConfig() = ButtonSizeConfig(
     iconSize = 16.dp,
     progressBarSize = 16.dp,
     progressBarStroke = 1.dp,
-    contentPadding = 12.dp
+    horizontalPadding = 12.dp
 )

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.R
 import com.telefonica.mistica.compose.button.Button
@@ -88,27 +89,40 @@ fun Callout(
                         .padding(top = 16.dp),
                 ) {
                     when (buttonConfig) {
-                        CalloutButtonConfig.NONE -> { /* No buttons are shown */ }
+                        CalloutButtonConfig.NONE -> { /* No buttons are shown */
+                        }
                         CalloutButtonConfig.PRIMARY -> {
-                            PrimaryButton(primaryButtonText, onPrimaryButtonClick)
+                            PrimaryButton(text = primaryButtonText, onClick = onPrimaryButtonClick)
                         }
                         CalloutButtonConfig.PRIMARY_AND_LINK -> {
-                            PrimaryButton(primaryButtonText, onPrimaryButtonClick)
-                            LinkButton(linkText, onLinkClicked)
+                            PrimaryButton(
+                                modifier = Modifier.padding(end = 16.dp),
+                                text = primaryButtonText,
+                                onClick = onPrimaryButtonClick
+                            )
+                            LinkButton(text = linkText, onClick = onLinkClicked)
                         }
                         CalloutButtonConfig.SECONDARY -> {
-                            SecondaryButton(secondaryButtonText, onSecondaryButtonClick)
+                            SecondaryButton(text = secondaryButtonText, onClick = onSecondaryButtonClick)
                         }
                         CalloutButtonConfig.PRIMARY_AND_SECONDARY -> {
-                            PrimaryButton(primaryButtonText, onPrimaryButtonClick)
-                            SecondaryButton(secondaryButtonText, onSecondaryButtonClick)
+                            PrimaryButton(
+                                modifier = Modifier.padding(end = 16.dp),
+                                text = primaryButtonText,
+                                onClick = onPrimaryButtonClick
+                            )
+                            SecondaryButton(text = secondaryButtonText, onClick = onSecondaryButtonClick)
                         }
                         CalloutButtonConfig.SECONDARY_AND_LINK -> {
-                            SecondaryButton(secondaryButtonText, onSecondaryButtonClick)
-                            LinkButton(linkText, onLinkClicked)
+                            SecondaryButton(
+                                modifier = Modifier.padding(end = 16.dp),
+                                text = secondaryButtonText,
+                                onClick = onSecondaryButtonClick
+                            )
+                            LinkButton(text = linkText, onClick = onLinkClicked)
                         }
                         CalloutButtonConfig.LINK -> {
-                            LinkButton(linkText, onLinkClicked)
+                            LinkButton(text = linkText, onClick = onLinkClicked)
                         }
                     }
                 }
@@ -117,10 +131,9 @@ fun Callout(
             if (dismissable) {
                 Image(
                     modifier = Modifier
-                        .padding(start = 16.dp)
                         .clickable { onDismiss?.invoke() },
                     painter = painterResource(id = R.drawable.icn_cross),
-                    contentDescription = null
+                    contentDescription = stringResource(id = R.string.close_button_content_description)
                 )
             }
         }
@@ -129,37 +142,41 @@ fun Callout(
 
 @Composable
 private fun PrimaryButton(
+    modifier: Modifier = Modifier,
     text: String?,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(text, onClick, ButtonStyle.PRIMARY_SMALL)
+    CalloutButton(modifier, text, onClick, ButtonStyle.PRIMARY_SMALL)
 }
 
 @Composable
 private fun SecondaryButton(
+    modifier: Modifier = Modifier,
     text: String?,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(text, onClick, ButtonStyle.SECONDARY_SMALL)
+    CalloutButton(modifier, text, onClick, ButtonStyle.SECONDARY_SMALL)
 }
 
 @Composable
 private fun LinkButton(
+    modifier: Modifier = Modifier,
     text: String?,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(text, onClick, ButtonStyle.LINK)
+    CalloutButton(modifier, text, onClick, ButtonStyle.LINK)
 }
 
 @Composable
 private fun CalloutButton(
+    modifier: Modifier = Modifier,
     text: String?,
     onClick: (() -> Unit)?,
     style: ButtonStyle,
 ) {
     text?.let {
         Button(
-            modifier = Modifier.padding(end = 16.dp),
+            modifier = modifier,
             text = text,
             buttonStyle = style,
             onClickListener = { onClick?.invoke() }

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -96,9 +96,9 @@ fun Callout(
                         }
                         CalloutButtonConfig.PRIMARY_AND_LINK -> {
                             PrimaryButton(
-                                modifier = Modifier.padding(end = 16.dp),
                                 text = primaryButtonText,
-                                onClick = onPrimaryButtonClick
+                                modifier = Modifier.padding(end = 16.dp),
+                                onClick = onPrimaryButtonClick,
                             )
                             LinkButton(text = linkText, onClick = onLinkClicked)
                         }
@@ -107,17 +107,17 @@ fun Callout(
                         }
                         CalloutButtonConfig.PRIMARY_AND_SECONDARY -> {
                             PrimaryButton(
-                                modifier = Modifier.padding(end = 16.dp),
                                 text = primaryButtonText,
-                                onClick = onPrimaryButtonClick
+                                modifier = Modifier.padding(end = 16.dp),
+                                onClick = onPrimaryButtonClick,
                             )
                             SecondaryButton(text = secondaryButtonText, onClick = onSecondaryButtonClick)
                         }
                         CalloutButtonConfig.SECONDARY_AND_LINK -> {
                             SecondaryButton(
-                                modifier = Modifier.padding(end = 16.dp),
                                 text = secondaryButtonText,
-                                onClick = onSecondaryButtonClick
+                                modifier = Modifier.padding(end = 16.dp),
+                                onClick = onSecondaryButtonClick,
                             )
                             LinkButton(text = linkText, onClick = onLinkClicked)
                         }
@@ -142,44 +142,46 @@ fun Callout(
 
 @Composable
 private fun PrimaryButton(
-    modifier: Modifier = Modifier,
     text: String?,
+    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(modifier, text, onClick, ButtonStyle.PRIMARY_SMALL)
+    CalloutButton(text = text, onClick = onClick, style = ButtonStyle.PRIMARY_SMALL, modifier = modifier)
 }
 
 @Composable
 private fun SecondaryButton(
-    modifier: Modifier = Modifier,
     text: String?,
+    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(modifier, text, onClick, ButtonStyle.SECONDARY_SMALL)
+    CalloutButton(text, onClick, ButtonStyle.SECONDARY_SMALL, modifier)
 }
 
 @Composable
 private fun LinkButton(
-    modifier: Modifier = Modifier,
     text: String?,
+    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
-    CalloutButton(modifier, text, onClick, ButtonStyle.LINK)
+    CalloutButton(text, onClick, ButtonStyle.LINK, modifier, true)
 }
 
 @Composable
 private fun CalloutButton(
-    modifier: Modifier = Modifier,
     text: String?,
     onClick: (() -> Unit)?,
     style: ButtonStyle,
+    modifier: Modifier = Modifier,
+    invalidatePaddings: Boolean = false,
 ) {
     text?.let {
         Button(
             modifier = modifier,
             text = text,
             buttonStyle = style,
-            onClickListener = { onClick?.invoke() }
+            onClickListener = { onClick?.invoke() },
+            invalidatePaddings = invalidatePaddings,
         )
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -109,7 +109,7 @@ fun ListRowItem(
 
 @ExperimentalMaterialApi
 @Composable
-fun ListRowItemImp(
+private fun ListRowItemImp(
     modifier: Modifier = Modifier,
     icon: @Composable (() -> Unit)? = null,
     title: String? = null,


### PR DESCRIPTION
### :goal_net: What's the goal?
Improve Callout buttons margin. Check 'How can I test this?' section to see the main differences.

### :construction: How do we do it?
* Improve Margins definition for Callout compose Component
* Remove link buttons horizontal margin

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
|  Before   | After   | Touch target size | 
| ------------- |-------------|-------------|
|  <img width="346" alt="actual_bad" src="https://github.com/Telefonica/mistica-android/assets/51969539/eaf3954f-dbd3-4c40-826d-009f681eb579">  | <img width="345" alt="after_good" src="https://github.com/Telefonica/mistica-android/assets/51969539/f2ce4146-2dc8-40a0-a57e-c0113afa9a57"> | <img width="341" alt="after_touch_area" src="https://github.com/Telefonica/mistica-android/assets/51969539/b794c9f7-a09a-4df8-a82b-63f727d214a5"> |


