### PR TITLE
ANDROID-14887 update set BottomSheet title as Heading for a11y

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
@@ -101,6 +101,7 @@ open class SheetView(
 
         handler.setOnClickListener { cancel() }
         title.setTextOrHide(titleText)
+        ViewCompat.setAccessibilityHeading(title, true)
         titleSpace.setSpaceOrGone(titleText)
         subtitle.setTextOrHide(subtitleText)
         description.setTextOrHide(descriptionText)


### PR DESCRIPTION
### :goal_net: What's the goal?
Set BottomSheet title as Heading for accessibility.

### :construction: How do we do it?
- Set the bottom sheet title as heading.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.

### :test_tube: How can I test this?
- [x] 🖼️ Screenshots/Videos

Before: (video with audio)

https://github.com/Telefonica/mistica-android/assets/13270085/4412f321-7a6f-4df2-84a8-78bc66425e23

After: (video with audio)

https://github.com/Telefonica/mistica-android/assets/13270085/6b112904-5323-4b57-bfa5-0ad78735ae80

- [x] [Mistica App QR or download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/558)
- [ ] Reviewed by Mistica design team
