### PR TITLE
Remove default padding in compose wrap button

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/button2/Button.kt
+++ b/library/src/main/java/com/telefonica/mistica/button2/Button.kt
@@ -85,6 +85,7 @@ class Button @JvmOverloads constructor(
                 enabled = isEnable,
                 icon = icon,
                 withChevron = withChevron,
+                invalidatePaddings = true,
                 onClickListener = onClick
             )
         }


### PR DESCRIPTION
### :goal_net: What's the goal?
Remove default padding in compose wrap button (button2.Button)

When we use button2.Button in xml, it has a default padding. We should add the option to remove this default padding

### :construction: How do we do it?
* Add a attr to set default padding

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
No tests
