### PR TITLE
ANDROID-15025 add number input

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Inputs.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Inputs.kt
@@ -28,6 +28,7 @@ import com.telefonica.mistica.compose.input.CheckBoxInput
 import com.telefonica.mistica.compose.input.DropDownInput
 import com.telefonica.mistica.compose.input.EmailInput
 import com.telefonica.mistica.compose.input.LimitCharacters
+import com.telefonica.mistica.compose.input.NumberInput
 import com.telefonica.mistica.compose.input.PasswordInput
 import com.telefonica.mistica.compose.input.PhoneInput
 import com.telefonica.mistica.compose.input.TextAreaInput
@@ -62,6 +63,8 @@ fun Inputs() {
         PasswordInputSample()
         Title("Phone input")
         PhoneInputSample()
+        Title("Number input")
+        NumericInputSample()
         Title("Email input")
         EmailInputSample()
         Title("Email input with validation")
@@ -199,6 +202,25 @@ private fun PhoneInputSample() {
     }
 
     PhoneInput(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp)
+        ,
+        value = text,
+        onValueChange = {
+            text = it
+        },
+        label = "Type Something"
+    )
+}
+
+@Composable
+private fun NumericInputSample() {
+    var text by remember {
+        mutableStateOf("")
+    }
+
+    NumberInput(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 8.dp, start = 16.dp, end = 16.dp)

--- a/catalog/src/main/res/layout/screen_inputs_catalog.xml
+++ b/catalog/src/main/res/layout/screen_inputs_catalog.xml
@@ -140,6 +140,20 @@
                 app:inputType="phone" />
 
             <com.telefonica.mistica.title.TitleView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start"
+                    app:title="Number Input" />
+
+            <com.telefonica.mistica.input.TextInput
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
+                    app:inputHint="Number"
+                    app:inputType="number" />
+
+            <com.telefonica.mistica.title.TitleView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="start"

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -48,7 +48,7 @@ fun NumberInput(
         onClick = onClick,
         visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Decimal
         )
     )
 

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -24,19 +24,10 @@ fun NumberInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
 
-    fun String.isNumericKeyboardEntry(): Boolean {
-        val regex = "^([+-]?\\d*\\.?\\d*)$".toRegex()
-        return this.matches(regex)
-    }
-
     TextInputImpl(
         modifier = modifier,
         value = value,
-        onValueChange = {
-            if (it.isNumericKeyboardEntry()) {
-                onValueChange(it)
-            }
-        },
+        onValueChange = onValueChange,
         label = label,
         helperText = helperText,
         isError = isError,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -1,0 +1,55 @@
+package com.telefonica.mistica.compose.input
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.core.text.isDigitsOnly
+
+@Composable
+fun NumberInput(
+    modifier: Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    helperText: String? = null,
+    isError: Boolean = false,
+    errorText: String? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isInverse: Boolean = false,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+) {
+
+    fun String.isNumericKeyboardEntry(): Boolean {
+        val regex = "^([+-]?\\d*\\.?\\d*)$".toRegex()
+        return this.matches(regex)
+    }
+
+    TextInputImpl(
+        modifier = modifier,
+        value = value,
+        onValueChange = {
+            if (it.isNumericKeyboardEntry()) {
+                onValueChange(it)
+            }
+        },
+        label = label,
+        helperText = helperText,
+        isError = isError,
+        errorText = errorText,
+        trailingIcon = trailingIcon,
+        isInverse = isInverse,
+        enabled = enabled,
+        readOnly = readOnly,
+        onClick = onClick,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
+            keyboardType = KeyboardType.Number
+        )
+    )
+
+}

--- a/library/src/main/java/com/telefonica/mistica/input/TextInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/input/TextInput.kt
@@ -74,7 +74,8 @@ class TextInput @JvmOverloads constructor(
         TYPE_EMAIL,
         TYPE_PASSWORD,
         TYPE_TEXT_AREA,
-        TYPE_PHONE
+        TYPE_PHONE,
+        TYPE_NUMBER
     )
     annotation class TextInputType
 
@@ -122,6 +123,7 @@ class TextInput @JvmOverloads constructor(
             TYPE_PASSWORD -> R.layout.input_text_password
             TYPE_TEXT_AREA -> R.layout.input_text_area
             TYPE_PHONE -> R.layout.input_text_phone
+            TYPE_NUMBER -> R.layout.input_text_number
             else -> R.layout.input_text
         }
 
@@ -259,6 +261,7 @@ class TextInput @JvmOverloads constructor(
         const val TYPE_PASSWORD = 2
         const val TYPE_TEXT_AREA = 3
         const val TYPE_PHONE = 4
+        const val TYPE_NUMBER = 5
 
         const val NO_MAX_LENGTH = 0
 

--- a/library/src/main/res/layout/input_text_number.xml
+++ b/library/src/main/res/layout/input_text_number.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text_input_layout"
+    style="@style/AppTheme.Forms.TextInputLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/text_input"
+        style="@style/AppTheme.Forms.TextInputLayout.EditText.Number" />
+
+</com.google.android.material.textfield.TextInputLayout>

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -174,6 +174,7 @@
             <enum name="password" value="2" />
             <enum name="textArea" value="3" />
             <enum name="phone" value="4" />
+            <enum name="number" value="5" />
         </attr>
         <attr name="inputText" format="string" /> <!-- Supports inverse databinding -->
         <attr name="inputCounterEnabled" format="boolean" />

--- a/library/src/main/res/values/styles_forms.xml
+++ b/library/src/main/res/values/styles_forms.xml
@@ -81,6 +81,10 @@
         <item name="android:inputType">phone</item>
     </style>
 
+    <style name="AppTheme.Forms.TextInputLayout.EditText.Number">
+        <item name="android:inputType">numberDecimal</item>
+    </style>
+
     <style name="AppTheme.Forms.TextInputLayout.EditText.Email">
         <item name="android:inputType">textEmailAddress</item>
     </style>


### PR DESCRIPTION
### :goal_net: What's the goal?
Add number input to xml and compose views

### :construction: How do we do it?
* Add Number input composable with decimal check (avoiding add symbols or characters)
* Add Number input attr to xml view with numberDecimal input type

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [x] 🖼️ Screenshots/Videos
- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team

<img width="441" alt="Captura de pantalla 2024-07-30 a las 13 13 05" src="https://github.com/user-attachments/assets/5f8bf50c-2240-4702-b810-c61a2abb27bc">

<img width="441" alt="Captura de pantalla 2024-07-30 a las 13 12 57" src="https://github.com/user-attachments/assets/fc018b9f-374c-4db9-a06a-233709e2a932">
