### PR TITLE
ANDROID-14177 Allow compose compatibility theme overrides

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
@@ -33,6 +33,9 @@ fun MisticaTheme(
     val context = LocalContext.current
     LaunchedEffect(key1 = brand) {
         context.setTheme(brand.compatibilityTheme)
+        brand.compatibilityThemeOverrides.forEach {
+            context.theme.applyStyle(it, true)
+        }
     }
 
     val colors = if (darkTheme) {

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
@@ -10,6 +10,8 @@ import com.telefonica.mistica.compose.title.TitleStyle
 
 interface Brand {
     val compatibilityTheme: Int
+    val compatibilityThemeOverrides: List<Int>
+        get() = emptyList()
     val lightColors: MisticaColors
     val darkColors: MisticaColors
     val fontFamily: FontFamily


### PR DESCRIPTION
### :goal_net: What's the goal?

Right now there is a recurrent scenario where we need to apply some override over the base theme because we can't make a theme to inherit from two parents. In one of our client apps, and in particular for Vivo app, we have been overriding our base theme (which inherits from MisticaTheme_Vivo) with another style (which inherits from VivoNewOverride, which is actually a copy of MisticaTheme_Vivo).

We need to accomplish the same result but with compose Brand interface. Right now this interface allows us to set a compatibility theme that is used in those composables implemented using AndroidViews (which use legacy xml components under the hood).

I'm proposing a solution where multiple compatibility themes can be provided to the Brand class so a base one is set as the base theme and the others will act as overrides in the same way on our example described above.

### :construction: How do we do it?
Add a new `compatibilityThemeOverrides: List<Int>` field to `Brand` interface. Then I used this list of themes to override the base theme on `MisticaTheme` composable, right after the base theme is set.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
