### PR TITLE
ANDROID-14001 Fix chevron glitch on button link

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/button/Button.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -148,8 +149,6 @@ private fun ButtonContent(
     withChevron: Boolean,
     enabled: Boolean,
 ) {
-    var textHeight by remember { mutableStateOf(0.dp) }
-    val density = LocalDensity.current
     AnimatedVisibility(
         modifier = Modifier.fillMaxHeight(),
         visible = !isLoading,
@@ -170,12 +169,7 @@ private fun ButtonContent(
             }
             Text(
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .onGloballyPositioned {
-                        textHeight = with(density) {
-                            it.size.height.toDp()
-                        }
-                    },
+                    .align(Alignment.CenterVertically),
                 text = text,
                 color = textColor,
                 style = size.textStyle,
@@ -183,19 +177,23 @@ private fun ButtonContent(
                 overflow = TextOverflow.Ellipsis,
             )
             if (withChevron) {
-                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.button_chevron_padding)))
-                CompositionLocalProvider(
-                    LocalContentAlpha provides if (enabled) ContentAlpha.high else ContentAlpha.disabled,
+                Box(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .aspectRatio(CHEVRON_ASPECT_RATIO)
+                        .align(Alignment.CenterVertically)
                 ) {
-                    Image(
-                        painterResource(id = R.drawable.icn_chevron),
-                        null,
-                        modifier = Modifier
-                            .height(textHeight)
-                            .aspectRatio(CHEVRON_ASPECT_RATIO)
-                            .align(Alignment.CenterVertically),
-                        colorFilter = ColorFilter.tint(style.textColor.copy(LocalContentAlpha.current)),
-                    )
+                    Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.button_chevron_padding)))
+                    CompositionLocalProvider(
+                        LocalContentAlpha provides if (enabled) ContentAlpha.high else ContentAlpha.disabled,
+                    ) {
+                        Image(
+                            painterResource(id = R.drawable.icn_chevron),
+                            null,
+                            modifier = Modifier.align(Alignment.Center),
+                            colorFilter = ColorFilter.tint(style.textColor.copy(LocalContentAlpha.current)),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
### :goal_net: What's the goal?
There is a UI glitch when a button2 with "link" style and chevron is rendered because of how chevron height is calculated. See the following video:

https://github.com/Telefonica/mistica-android/assets/47142570/e02ac130-279c-4296-b6ae-a7a0e9a35ad6

### :construction: How do we do it?
Use built in `IntrinsicSize.Min` as the chevron height instead of listening to the height of the text which makes the chevron to switch from big to small very quickly.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 23.

### :test_tube: How can I test this?
- [x] [Mistica App download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/379)
- [x] 🖼️ Screenshots

https://github.com/Telefonica/mistica-android/assets/47142570/7236b0bb-55f9-4c01-abf9-209738f50081


