### PR TITLE
animate views onAttachedToWindow and after setFeedbackType #ANDROID-15196

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/activity/FeedbackScreenCatalogActivity.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/activity/FeedbackScreenCatalogActivity.kt
@@ -2,7 +2,6 @@ package com.telefonica.mistica.catalog.ui.classic.activity
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import com.telefonica.mistica.catalog.R
@@ -49,14 +48,14 @@ class FeedbackScreenCatalogActivity : AppCompatActivity() {
             firstButtonLoadingText?.let { setFeedbackFirstButtonLoadingText(it) }
             secondButtonText?.let { setFeedbackSecondButtonText(it) }
             showSecondButtonAsLink?.let { setFeedbackSecondButtonAsLink(it) }
-            setFirstButtonOnClick(View.OnClickListener {
+            setFirstButtonOnClick {
                 if (showLoadingInButton == true) {
                     setIsLoading(true)
                     handler.postDelayed({ setIsLoading(false) }, RETRY_DELAY)
                 } else {
                     finish()
                 }
-            })
+            }
             customIcon?.let { setCustomIcon(it) }
             customAnimation?.let { setCustomAnimation(it) }
             setShouldAnimateOnAttached(shouldAnimateOnAttached)

--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
@@ -242,7 +242,6 @@ class FeedbackScreenView : ConstraintLayout {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         configureView()
-        animateViewsOnFirstLayout()
     }
 
     private fun configureView() {
@@ -251,6 +250,7 @@ class FeedbackScreenView : ConstraintLayout {
         configureTexts()
         configureCustomContentView()
         configureButtons()
+        animateViewsOnFirstLayout()
     }
 
     private fun configureBackground() {


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix a bug that hides feedback icon when the feedback type is changed. If first type is TYPE_SUCCESS or TYPE_ERROR icon always appears after changing the type but is not animated. 

### :construction: How do we do it?
* _Call animateViewsOnFirstLayout() inside configureView() instead of inside onAttachedToWindow(). This way, we ensure that this function is also called when we change the feedback type and the animation restarts._

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [ ] Tested with dark mode.
- [ ] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.
- [ ] Accessibility considerations.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team

| Before        | After           |
| ------------- |-------------|
| <video src="https://github.com/user-attachments/assets/31a314ad-b0d1-47ad-b3cf-9ca0bea532f5" alt="drawing" width="200"/>      | <video src="https://github.com/user-attachments/assets/5023a018-ef14-411d-9351-53e6320a47c9" alt="drawing" width="200"/> |



