### PR TITLE
Make text button optional fix #ANDROID-13854

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/button2/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/button2/Button.kt
@@ -37,7 +37,7 @@ class Button @JvmOverloads constructor(
                 0
             )
             try {
-                text = textTypedArray.getText(0).toString()
+                text = textTypedArray.getText(0)?.toString() ?: ""
                 loadingText = styledAttrs.getString(R.styleable.Button_loadingText) ?: ""
                 isLoading = styledAttrs.getBoolean(R.styleable.Button_isLoading, false)
                 style = styledAttrs.getInt(R.styleable.Button_style, 0).toButtonStyle()

--- a/library/src/main/java/com/telefonica/mistica/button2/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/button2/Button.kt
@@ -19,12 +19,12 @@ class Button @JvmOverloads constructor(
 
     var text: String by mutableStateOf("")
     var icon: Int? by mutableStateOf(null)
+    var withChevron: Boolean by mutableStateOf(true)
 
     private var loadingText: String by mutableStateOf("")
     private var isLoading: Boolean by mutableStateOf(false)
     private var style: ButtonStyle by mutableStateOf(ButtonStyle.PRIMARY)
     private var isEnable: Boolean by mutableStateOf(true)
-    var withChevron: Boolean by mutableStateOf(true)
     private var onClick: () -> Unit by mutableStateOf({})
 
      init {

--- a/library/src/main/java/com/telefonica/mistica/button2/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/button2/Button.kt
@@ -18,10 +18,11 @@ class Button @JvmOverloads constructor(
 ) : AbstractMisticaComposeView(context, attrs, defStyleAttr) {
 
     var text: String by mutableStateOf("")
+    var icon: Int? by mutableStateOf(null)
+
     private var loadingText: String by mutableStateOf("")
     private var isLoading: Boolean by mutableStateOf(false)
     private var style: ButtonStyle by mutableStateOf(ButtonStyle.PRIMARY)
-    private var icon: Int? by mutableStateOf(null)
     private var isEnable: Boolean by mutableStateOf(true)
     var withChevron: Boolean by mutableStateOf(true)
     private var onClick: () -> Unit by mutableStateOf({})

--- a/library/src/main/res/layout/sheet_bottom_actions.xml
+++ b/library/src/main/res/layout/sheet_bottom_actions.xml
@@ -36,7 +36,6 @@
 			android:layout_height="wrap_content"
 			android:importantForAccessibility="yes"
 			android:layout_marginTop="16dp"
-			android:text=""
 			app:layout_constraintTop_toBottomOf="@id/sheet_action_secondary_button"
 			app:layout_constraintStart_toStartOf="parent"
 			app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
### :goal_net: What's the goal?
Make button2.button text xml attribute optional

### :construction: How do we do it?
* Check if returned value from typedArray is null
* Set empty in this case

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] No tests
