### PR TITLE
ANDROID-14133 Update roborazzi to 1.7.0

### DIFF
--- a/.github/actions/generate-html-report/scripts/generate-html-report.sh
+++ b/.github/actions/generate-html-report/scripts/generate-html-report.sh
@@ -2,7 +2,7 @@
 
 mkdir reports
 touch reports/report.html
-cp */screenshots/*_compare.png reports/
+cp */build/outputs/roborazzi/*_compare.png reports/
 files=$(find . -type f -name "*_compare.png" | grep "reports/")
 {
   echo '<!doctype html>'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         accompanist_version = "0.30.1"
         coil_version = '2.2.2'
         constraintComposeVersion = '1.0.1'
-        roborazzi_version = "1.4.0"
+        roborazzi_version = "1.7.0"
     }
     repositories {
         google()
@@ -28,7 +28,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.android' version '1.5.21' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
-    id "io.github.takahirom.roborazzi" version '1.4.0' apply false
+    id "io.github.takahirom.roborazzi" version '1.7.0' apply false
 }
 
 allprojects {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
-    testImplementation 'androidx.compose.ui:ui-test-manifest:1.0.5'
+    testImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
     testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation "io.github.takahirom.roborazzi:roborazzi:$roborazzi_version"
     testImplementation "io.github.takahirom.roborazzi:roborazzi-compose:$roborazzi_version"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     testImplementation 'androidx.compose.ui:ui-test-manifest:1.0.5'
-    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation "io.github.takahirom.roborazzi:roborazzi:$roborazzi_version"
     testImplementation "io.github.takahirom.roborazzi:roborazzi-compose:$roborazzi_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"


### PR DESCRIPTION
### :goal_net: What's the goal?
Update roborazzi from 1.4.0 to the latest stable version 1.7.0

### :construction: How do we do it?
- Update the lib.
- Update the location where the compare images are created.
- Also updated roboelectric and ui-test-manifest

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
https://github.com/Telefonica/mistica-android/actions/runs/7298913782
<img width="1510" alt="Screenshot 2023-12-22 at 11 09 19" src="https://github.com/Telefonica/mistica-android/assets/13270085/407434a1-27db-4209-b8f4-c29c3177e00c">
https://github.com/Telefonica/mistica-android/actions/runs/7298905162
<img width="1497" alt="Screenshot 2023-12-22 at 11 15 28" src="https://github.com/Telefonica/mistica-android/assets/13270085/3ecc4f68-31c4-4617-b5b6-83f23b16b482">
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
