### PR TITLE
ANDROID-15075 ListRowItem Switch & CheckBox a11y compose

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -19,6 +19,10 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,6 +38,8 @@ import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.compose.list.BackgroundType
 import com.telefonica.mistica.compose.list.ListRowIcon
 import com.telefonica.mistica.compose.list.ListRowItem
+import com.telefonica.mistica.compose.list.ListRowItemWithCheckBox
+import com.telefonica.mistica.compose.list.ListRowItemWithSwitch
 import com.telefonica.mistica.compose.shape.Chevron
 import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -378,11 +384,40 @@ fun Lists() {
             SectionTitle("Clickable Asset")
             ClickableAssetSample(
                 context = context,
-                onRowClick = {},
+                onRowClick = null,
             )
             ClickableAssetSample(
                 context = context,
                 onRowClick = { Toast.makeText(context, "Row Clicked", Toast.LENGTH_SHORT).show() },
+            )
+        }
+        item {
+            SectionTitle("Toggleables")
+            var switchState by remember {
+                mutableStateOf(false)
+            }
+            ListRowItemWithSwitch(
+                headline = Tag("Headline").withStyle(TYPE_PROMO),
+                title = "Title",
+                subtitle = "Subtitle",
+                description = "Description",
+                isBadgeVisible = true,
+                badge = "1",
+                checked = switchState,
+                onCheckedChange = { switchState = it },
+            )
+            var checkBoxState by remember {
+                mutableStateOf(false)
+            }
+            ListRowItemWithCheckBox(
+                headline = Tag("Headline").withStyle(TYPE_PROMO),
+                title = "Title",
+                subtitle = "Subtitle",
+                description = "Description",
+                isBadgeVisible = true,
+                badge = "1",
+                checked = checkBoxState,
+                onCheckedChange = { checkBoxState = it },
             )
         }
     }
@@ -451,9 +486,9 @@ private fun CustomSlot() {
 }
 
 @Composable
-private fun ClickableAssetSample(context: Context, onRowClick: () -> Unit) {
+private fun ClickableAssetSample(context: Context, onRowClick: (() -> Unit)? = null) {
     ListRowItem(
-        title = "Clickable Asset in Clickable Row",
+        title = if (onRowClick != null) "Clickable Asset in Clickable Row" else "Clickable Asset",
         subtitle = "Subtitle",
         description = "Description",
         isBadgeVisible = true,
@@ -461,6 +496,7 @@ private fun ClickableAssetSample(context: Context, onRowClick: () -> Unit) {
         onClick = onRowClick,
         listRowIcon = ListRowIcon.CircleIcon(
             painterResource(id = R.drawable.ic_lists),
+            description = "Clickable asset",
             backgroundColor = MisticaTheme.colors.backgroundAlternative,
             modifier = Modifier.clickable {
                 Toast.makeText(context, "Asset Clicked", Toast.LENGTH_SHORT).show()

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Lists.kt
@@ -397,27 +397,21 @@ fun Lists() {
                 mutableStateOf(false)
             }
             ListRowItemWithSwitch(
-                headline = Tag("Headline").withStyle(TYPE_PROMO),
                 title = "Title",
                 subtitle = "Subtitle",
-                description = "Description",
-                isBadgeVisible = true,
-                badge = "1",
                 checked = switchState,
                 onCheckedChange = { switchState = it },
+                listRowIcon = ListRowIcon.NormalIcon(painter = painterResource(id = R.drawable.ic_lists)),
             )
             var checkBoxState by remember {
                 mutableStateOf(false)
             }
             ListRowItemWithCheckBox(
-                headline = Tag("Headline").withStyle(TYPE_PROMO),
                 title = "Title",
                 subtitle = "Subtitle",
-                description = "Description",
-                isBadgeVisible = true,
-                badge = "1",
                 checked = checkBoxState,
                 onCheckedChange = { checkBoxState = it },
+                listRowIcon = ListRowIcon.NormalIcon(painter = painterResource(id = R.drawable.ic_lists)),
             )
         }
     }

--- a/library/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Badge as MaterialBadge
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -36,7 +37,7 @@ fun Badge(
                 .size(8.dp),
         ) { }
     } else {
-        androidx.compose.material.Badge(
+        MaterialBadge(
             backgroundColor = MisticaTheme.colors.badge,
             modifier = modifier.testTag(BadgeTestTags.BADGE_NUMBER),
         ) {

--- a/library/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/badge/Badge.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -23,6 +25,7 @@ import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 fun Badge(
     modifier: Modifier = Modifier,
     content: String? = null,
+    contentDescription: String? = null,
 ) {
     if (content.isNullOrEmpty()) {
         Surface(
@@ -38,7 +41,14 @@ fun Badge(
             modifier = modifier.testTag(BadgeTestTags.BADGE_NUMBER),
         ) {
             Text(
-                modifier = Modifier.testTag(BadgeTestTags.BADGE_NUMBER_VALUE),
+                modifier = Modifier
+                    .testTag(BadgeTestTags.BADGE_NUMBER_VALUE)
+                    .then(
+                        if (contentDescription != null)
+                            Modifier.semantics { this.contentDescription = contentDescription }
+                        else
+                            Modifier
+                    ),
                 text = content,
                 color = MisticaTheme.colors.textPrimaryInverse,
             )

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import com.telefonica.mistica.R
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
 @Composable
 fun PasswordInput(
@@ -86,38 +88,46 @@ private fun PasswordVisibleIcon(
 @Preview(showBackground = true)
 @Composable
 fun PreviewEmptyPasswordInput() {
-    PasswordInput(
-        value = "",
-        onValueChange = {},
-        label = "empty",
-    )
+    MisticaTheme(brand = MovistarBrand) {
+        PasswordInput(
+            value = "",
+            onValueChange = {},
+            label = "empty",
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewPasswordInput() {
-    PasswordInput(
-        value = "value",
-        onValueChange = {},
-        label = "label",
-    )
+    MisticaTheme(brand = MovistarBrand) {
+        PasswordInput(
+            value = "value",
+            onValueChange = {},
+            label = "label",
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewPasswordVisibleIconVisible() {
-    PasswordVisibleIcon(
-        passwordVisible = true,
-        onIconClicked = {},
-    )
+    MisticaTheme(brand = MovistarBrand) {
+        PasswordVisibleIcon(
+            passwordVisible = true,
+            onIconClicked = {},
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewPasswordVisibleIconInVisible() {
-    PasswordVisibleIcon(
-        passwordVisible = false,
-        onIconClicked = {},
-    )
+    MisticaTheme(brand = MovistarBrand) {
+        PasswordVisibleIcon(
+            passwordVisible = false,
+            onIconClicked = {},
+        )
+    }
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.R
@@ -40,7 +42,6 @@ import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ListRowItem(
     modifier: Modifier = Modifier,
@@ -52,6 +53,7 @@ fun ListRowItem(
     backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
     badge: String? = null,
     isBadgeVisible: Boolean = false,
+    isToggleable: Boolean = false,
     headline: Tag? = null,
     trailing: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
@@ -68,6 +70,7 @@ fun ListRowItem(
         backgroundType = backgroundType,
         badge = badge,
         isBadgeVisible = isBadgeVisible,
+        isToggleable = isToggleable,
         headline = headline,
         trailing = trailing,
         onClick = onClick,
@@ -76,7 +79,6 @@ fun ListRowItem(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 @Deprecated(replaceWith = ReplaceWith("ListRowItem"), message = "Use new ListRowItem with ListRowIcon param instead")
 fun ListRowItem(
@@ -113,9 +115,9 @@ fun ListRowItem(
     )
 }
 
-@ExperimentalMaterialApi
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
-private fun ListRowItemImp(
+internal fun ListRowItemImp(
     modifier: Modifier = Modifier,
     icon: @Composable (() -> Unit)? = null,
     title: String? = null,
@@ -125,6 +127,7 @@ private fun ListRowItemImp(
     backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
     badge: String? = null,
     isBadgeVisible: Boolean = false,
+    isToggleable: Boolean = false,
     headline: Tag? = null,
     trailing: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
@@ -187,9 +190,17 @@ private fun ListRowItemImp(
 
     Box(
         modifier = boxModifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM)
+            .then(
+                if (isToggleable)
+                    Modifier.semantics(mergeDescendants = true) {}
+                else
+                    Modifier
+            )
     ) {
         Row(
-            modifier = rowModifier.height(IntrinsicSize.Min)
+            modifier = rowModifier
+                .height(IntrinsicSize.Min)
+                .semantics { isTraversalGroup = true },
         ) {
             if (icon != null) {
                 Box(modifier = Modifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM_ICON)) {
@@ -202,10 +213,15 @@ private fun ListRowItemImp(
                 modifier = Modifier
                     .weight(1f)
                     .absolutePadding(right = 16.dp)
-                    .align(CenterVertically)
+                    .align(CenterVertically),
             ) {
                 headline?.let {
-                    it.build()
+                    it
+                        .withModifier(
+                            modifier = Modifier
+                                .semantics { traversalIndex = 2f }
+                        )
+                        .build()
                     Spacer(modifier = Modifier.height(8.dp))
                 }
                 title?.let {
@@ -215,6 +231,7 @@ private fun ListRowItemImp(
                         color = textColorPrimary,
                         modifier = Modifier
                             .testTag(ListRowItemTestTags.LIST_ROW_ITEM_TITLE)
+                            .semantics { traversalIndex = 1f }
                             .then(
                                 if (isTitleHeading) {
                                     Modifier.semantics { heading() }
@@ -231,6 +248,7 @@ private fun ListRowItemImp(
                         color = textColorPrimary,
                         modifier = Modifier
                             .testTag(ListRowItemTestTags.LIST_ROW_ITEM_SUBTITLE)
+                            .semantics { traversalIndex = 3f }
                             .padding(vertical = 2.dp)
                             .defaultMinSize(minHeight = 20.dp),
                     )
@@ -242,13 +260,19 @@ private fun ListRowItemImp(
                         color = textColorSecondary,
                         modifier = Modifier
                             .testTag(ListRowItemTestTags.LIST_ROW_ITEM_DESCRIPTION)
+                            .semantics { traversalIndex = 4f }
                             .padding(vertical = 2.dp)
                             .defaultMinSize(minHeight = 20.dp),
                     )
                 }
                 bottom?.let {
                     Spacer(modifier = Modifier.height(2.dp))
-                    bottom()
+                    Box(
+                        modifier = Modifier
+                            .semantics(mergeDescendants = !isToggleable) { traversalIndex = 5f }
+                    ) {
+                        bottom()
+                    }
                 }
             }
 
@@ -256,6 +280,7 @@ private fun ListRowItemImp(
                 val badgeModifier = Modifier
                     .align(CenterVertically)
                     .absolutePadding(0.dp, 0.dp, 16.dp, 0.dp)
+                    .semantics(mergeDescendants = !isToggleable) { traversalIndex = 6f }
                 Badge(
                     modifier = badgeModifier,
                     content = badge,
@@ -263,7 +288,11 @@ private fun ListRowItemImp(
             }
 
             trailing?.let {
-                Column(modifier = Modifier.align(CenterVertically)) {
+                Column(
+                    modifier = Modifier
+                        .align(CenterVertically)
+                        .semantics { traversalIndex = 7f }
+                ) {
                     it()
                 }
             }

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -189,13 +189,9 @@ internal fun ListRowItemImp(
     }
 
     Box(
-        modifier = boxModifier.testTag(ListRowItemTestTags.LIST_ROW_ITEM)
-            .then(
-                if (isToggleable)
-                    Modifier.semantics(mergeDescendants = true) {}
-                else
-                    Modifier
-            )
+        modifier = boxModifier
+            .testTag(ListRowItemTestTags.LIST_ROW_ITEM)
+            .semantics(mergeDescendants = isToggleable) {  }
     ) {
         Row(
             modifier = rowModifier

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItemWithCheckBox.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItemWithCheckBox.kt
@@ -1,0 +1,55 @@
+package com.telefonica.mistica.compose.list
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Checkbox
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.telefonica.mistica.compose.tag.Tag
+
+@Composable
+fun ListRowItemWithCheckBox(
+    modifier: Modifier = Modifier,
+    listRowIcon: ListRowIcon? = null,
+    title: String? = null,
+    isTitleHeading: Boolean = false,
+    subtitle: String? = null,
+    description: String? = null,
+    backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
+    badge: String? = null,
+    isBadgeVisible: Boolean = false,
+    headline: Tag? = null,
+    checked: Boolean = false,
+    onCheckedChange: (Boolean) -> Unit,
+    bottom: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+) {
+    ListRowItemImp(
+        modifier = modifier.toggleable(
+            value = checked,
+            onValueChange = { onCheckedChange(!checked)},
+            role = Role.Checkbox,
+        ),
+        icon = { listRowIcon?.Draw() },
+        title = title,
+        isTitleHeading = isTitleHeading,
+        subtitle = subtitle,
+        description = description,
+        backgroundType = backgroundType,
+        badge = badge,
+        isBadgeVisible = isBadgeVisible,
+        isToggleable = true,
+        headline = headline,
+        trailing = {
+            Checkbox(
+                checked = checked,
+                onCheckedChange = null,
+            )
+        },
+        onClick = null,
+        bottom = bottom,
+        contentPadding = contentPadding
+    )
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItemWithSwitch.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItemWithSwitch.kt
@@ -1,0 +1,55 @@
+package com.telefonica.mistica.compose.list
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.telefonica.mistica.compose.tag.Tag
+
+@Composable
+fun ListRowItemWithSwitch(
+    modifier: Modifier = Modifier,
+    listRowIcon: ListRowIcon? = null,
+    title: String? = null,
+    isTitleHeading: Boolean = false,
+    subtitle: String? = null,
+    description: String? = null,
+    backgroundType: BackgroundType = BackgroundType.TYPE_NORMAL,
+    badge: String? = null,
+    isBadgeVisible: Boolean = false,
+    headline: Tag? = null,
+    checked: Boolean = false,
+    onCheckedChange: (Boolean) -> Unit,
+    bottom: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+) {
+    ListRowItemImp(
+        modifier = modifier.toggleable(
+            value = checked,
+            onValueChange = { onCheckedChange(!checked)},
+            role = Role.Switch,
+        ),
+        icon = { listRowIcon?.Draw() },
+        title = title,
+        isTitleHeading = isTitleHeading,
+        subtitle = subtitle,
+        description = description,
+        backgroundType = backgroundType,
+        badge = badge,
+        isBadgeVisible = isBadgeVisible,
+        isToggleable = true,
+        headline = headline,
+        trailing = {
+            Switch(
+                checked = checked,
+                onCheckedChange = null,
+            )
+        },
+        onClick = null,
+        bottom = bottom,
+        contentPadding = contentPadding
+    )
+}

--- a/library/src/main/java/com/telefonica/mistica/compose/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/README.md
@@ -151,3 +151,25 @@ Any `@Composable` is allowed to be used as `trailing` parameter. This will show 
       }
   )
 ```
+
+## Toggleables
+There is two new sub-components from ListRowView to handle Action Layouts with toggleable views like Switch or CheckBox components.
+Take a look to the new available sub-components:
+* [ListRowViewWithSwitch](ListRowItemWithSwitch.kt)
+* [ListRowViewWithCheckBox](ListRowItemWithCheckBox.kt)
+
+This two new sub-components have been created in order to handle the main accessibility actions according to Google standards with Toggleables views.
+So please, consider replacing and start using these two new sub-components if you need to use a list element with a Switch or CheckBox view.
+
+```kotlin
+var switchState by remember {
+    mutableStateOf(false)
+}
+ListRowItemWithSwitch(
+    title = "Title",
+    subtitle = "Subtitle",
+    checked = switchState,
+    onCheckedChange = { switchState = it },
+    listRowIcon = ListRowIcon.NormalIcon(painter = painterResource(id = R.drawable.ic_lists)),
+)
+```

--- a/library/src/main/java/com/telefonica/mistica/compose/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/README.md
@@ -158,7 +158,7 @@ Take a look to the new available sub-components:
 * [ListRowViewWithSwitch](ListRowItemWithSwitch.kt)
 * [ListRowViewWithCheckBox](ListRowItemWithCheckBox.kt)
 
-This two new sub-components have been created in order to handle the main accessibility actions according to Google standards with Toggleables views.
+This two new sub-components have been created in order to handle the main accessibility actions according to Google standards with Toggleable views.
 So please, consider replacing and start using these two new sub-components if you need to use a list element with a Switch or CheckBox view.
 
 ```kotlin

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -79,7 +79,7 @@ Take a look to the new available sub-components:
 * [ListRowViewWithSwitch](https://github.com/Telefonica/mistica-android/blob/ANDROID-14884_list_row_a11y/library/src/main/java/com/telefonica/mistica/list/ListRowViewWithSwitch.kt)
 * [ListRowViewWithCheckBox](https://github.com/Telefonica/mistica-android/blob/ANDROID-14884_list_row_a11y/library/src/main/java/com/telefonica/mistica/list/ListRowViewWithCheckBox.kt)
 
-This two new sub-components have been created in order to handle the main accessibility actions according to Google standards with Toggleables views. So 
+This two new sub-components have been created in order to handle the main accessibility actions according to Google standards with Toggleable views. So 
 please, consider replacing and start using these two new sub-components if you need to use a list element with a Switch or CheckBox view.
 
 ### How to use the new sub-components?

--- a/library/src/test/java/com/telefonica/mistica/compose/list/ListRowItemWithCheckBoxTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/compose/list/ListRowItemWithCheckBoxTest.kt
@@ -1,0 +1,92 @@
+package com.telefonica.mistica.compose.list
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import com.telefonica.mistica.compose.tag.Tag
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+import com.telefonica.mistica.testutils.ScreenshotsTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class ListRowItemWithCheckBoxTest : ScreenshotsTest() {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `check ListRowItemWithCheckBox Off`() {
+        `when ListRowItemWithCheckBox`(checked = false)
+
+        `then is NOT checked`()
+        `then screenshot is OK`()
+    }
+
+    @Test
+    fun `check ListRowItemWithCheckBox On`() {
+        `when ListRowItemWithCheckBox`(checked = true)
+
+        `then is checked`()
+        `then screenshot is OK`()
+    }
+
+    @Test
+    fun `check ListRowItemWithCheckBox state change`() {
+        `given ListRowItemWithCheckBox`(checked = false)
+        `given is NOT checked`()
+
+        `when toggling the state`()
+
+        `then is checked`()
+    }
+
+    private fun `given ListRowItemWithCheckBox`(checked: Boolean = false) =
+        `when ListRowItemWithCheckBox`(checked)
+
+    private fun `given is NOT checked`() =
+        `then is NOT checked`()
+
+    private fun `when ListRowItemWithCheckBox`(checked: Boolean = false) {
+        composeTestRule.setContent {
+            var isChecked by remember { mutableStateOf(checked) }
+            MisticaTheme(brand = MovistarBrand) {
+                ListRowItemWithCheckBox(
+                    listRowIcon = null,
+                    headline = Tag("Promo"),
+                    title = "title",
+                    subtitle = "Subtitle",
+                    description = "Description",
+                    checked = isChecked,
+                    onCheckedChange = { isChecked = it},
+                )
+            }
+        }
+    }
+
+    private fun `when toggling the state`() {
+        composeTestRule.onNode(isToggleable()).performClick()
+    }
+
+    private fun `then screenshot is OK`() {
+        compareScreenshot(composeTestRule.onRoot())
+    }
+
+    private fun `then is NOT checked`() {
+        composeTestRule.onNode(isToggleable()).assertIsOff()
+    }
+
+    private fun `then is checked`() {
+        composeTestRule.onNode(isToggleable()).assertIsOn()
+    }
+}

--- a/library/src/test/java/com/telefonica/mistica/compose/list/ListRowItemWithSwitchTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/compose/list/ListRowItemWithSwitchTest.kt
@@ -1,0 +1,92 @@
+package com.telefonica.mistica.compose.list
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import com.telefonica.mistica.compose.tag.Tag
+import com.telefonica.mistica.compose.theme.MisticaTheme
+import com.telefonica.mistica.compose.theme.brand.MovistarBrand
+import com.telefonica.mistica.testutils.ScreenshotsTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class ListRowItemWithSwitchTest : ScreenshotsTest() {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `check ListRowItemWithSwitch Off`() {
+        `when ListRowItemWithSwitch`(checked = false)
+
+        `then is NOT checked`()
+        `then screenshot is OK`()
+    }
+
+    @Test
+    fun `check ListRowItemWithSwitch On`() {
+        `when ListRowItemWithSwitch`(checked = true)
+
+        `then is checked`()
+        `then screenshot is OK`()
+    }
+
+    @Test
+    fun `check ListRowItemWithSwitch state change`() {
+        `given ListRowItemWithSwitch`(checked = false)
+        `given is NOT checked`()
+
+        `when toggling the state`()
+
+        `then is checked`()
+    }
+
+    private fun `given ListRowItemWithSwitch`(checked: Boolean = false) =
+        `when ListRowItemWithSwitch`(checked)
+
+    private fun `given is NOT checked`() =
+        `then is NOT checked`()
+
+    private fun `when ListRowItemWithSwitch`(checked: Boolean = false) {
+        composeTestRule.setContent {
+            var isChecked by remember { mutableStateOf(checked) }
+            MisticaTheme(brand = MovistarBrand) {
+                ListRowItemWithSwitch(
+                    listRowIcon = null,
+                    headline = Tag("Promo"),
+                    title = "title",
+                    subtitle = "Subtitle",
+                    description = "Description",
+                    checked = isChecked,
+                    onCheckedChange = { isChecked = it},
+                )
+            }
+        }
+    }
+
+    private fun `when toggling the state`() {
+        composeTestRule.onNode(isToggleable()).performClick()
+    }
+
+    private fun `then screenshot is OK`() {
+        compareScreenshot(composeTestRule.onRoot())
+    }
+
+    private fun `then is NOT checked`() {
+        composeTestRule.onNode(isToggleable()).assertIsOff()
+    }
+
+    private fun `then is checked`() {
+        composeTestRule.onNode(isToggleable()).assertIsOn()
+    }
+}


### PR DESCRIPTION
### :goal_net: What's the goal?
Align ListRowItem accessibility for Compose according to new Figma definition: https://www.figma.com/design/Be8QB9onmHunKCCAkIBAVr/%F0%9F%94%B8-Lists-Specs?node-id=4977-5442&t=iqE1tr998GXqKVZ4-4

### :construction: How do we do it?
- Creating ListRowItemWithSwitch and ListRowItemWithCheckBox ( b24f198a1603781be512ec2ab80da348465c90e3 )
- Letting developers to pass a contentDescription for badges ( 600bf16aced8749eeecd9efee930731977a315b6 )
- Adding info to the compose list README file.
- Scouting (unrelated task): Adding MisticaTheme to the PasswordInput so the previews in that file work again.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [ ] Tested with dark mode.
- [ ] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.

### :test_tube: How can I test this?
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...
