### PR TITLE
ANDROID-14752 Fix Badge

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/BadgesCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/BadgesCatalogFragment.kt
@@ -40,21 +40,18 @@ class BadgesCatalogFragment : Fragment() {
                 badgeVisible = !badgeVisible
             }
         }
-        findViewById<Button>(R.id.button_add_numeric_badge).apply {
-            setOnClickListener {
-                if (!badgeVisible) {
-                    Badge.showNumericBadgeIn(imageView, imageContainer, Random(System.currentTimeMillis()).nextInt(1, 11))
-                } else {
-                    Badge.removeBadge(imageView)
-                }
-                badgeVisible = !badgeVisible
-            }
+        findViewById<Button>(R.id.button_add_one_digit_numeric_badge).setOnClickListener {
+            Badge.showNumericBadgeIn(imageView, imageContainer, Random(System.currentTimeMillis()).nextInt(1, 9))
+            badgeVisible = true
         }
-        findViewById<Button>(R.id.button_remove_badge_if_numeric_with_count_zero).apply {
-            setOnClickListener {
-                Badge.showNumericBadgeIn(imageView, imageContainer, 0)
-                badgeVisible = false
-            }
+
+        findViewById<Button>(R.id.button_add_two_digit_numeric_badge).setOnClickListener {
+            Badge.showNumericBadgeIn(imageView, imageContainer, Random(System.currentTimeMillis()).nextInt(10, 20))
+            badgeVisible = true
+        }
+        findViewById<Button>(R.id.button_remove_badge_if_numeric_with_count_zero).setOnClickListener {
+            Badge.showNumericBadgeIn(imageView, imageContainer, 0)
+            badgeVisible = false
         }
     }
 }

--- a/catalog/src/main/res/layout/screen_badges_catalog.xml
+++ b/catalog/src/main/res/layout/screen_badges_catalog.xml
@@ -38,11 +38,18 @@
         android:text="Toggle" />
 
     <Button
-        android:id="@+id/button_add_numeric_badge"
+        android:id="@+id/button_add_one_digit_numeric_badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:text="Toggle With Number > 0" />
+        android:text="Show with one digit number" />
+
+    <Button
+        android:id="@+id/button_add_two_digit_numeric_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Show with two digit number " />
 
     <Button
         android:id="@+id/button_remove_badge_if_numeric_with_count_zero"

--- a/library/src/main/java/com/telefonica/mistica/badge/Badge.kt
+++ b/library/src/main/java/com/telefonica/mistica/badge/Badge.kt
@@ -74,7 +74,7 @@ object Badge {
     private fun buildBadgeContentDescription(
         anchor: View,
         count: Int,
-        badgeDescription: String?
+        badgeDescription: String?,
     ): String {
         if (!contentDescriptions.containsKey(anchor.hashCode())) {
             contentDescriptions[anchor.hashCode()] = anchor.contentDescription
@@ -90,7 +90,7 @@ object Badge {
 
     private fun getDefaultBadgeDescription(
         anchor: View,
-        count: Int
+        count: Int,
     ) = if (count == 0) {
         anchor.context.getString(R.string.badge_notification_description)
     } else {
@@ -119,6 +119,7 @@ object Badge {
         parent.post {
             this.setBoundsFor(anchor, parent)
             val overlay = parent.overlay
+            overlay.clear()
             overlay.add(this)
             anchor.contentDescription = contentDescription
         }


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix a bug when a Badge with lower width is set after a higher width badge.

### :construction: How do we do it?
* Just adapt catalog code to be able to reproduce the bug
* Clear the old badge before set a new one.

### ☑️ Checks
- [X] Tested with dark mode.
- [X] Tested with API 24.

### :test_tube: How can I test this?
- [X] 📹 [Before](https://jira.tid.es/secure/attachment/2321980/badge-error.mp4)
- [X] 📹 [After](https://github.com/Telefonica/mistica-android/assets/8106237/35ef9366-3d3a-4c06-abe0-1f0013e1015e)
