### PR TITLE
ANDROID-14416 Allow tint for RowItem icons

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +31,7 @@ sealed class ListRowIcon(val contentDescription: String?) {
         val painter: Painter? = null,
         private val description: String? = null,
         val modifier: Modifier = Modifier,
+        val tint: Color? = null,
     ) : ListRowIcon(description)
 
     data class CircleIcon(
@@ -36,6 +39,7 @@ sealed class ListRowIcon(val contentDescription: String?) {
         val backgroundColor: Color = Color.Transparent,
         private val description: String? = null,
         val modifier: Modifier = Modifier,
+        val tint: Color? = null,
     ) : ListRowIcon(description)
 
     data class SmallAsset(
@@ -88,7 +92,8 @@ sealed class ListRowIcon(val contentDescription: String?) {
                 Icon(
                     painter = painter,
                     modifier = Modifier.size(24.dp),
-                    contentDescription = contentDescription
+                    contentDescription = contentDescription,
+                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
                 )
             }
         }
@@ -104,7 +109,8 @@ sealed class ListRowIcon(val contentDescription: String?) {
            painter?.let {
                 Icon(
                     painter = painter,
-                    contentDescription = contentDescription
+                    contentDescription = contentDescription,
+                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
                 )
             }
         }

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowIcon.kt
@@ -93,7 +93,7 @@ sealed class ListRowIcon(val contentDescription: String?) {
                     painter = painter,
                     modifier = Modifier.size(24.dp),
                     contentDescription = contentDescription,
-                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
                 )
             }
         }
@@ -110,7 +110,7 @@ sealed class ListRowIcon(val contentDescription: String?) {
                 Icon(
                     painter = painter,
                     contentDescription = contentDescription,
-                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+                    tint = tint ?: LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
                 )
             }
         }

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -304,9 +304,10 @@ fun ListRowItemPreview() {
                 subtitle = "Subtitle",
                 description = "Description",
                 listRowIcon = ListRowIcon.CircleIcon(
-                    painter = painterResource(id = R.drawable.icn_arrow),
+                    painter = painterResource(id = R.drawable.icn_creditcard),
                     backgroundColor = MisticaTheme.colors.neutralLow,
-                    description = null
+                    description = null,
+                    tint = Color.Red
                 ),
                 trailing = {
                     Checkbox(


### PR DESCRIPTION
### :goal_net: What's the goal?
Currently the ListRowItem component in Mistica only admits a "ListRowIcon" param where we can only define a painterResource. This limitation causes that Icon types are tinted with default color (Black) instead of its original color.

We need to add a new optional param to allow original tint (tint= Color.Unspecified) or a custom tint color.

### :construction: How do we do it?
* Create new optional parameter "tint: Color? = null" for Icon builders data classes.
* Use this value when composing the Icon.
  * If it's not provided (null) use the default color keeping the same behavior as before.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
<img width="987" alt="Captura de pantalla 2024-03-06 a las 16 00 39" src="https://github.com/Telefonica/mistica-android/assets/51969539/94f62174-a6b6-4ee2-be91-acf7da54c801">

