### PR TITLE
ANDROID-14548 update close translation

### DIFF
--- a/library/src/main/res/values-de/strings_content_descriptions.xml
+++ b/library/src/main/res/values-de/strings_content_descriptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views" tools:ignore="Typos">Schliessen</string>
+    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views" tools:ignore="Typos">Fenster schließen</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">Neue Inhalte</string>
 </resources>

--- a/library/src/main/res/values-en/strings_content_descriptions.xml
+++ b/library/src/main/res/values-en/strings_content_descriptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Dismiss</string>
+    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Close window</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">New content</string>
 </resources>

--- a/library/src/main/res/values-es/strings_content_descriptions.xml
+++ b/library/src/main/res/values-es/strings_content_descriptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Cerrar</string>
+    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Cerrar ventana</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">Contenido nuevo</string>
 </resources>

--- a/library/src/main/res/values-pt/strings_content_descriptions.xml
+++ b/library/src/main/res/values-pt/strings_content_descriptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">
-Fechar janela</string>
+    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Fechar janela</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">Novos conteúdos</string>
 </resources>

--- a/library/src/main/res/values-pt/strings_content_descriptions.xml
+++ b/library/src/main/res/values-pt/strings_content_descriptions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">
-Fechar</string>
+Fechar janela</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">Novos conteúdos</string>
 </resources>

--- a/library/src/main/res/values/strings_content_descriptions.xml
+++ b/library/src/main/res/values/strings_content_descriptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Dismiss</string>
+    <string name="close_button_content_description" comment="Content description for image views that act as buttons for dismissing views">Close window</string>
     <string name="badge_notification_description" comment="Content description for non numeric badge">Contenido nuevo</string>
 </resources>


### PR DESCRIPTION
### :goal_net: What's the goal?
Update string used for closing the bottom sheet as content description.
### :construction: How do we do it?
- Asking for the translation and updating it.
The translations:
es_es: Cerrar ventana
de_de: Fenster schließen
en_us: Close window
pt_br: Fechar janela

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [ ] Tested with dark mode.
- [ ] Tested with API 21.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos

(turn the volume ON)

https://github.com/Telefonica/mistica-android/assets/13270085/6adbb667-10e5-4f6f-9264-5e888b3659d4

- [ ] Mistica App QR or download link
