### PR TITLE
ANDROID-13896 Ignore appcenter link in link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica/distribution_groups/public


### PR DESCRIPTION
### :goal_net: What's the goal?
Ignore appcenter link in link checker as it's failing because the user-agent of the request is not a browser.