### PR TITLE
Update full width scaleType to center crop

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/emptystate/screen/EmptyStateScreenView.kt
@@ -255,7 +255,8 @@ class EmptyStateScreenView @JvmOverloads constructor(
         }
         image.scaleType = when (imageSize) {
             IMAGE_SIZE_ICON -> ImageView.ScaleType.CENTER_INSIDE
-            else -> ImageView.ScaleType.FIT_START
+            IMAGE_SIZE_SMALL -> ImageView.ScaleType.FIT_START
+            else -> ImageView.ScaleType.CENTER_CROP
         }
         image.layoutParams = image.layoutParams.apply {
             width = imageWidth


### PR DESCRIPTION
### :goal_net: What's the goal?
We need to show the fullWidth mode image to fit entire screen

### :construction: How do we do it?
* Add else condition to set CenterCrop in full_width mode

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [x] 🖼️ Screenshots/Videos
- [x] Mistica App QR or download link
- [x] Reviewed by Mistica design team

BEFORE
![Captura de pantalla 2024-04-25 a las 12 17 08](https://github.com/Telefonica/mistica-android/assets/42326032/0ca6c480-effb-4e66-8e84-bcbd65bcc135)


AFTER
![Captura de pantalla 2024-04-25 a las 10 43 47](https://github.com/Telefonica/mistica-android/assets/42326032/72b18014-0b62-4881-8030-78e106369905)
