### PR TITLE
ANDROID-14117 Using containers context as others methods

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
@@ -225,7 +225,7 @@ private fun Children.toView(context: Context, onSheetTapped: InternalOnSheetTapp
     is ListSingleSelection -> this.toView(context, onSheetTapped)
     is ListActions -> this.toView(context, onSheetTapped)
     is ListInformative -> this.toView(context)
-    is BottomActions -> this.toView(context, onSheetTapped, container)
+    is BottomActions -> this.toView(onSheetTapped, container)
 }
 
 private fun ListSingleSelection.toView(context: Context, onSheetTapped: InternalOnSheetTapped): View =
@@ -246,8 +246,8 @@ private fun ListInformative.toView(context: Context): View =
         it.adapter = InformativeListAdapter(this.elements.mapToInformativeViewData())
     }
 
-private fun BottomActions.toView(context: Context, onSheetTapped: InternalOnSheetTapped, container: ViewGroup): View {
-    return LayoutInflater.from(context).inflate(R.layout.sheet_bottom_actions, container, false)
+private fun BottomActions.toView(onSheetTapped: InternalOnSheetTapped, container: ViewGroup): View {
+    return LayoutInflater.from(container.context).inflate(R.layout.sheet_bottom_actions, container, false)
         .also { view ->
             setBottomActionsContent(view, onSheetTapped)
         }


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix BottomSheet actions fonts error.

### :construction: How do we do it?
* Using containers context. Same context as other views.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 23.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team


Before: https://github.com/Telefonica/mistica-android/assets/8106237/dd95ad13-4cb2-4c32-a124-5a6c746a5796
After: https://github.com/Telefonica/mistica-android/assets/8106237/e9905095-c07e-4951-bf26-4a3268d8fe96

