### PR TITLE
ANDROID-14597 title view heading

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Titles.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Titles.kt
@@ -32,6 +32,7 @@ private fun DefaultTitles() {
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
         text = "Short default title",
+        isTitleHeading = true,
     )
     Title(
         modifier = Modifier.padding(bottom = 8.dp),
@@ -59,6 +60,7 @@ private fun TitlesWithStyleOverridden(
         modifier = Modifier.padding(bottom = 8.dp),
         style = style,
         text = "Short title $style",
+        isTitleHeading = true,
     )
     Title(
         modifier = Modifier.padding(bottom = 8.dp),

--- a/catalog/src/main/res/layout/title_catalog.xml
+++ b/catalog/src/main/res/layout/title_catalog.xml
@@ -18,6 +18,7 @@
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
+				app:isTitleHeading="true"
 				app:title="Short default Title" />
 
 		<com.telefonica.mistica.title.TitleView
@@ -48,6 +49,7 @@
 				android:layout_height="wrap_content"
 				android:layout_marginBottom="8dp"
 				app:titleStyle="title1"
+				app:isTitleHeading="true"
 				app:title="Some title 1" />
 
 		<com.telefonica.mistica.title.TitleView

--- a/library/src/main/java/com/telefonica/mistica/compose/title/Title.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/title/Title.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -14,6 +16,7 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 @Composable
 fun Title(
     modifier: Modifier = Modifier,
+    isTitleHeading: Boolean = false,
     style: TitleStyle = MisticaTheme.values.titleStyle,
     text: String,
     linkText: String? = null,
@@ -24,6 +27,13 @@ fun Title(
     ) {
         TitleText(
             modifier = Modifier
+                .then(
+                    if (isTitleHeading) {
+                        Modifier.semantics { heading() }
+                    } else {
+                        Modifier
+                    }
+                )
                 .weight(1F)
                 .alignByBaseline(),
             text = text,

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -54,6 +54,11 @@ import com.telefonica.mistica.util.setAlpha
     ),
     BindingMethod(
         type = ListRowView::class,
+        attribute = "listRowIsTitleHeading",
+        method = "setIsTitleHeading"
+    ),
+    BindingMethod(
+        type = ListRowView::class,
         attribute = "listRowSubtitle",
         method = "setSubtitle"
     ),

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -55,7 +55,7 @@ import com.telefonica.mistica.util.setAlpha
     BindingMethod(
         type = ListRowView::class,
         attribute = "listRowIsTitleHeading",
-        method = "setIsTitleHeading"
+        method = "setTitleHeading"
     ),
     BindingMethod(
         type = ListRowView::class,

--- a/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
+++ b/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
@@ -30,6 +30,11 @@ import com.telefonica.mistica.util.setTextPreset
     ),
     BindingMethod(
         type = TitleView::class,
+        attribute = "isTitleHeading",
+        method = "setIsTitleHeading"
+    ),
+    BindingMethod(
+        type = TitleView::class,
         attribute = "link",
         method = "setLink"
     ),

--- a/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
+++ b/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
@@ -7,7 +7,9 @@ import android.widget.TextView
 import androidx.annotation.AttrRes
 import androidx.annotation.IntDef
 import androidx.annotation.StyleRes
+import androidx.annotation.VisibleForTesting
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.telefonica.mistica.R
@@ -71,6 +73,13 @@ class TitleView @JvmOverloads constructor(
             titleTextView.setTextAndVisibility(styledAttrs.getText(R.styleable.TitleView_title))
             setTitleStyle(styledAttrs.getInt(R.styleable.TitleView_titleStyle, -1))
 
+            styledAttrs.getBoolean(
+                R.styleable.TitleView_isTitleHeading,
+                false
+            )
+                .takeIf { it }
+                ?.let { setTitleHeading() }
+
             linkTextView.setTextAndVisibility(styledAttrs.getText(R.styleable.TitleView_link))
 
             styledAttrs.recycle()
@@ -78,6 +87,9 @@ class TitleView @JvmOverloads constructor(
     }
 
     fun getTitle(): String = titleTextView.text.toString()
+
+    @VisibleForTesting
+    internal fun getTitleTextView(): TextView = titleTextView
 
     fun setTitle(text: CharSequence?) {
         titleTextView.setTextAndVisibility(text)
@@ -93,6 +105,10 @@ class TitleView @JvmOverloads constructor(
         titleTextView.setTextPreset(styleConfig.preset)
         titleTextView.setTextColor(context.getThemeColor(styleConfig.colorAttrRes))
         titleTextView.isAllCaps = styleConfig.isAllCaps
+    }
+
+    fun setTitleHeading() {
+        ViewCompat.setAccessibilityHeading(titleTextView, true)
     }
 
     fun getLink(): String = linkTextView.text.toString()

--- a/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
+++ b/library/src/main/java/com/telefonica/mistica/title/TitleView.kt
@@ -31,7 +31,7 @@ import com.telefonica.mistica.util.setTextPreset
     BindingMethod(
         type = TitleView::class,
         attribute = "isTitleHeading",
-        method = "setIsTitleHeading"
+        method = "setTitleHeading"
     ),
     BindingMethod(
         type = TitleView::class,

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -126,6 +126,7 @@
 
     <declare-styleable name="TitleView">
         <attr name="title" format="string" />
+        <attr name="isTitleHeading" format="boolean" />
         <attr name="titleStyle" format="enum">
             <enum name="title1" value="0" />
             <enum name="title2" value="1" />

--- a/library/src/test/java/com/telefonica/mistica/compose/title/TitleKtTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/compose/title/TitleKtTest.kt
@@ -1,0 +1,56 @@
+package com.telefonica.mistica.compose.title
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.isHeading
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class TitleKtTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `check the title is not set with accessibility heading by default`() = test {
+        `given Title`()
+
+        composeTestRule.onNodeWithText(textValue).assert(!isHeading())
+    }
+
+    @Test
+    fun `check the title is set with accessibility heading when isHeading is set`() = test {
+        `given Title`(isHeading = true)
+
+        composeTestRule.onNodeWithText(textValue).assert(isHeading())
+    }
+
+    private fun TestScope.`given Title`(isHeading: Boolean = false) {
+        `when Title`(isHeading)
+    }
+
+    private fun TestScope.`when Title`(isHeading: Boolean = false) {
+        composeTestRule.setContent {
+            MisticaTheme(brand = MovistarBrand) {
+                Title(
+                    text = textValue,
+                    isTitleHeading = isHeading
+                )
+            }
+        }
+    }
+
+    private fun test(block: TestScope.() -> Unit) {
+        TestScope().block()
+    }
+
+    private class TestScope {
+        val textValue = "textValue"
+    }
+
+}

--- a/library/src/test/java/com/telefonica/mistica/title/TitleViewTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/title/TitleViewTest.kt
@@ -1,0 +1,54 @@
+package com.telefonica.mistica.title
+
+import android.widget.FrameLayout
+import androidx.test.ext.junit.rules.activityScenarioRule
+import com.telefonica.mistica.DummyActivity
+import com.telefonica.mistica.R
+import com.telefonica.mistica.testutils.ScreenshotsTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+internal class TitleViewTest: ScreenshotsTest() {
+    @get:Rule
+    val rule = activityScenarioRule<DummyActivity>()
+
+    @Test
+    fun `check TitleView has accessibility heading when setTitleHeading is invoked`() {
+        checkTitleView {
+            setTitle("Title")
+            setTitleHeading()
+
+            assertTrue(this.getTitleTextView().isAccessibilityHeading)
+        }
+    }
+
+    @Test
+    fun `check TitleView has NOT accessibility heading when setTitleHeading is not invoked`() {
+        checkTitleView {
+            setTitle("Title")
+
+            assertFalse(this.getTitleTextView().isAccessibilityHeading)
+        }
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun `check TextInput dark`() {
+        checkTitleView()
+    }
+
+    private fun checkTitleView(onTitleView: TitleView.() -> Unit = {}) {
+        rule.scenario.onActivity { activity ->
+            val wrapper: FrameLayout = activity.findViewById(R.id.dummy_activity_wrapper)
+            val titleView = TitleView(activity)
+            wrapper.addView(titleView)
+            titleView.onTitleView()
+        }
+    }
+}


### PR DESCRIPTION
### :goal_net: What's the goal?
The title of TitleView component should be able to be set with accessibility heading.

### :construction: How do we do it?
- Add isTitleHeading to TitleView
- Add isTitleHeading parameter to Title composable
- Add few samples in the catalog.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, update [UPGRADING.md](../UPGRADING.md) to inform users how to proceed. If no updates are necessary, indicate so.
- [x] Tested with dark mode.
- [x] Tested with API 21.

### :test_tube: How can I test this?
https://github.com/Telefonica/mistica-android/assets/13270085/0cc6d8c6-9fb9-4e40-8e37-0e4bf754678a
- [x] Mistica App QR or [download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/481)