### PR TITLE
ADD - new presets #ANDROID-14321

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Texts.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Texts.kt
@@ -17,6 +17,14 @@ fun Texts() {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
+            text = "Preset 10",
+            style = MisticaTheme.typography.preset10
+        )
+        Text(
+            text = "Preset 9",
+            style = MisticaTheme.typography.preset9
+        )
+        Text(
             text = "Preset 8",
             style = MisticaTheme.typography.preset8
         )

--- a/catalog/src/main/res/layout/text_presets_fragment_catalog.xml
+++ b/catalog/src/main/res/layout/text_presets_fragment_catalog.xml
@@ -15,6 +15,20 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
+            android:text="Preset 10"
+            android:textAppearance="@style/AppTheme.TextAppearance.Preset10" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="Preset 9"
+            android:textAppearance="@style/AppTheme.TextAppearance.Preset9" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:text="Preset 8"
             android:textAppearance="@style/AppTheme.TextAppearance.Preset8" />
 

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/MisticaTheme.kt
@@ -52,6 +52,8 @@ fun MisticaTheme(
     }.apply {
         updateWith(
             fontFamily = brand.fontFamily,
+            preset10FontWeight = brand.preset10FontWeight,
+            preset9FontWeight = brand.preset9FontWeight,
             preset8FontWeight = brand.preset8FontWeight,
             preset7FontWeight = brand.preset7FontWeight,
             preset6FontWeight = brand.preset6FontWeight,

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/BlauBrand.kt
@@ -19,6 +19,10 @@ object BlauBrand : Brand {
 
     override val preset8FontWeight = BlauBrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = BlauBrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = BlauBrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = BlauBrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = BlauBrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/Brand.kt
@@ -18,6 +18,8 @@ interface Brand {
     val preset6FontWeight: FontWeight
     val preset7FontWeight: FontWeight
     val preset8FontWeight: FontWeight
+    val preset9FontWeight: FontWeight
+    val preset10FontWeight: FontWeight
     val cardTitleFontWeight: FontWeight
     val buttonFontWeight: FontWeight
     val linkFontWeight: FontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/MovistarBrand.kt
@@ -21,6 +21,10 @@ object MovistarBrand : Brand {
 
     override val preset8FontWeight = MovistarBrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = MovistarBrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = MovistarBrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = MovistarBrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = MovistarBrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/O2Brand.kt
@@ -19,6 +19,10 @@ object O2Brand : Brand {
 
     override val preset8FontWeight = O2BrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = O2BrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = O2BrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = O2BrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = O2BrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/TelefonicaBrand.kt
@@ -20,6 +20,10 @@ object TelefonicaBrand : Brand {
 
     override val preset8FontWeight = TelefonicaBrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = TelefonicaBrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = TelefonicaBrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = TelefonicaBrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = TelefonicaBrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoBrand.kt
@@ -19,6 +19,10 @@ object VivoBrand : Brand {
 
     override val preset8FontWeight = VivoBrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = VivoBrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = VivoBrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = VivoBrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = VivoBrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoNewBrand.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/brand/VivoNewBrand.kt
@@ -19,6 +19,10 @@ object VivoNewBrand : Brand {
 
     override val preset8FontWeight = VivoNewBrandFontWeights.text8FontWeight
 
+    override val preset9FontWeight = VivoNewBrandFontWeights.text9FontWeight
+
+    override val preset10FontWeight = VivoNewBrandFontWeights.text10FontWeight
+
     override val cardTitleFontWeight = VivoNewBrandFontWeights.cardTitleFontWeight
 
     override val buttonFontWeight = VivoNewBrandFontWeights.buttonFontWeight

--- a/library/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/theme/text/MisticaTypography.kt
@@ -16,6 +16,12 @@ class MisticaTypography(
     private var fontFamily: FontFamily = FontFamily.SansSerif,
     private var defaultTextColor: Color = Color.Unspecified,
 ) {
+    var preset10 by mutableStateOf(buildPreset10(), structuralEqualityPolicy())
+        private set
+
+    var preset9 by mutableStateOf(buildPreset9(), structuralEqualityPolicy())
+        private set
+
     var preset8 by mutableStateOf(buildPreset8(), structuralEqualityPolicy())
         private set
 
@@ -87,6 +93,24 @@ class MisticaTypography(
             letterSpacing = 0.sp,
             fontFamily = fontFamily,
             color = defaultTextColor,
+        )
+
+    private fun buildPreset10(
+        fontWeight: FontWeight = FontWeight.Bold,
+    ) =
+        buildBaseStyle().copy(
+            fontSize = 48.sp,
+            lineHeight = 56.sp,
+            fontWeight = fontWeight,
+        )
+
+    private fun buildPreset9(
+        fontWeight: FontWeight = FontWeight.Bold,
+    ) =
+        buildBaseStyle().copy(
+            fontSize = 40.sp,
+            lineHeight = 48.sp,
+            fontWeight = fontWeight,
         )
 
     private fun buildPreset8(
@@ -236,6 +260,8 @@ class MisticaTypography(
 
     fun updateWith(
         fontFamily: FontFamily,
+        preset10FontWeight: FontWeight,
+        preset9FontWeight: FontWeight,
         preset8FontWeight: FontWeight,
         preset7FontWeight: FontWeight,
         preset6FontWeight: FontWeight,
@@ -250,6 +276,8 @@ class MisticaTypography(
         presetTabsLabelFontSize: TextUnit,
     ) {
         this.fontFamily = fontFamily
+        preset10 = buildPreset10(fontWeight = preset10FontWeight)
+        preset9 = buildPreset9(fontWeight = preset9FontWeight)
         preset8 = buildPreset8(fontWeight = preset8FontWeight)
         preset7 = buildPreset7(fontWeight = preset7FontWeight)
         preset6 = buildPreset6(fontWeight = preset6FontWeight)

--- a/library/src/main/res/values/styles_fonts.xml
+++ b/library/src/main/res/values/styles_fonts.xml
@@ -5,6 +5,20 @@
         <item name="android:letterSpacing">0.0</item>
     </style>
 
+    <style name="AppTheme.TextAppearance.Preset10">
+        <item name="android:textSize">48sp</item>
+        <item name="lineHeight">56sp</item>
+        <item name="android:fontFamily">?text10Font</item>
+        <item name="android:textStyle">?text10TextStyle</item>
+    </style>
+
+    <style name="AppTheme.TextAppearance.Preset9">
+        <item name="android:textSize">40sp</item>
+        <item name="lineHeight">48sp</item>
+        <item name="android:fontFamily">?text9Font</item>
+        <item name="android:textStyle">?text9TextStyle</item>
+    </style>
+
     <style name="AppTheme.TextAppearance.Preset8">
         <item name="android:textSize">32sp</item>
         <item name="lineHeight">40sp</item>


### PR DESCRIPTION
### :goal_net: What's the goal?
Add preset-9 and preset-10 to Mistica app. These new presets have just been defined on figma, but not implemented.

### :construction: How do we do it?
_Provide a description of the implementation. A list of steps would be ideal._
* _Add them to compose: create new properties for Brand and set inside brands_
* _Add to xml_
* _Add new Texts for the app both compose and xml tabs_

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
![Captura de pantalla 2024-02-15 a las 13 17 34](https://github.com/Telefonica/mistica-android/assets/76561300/9103fc45-d446-4d12-8d6c-5e1bb1df8a99)
![Captura de pantalla 2024-02-15 a las 13 17 38](https://github.com/Telefonica/mistica-android/assets/76561300/6054cd61-90f4-45be-94df-64b9f371eafc)

- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team


