### PR TITLE
ANDROID-14406 update roborazzi to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         accompanist_version = "0.32.0"
         coil_version = '2.5.0'
         constraintComposeVersion = '1.0.1'
-        roborazzi_version = "1.7.0"
+        roborazzi_version = "1.10.1"
     }
     repositories {
         google()
@@ -29,7 +29,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.android' version '1.5.21' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
-    id "io.github.takahirom.roborazzi" version '1.7.0' apply false
+    id "io.github.takahirom.roborazzi" version '1.10.1' apply false
 }
 
 allprojects {


### PR DESCRIPTION
### :goal_net: What's the goal?
Update roborazzi in mística to have the latest updates and fixes of the lib and to then check its accessibility debug info in training sessions.

### :construction: How do we do it?
- Updating roborazzi version to 1.10.1
- Force error in screenshots on another branch and checking that the report is ok.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
This branch:
<img width="1112" alt="Screenshot 2024-03-08 at 11 26 23" src="https://github.com/Telefonica/mistica-android/assets/13270085/27f71ba3-9f41-4d23-9c98-ed03616cc5f1">
Forced errors:
<img width="1112" alt="Screenshot 2024-03-08 at 11 30 40" src="https://github.com/Telefonica/mistica-android/assets/13270085/d4838cad-ffb8-4554-be32-e02985955568">
And the report:
<img width="1238" alt="Screenshot 2024-03-08 at 11 32 15" src="https://github.com/Telefonica/mistica-android/assets/13270085/654569d8-5479-4034-8bf8-ccd091353111">
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
