### PR TITLE
ANDROID-14803 Update all the 24dp lateral margins to 16dp

### DIFF
--- a/library/src/main/res/layout/empty_state_screen_view.xml
+++ b/library/src/main/res/layout/empty_state_screen_view.xml
@@ -66,7 +66,7 @@
 					android:id="@+id/empty_state_screen_primary_button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_marginEnd="24dp"
+					android:layout_marginEnd="@dimen/button_separation"
 					tools:text="Explore Marketplace"
 					/>
 
@@ -74,7 +74,7 @@
 					android:id="@+id/empty_state_screen_secondary_button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_marginEnd="24dp"
+					android:layout_marginEnd="@dimen/button_separation"
 					style="@style/AppTheme.Button.SecondaryButton"
 					tools:text="Secondary Action"
 					/>

--- a/library/src/main/res/layout/empty_state_screen_view.xml
+++ b/library/src/main/res/layout/empty_state_screen_view.xml
@@ -7,9 +7,10 @@
 	<androidx.constraintlayout.widget.ConstraintLayout
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
+			android:paddingStart="16dp"
 			android:paddingTop="64dp"
-			android:paddingEnd="24dp"
-			android:paddingBottom="24dp"
+			android:paddingEnd="16dp"
+			android:paddingBottom="16dp"
 			style="@style/EmptyStateContainerWidth"
 			tools:ignore="RtlSymmetry"
 			>
@@ -18,7 +19,6 @@
 				android:id="@+id/empty_state_screen_image"
 				android:layout_width="wrap_content"
 				android:layout_height="112dp"
-				android:layout_marginStart="24dp"
 				android:scaleType="fitStart"
 				app:layout_constraintTop_toTopOf="parent"
 				app:layout_constraintStart_toStartOf="parent"
@@ -32,7 +32,6 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_marginTop="24dp"
-				android:layout_marginStart="24dp"
 				app:layout_constraintTop_toBottomOf="@id/empty_state_screen_image"
 				app:layout_constraintStart_toStartOf="parent"
 				tools:text="Your cart is empty"
@@ -45,7 +44,6 @@
 				android:layout_height="wrap_content"
 				android:visibility="gone"
 				android:layout_marginTop="16dp"
-				android:layout_marginStart="24dp"
 				android:textColor="?colorTextSecondary"
 				app:layout_constraintTop_toBottomOf="@id/empty_state_screen_title"
 				app:layout_constraintStart_toStartOf="parent"
@@ -60,7 +58,6 @@
 				android:gravity="start"
 				android:orientation="horizontal"
 				android:layout_marginTop="24dp"
-				android:layout_marginStart="0dp"
 				app:layout_constraintTop_toBottomOf="@id/empty_state_screen_subtitle"
 				app:layout_constraintStart_toStartOf="parent"
 				>
@@ -69,7 +66,7 @@
 					android:id="@+id/empty_state_screen_primary_button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_marginStart="24dp"
+					android:layout_marginEnd="24dp"
 					tools:text="Explore Marketplace"
 					/>
 
@@ -77,7 +74,7 @@
 					android:id="@+id/empty_state_screen_secondary_button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_marginStart="24dp"
+					android:layout_marginEnd="24dp"
 					style="@style/AppTheme.Button.SecondaryButton"
 					tools:text="Secondary Action"
 					/>
@@ -86,7 +83,6 @@
 					android:id="@+id/empty_state_screen_link_button"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_marginStart="16dp"
 					android:layout_gravity="center_vertical"
 					style="@style/AppTheme.Button.LinkButton"
 					tools:text="More info"

--- a/library/src/main/res/layout/highlighted_card_view.xml
+++ b/library/src/main/res/layout/highlighted_card_view.xml
@@ -7,8 +7,7 @@
     android:layout_height="wrap_content"
     android:background="@drawable/highlighted_card_background"
     android:focusable="true"
-    android:minHeight="100dp"
-    android:padding="1dp">
+    android:minHeight="100dp">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"

--- a/library/src/main/res/values/dimens_buttons.xml
+++ b/library/src/main/res/values/dimens_buttons.xml
@@ -9,6 +9,7 @@
     <dimen name="button_outline_stroke_width">1.5dp</dimen>
     <dimen name="button_max_animation_translation">32dp</dimen>
     <dimen name="button_chevron_padding">2dp</dimen>
+    <dimen name="button_separation">24dp</dimen>
 
     <!-- Small variant -->
     <dimen name="button_small_height">32dp</dimen>


### PR DESCRIPTION
### :goal_net: What's the goal?
Check that all sides margins of Mistica elements are 16dp (and not 24dp)

### :construction: How do we do it?
-Checked Mistica catalog using layout inspector to check sides margins
-Replaced 24dp with 16dp

Only found empty state xml implementation which used 24dp of side margins
I also found that link button of card_actions_view uses a negative margin. I think this should be reviewed in another task

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.

### :test_tube: How can I test this?
- [x] Open Mistica catalog using layout inspector
- [x] Check that sides margins are 16dp

Before
<img src="https://github.com/Telefonica/mistica-android/assets/49242917/12e943c4-6fb7-4b23-b64a-d7ebd4e123b2" alt="drawing" width="300"/>

After
<img src="https://github.com/Telefonica/mistica-android/assets/49242917/1525665f-739d-430f-8dc7-ab37c64ff2d2" alt="drawing" width="300"/>


