### PR TITLE
ANDROID-14490 expose content description in sheet actions

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/sheet/SheetModel.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/SheetModel.kt
@@ -49,6 +49,7 @@ data class RowSelectable(
 data class RowAction(
     val id: String,
     val title: String,
+    val contentDescription: String? = null,
     val style: RowActionStyle = RowActionStyle.Default,
     @Deprecated("Use new field rowAsset. RowAsset will have preference over asset")
     val asset: Drawable? = null,

--- a/library/src/main/java/com/telefonica/mistica/sheet/children/list/ListElementViewData.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/children/list/ListElementViewData.kt
@@ -30,6 +30,7 @@ internal sealed class ListElementViewData(
         override val id: String,
         val onClickListener: OnClickListener,
         val title: String,
+        val contentDescription: String,
         val rowActionStyle: RowActionStyleViewData = RowActionStyleViewData.Default,
         val asset: RowAssetViewData?,
     ) : ListElementViewData(

--- a/library/src/main/java/com/telefonica/mistica/sheet/children/list/adapter/ActionsListAdapter.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/children/list/adapter/ActionsListAdapter.kt
@@ -26,6 +26,7 @@ internal class ActionsListAdapter(val items: List<RowActionViewData>) : Recycler
     override fun onBindViewHolder(holder: ActionsListViewHolder, position: Int) {
         val item = items[position]
         holder.text.text = item.title
+        holder.text.contentDescription = item.contentDescription
         if (item.asset != null) {
             holder.icon.loadRowAsset(item.asset)
             holder.icon.visibility = View.VISIBLE

--- a/library/src/main/java/com/telefonica/mistica/sheet/viewDataModelMappers.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/viewDataModelMappers.kt
@@ -50,6 +50,7 @@ private fun RowAction.mapToViewData(childrenId: String, onBottomSheetClicked: In
             }
         },
         title = title,
+        contentDescription = contentDescription ?: title,
         asset = getRowAssetViewData(asset, rowAsset),
         rowActionStyle = when (style) {
             RowActionStyle.Default -> RowActionStyleViewData.Default

--- a/library/src/main/java/com/telefonica/mistica/util/AccesibilityElementType.kt
+++ b/library/src/main/java/com/telefonica/mistica/util/AccesibilityElementType.kt
@@ -1,0 +1,6 @@
+package com.telefonica.mistica.util
+
+enum class AccesibilityElementType {
+    Button,
+    Link,
+}


### PR DESCRIPTION
### :goal_net: What's the goal?
Expose the bottom sheet actions content description so that any app can pass a content description for that elements.
Also add AccesibilityElementType in there as an enum for links and buttons.

### :construction: How do we do it?
- Expose contentDescription in Sheet component by adding it to RowAction and the mapper and adapter of it.
- Added AccessibilityElementType as this is going to be used in android and iOS for accessibility strings.

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos
I've created a version in maven local and then used it in novum adding " link" to the content description of these actions and checked with talkback (enable audio):

https://github.com/Telefonica/mistica-android/assets/13270085/ef9ea1f7-b569-4727-a7ab-e1db1f85876a

- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
