### PR TITLE
ANDROID-15026 make TextInput label param as nullable

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
@@ -10,7 +10,7 @@ fun EmailInput(
     modifier: Modifier,
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     helperText: String? = null,
     isError: Boolean = false,
     errorText: String? = null,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -4,9 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.core.text.isDigitsOnly
 
 @Composable
-fun TextInput(
+fun NumberInput(
     modifier: Modifier,
     value: String,
     onValueChange: (String) -> Unit,
@@ -22,10 +23,20 @@ fun TextInput(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
+
+    fun String.isNumericKeyboardEntry(): Boolean {
+        val regex = "^([+-]?\\d*\\.?\\d*)$".toRegex()
+        return this.matches(regex)
+    }
+
     TextInputImpl(
         modifier = modifier,
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = {
+            if (it.isNumericKeyboardEntry()) {
+                onValueChange(it)
+            }
+        },
         label = label,
         helperText = helperText,
         isError = isError,
@@ -37,7 +48,8 @@ fun TextInput(
         onClick = onClick,
         visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions.toFoundationKeyboardOptions(
-            keyboardType = KeyboardType.Text
+            keyboardType = KeyboardType.Decimal
         )
     )
+
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
@@ -20,7 +20,7 @@ import com.telefonica.mistica.R
 fun PasswordInput(
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     modifier: Modifier = Modifier,
     helperText: String? = null,
     isError: Boolean = false,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
@@ -10,7 +10,7 @@ fun PhoneInput(
     modifier: Modifier,
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     helperText: String? = null,
     isError: Boolean = false,
     errorText: String? = null,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 fun TextAreaInput(
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     modifier: Modifier = Modifier,
     helperText: String? = null,
     isError: Boolean = false,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -29,7 +29,7 @@ internal fun TextInputImpl(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     helperText: String?,
     isError: Boolean,
     errorText: String?,
@@ -82,7 +82,7 @@ private fun TextBox(
     value: String,
     modifier: Modifier = Modifier,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String?,
     isError: Boolean,
     trailingIcon: @Composable (() -> Unit)?,
     enabled: Boolean,
@@ -113,16 +113,18 @@ private fun TextBox(
         readOnly = readOnly,
         value = value,
         onValueChange = onValueChange,
-        label = {
-            val transformedText = remember(value) {
-                visualTransformation.filter(AnnotatedString(value))
+        label = label?.let {
+            {
+                val transformedText = remember(value) {
+                    visualTransformation.filter(AnnotatedString(value))
+                }
+                TextInputLabel(
+                    text = it,
+                    inputIsNotEmpty = transformedText.text.isNotEmpty(),
+                    isFocused = interactionSource.collectIsFocusedAsState().value,
+                    isError = isError,
+                )
             }
-            TextInputLabel(
-                text = label,
-                inputIsNotEmpty = transformedText.text.isNotEmpty(),
-                isFocused = interactionSource.collectIsFocusedAsState().value,
-                isError = isError,
-            )
         },
         interactionSource = interactionSource,
         keyboardOptions = keyboardOptions,


### PR DESCRIPTION
### :goal_net: What's the goal?
Currently "label" param is a not nullable string, this way, when we are developing if we pass empty value, the label is not shown, but the space is reserved and the value is not center vertically

### :construction: How do we do it?
* Make label param nullable

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [ ] Tested with dark mode.
- [ ] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team

<img width="441" alt="Captura de pantalla 2024-07-31 a las 10 20 52" src="https://github.com/user-attachments/assets/0c0660bd-6dd4-444d-9418-ffff6a839b8e">
