### PR TITLE
ANDROID-14628 Not include release notes in the release notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
           needs: ${{ toJson(needs) }}
           job: ${{ toJson(job) }}
           steps: ${{ toJson(steps) }}
-          overwrite: "{title: `New Mistica version published ${{ github.event.release.tag_name }}`, text:`Release Notes:\n ${{ github.event.release.body }}`}"
+          overwrite: "{title: `New Mistica version published ${{ github.event.release.tag_name }}`, text:`Release Notes:\n ${{ github.event.release.html_url }}`}"


### PR DESCRIPTION
### :goal_net: What's the goal?
Not include release notes in the release notification. Just include the link to the release to avoid errors when it contains markdown.

I've checked with the GitHub API that `html_url` is the right field:
![imagen](https://github.com/Telefonica/mistica-android/assets/2582348/ae799904-1b90-4975-9f0f-85a51c65953d)
