### PR TITLE
ANDROID-15206 Set icon as null when there is no icon

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -60,7 +60,7 @@ fun ListRowItem(
 ) {
     ListRowItemImp(
         modifier = modifier,
-        icon = { listRowIcon?.Draw() },
+        icon = listRowIcon?.let { { listRowIcon.Draw() } },
         title = title,
         isTitleHeading = isTitleHeading,
         subtitle = subtitle,
@@ -293,6 +293,10 @@ fun ListRowItemPreview() {
     MisticaTheme(brand = MovistarBrand) {
         val checkedState = remember { mutableStateOf(true) }
         Column {
+            ListRowItem(
+                listRowIcon = null,
+                title = "Title",
+            )
             ListRowItem(
                 listRowIcon = null,
                 headline = Tag("Promo"),


### PR DESCRIPTION
### :goal_net: What's the goal?
Set icon as null when there is no icon. Due to this, the left padding was wrong in the compose list row item because we were adding an extra space because the icon was not null.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.

### :test_tube: How can I test this?

| Before        | After           |
| ------------- |-------------|
| <img src="https://github.com/user-attachments/assets/2698067f-5d9e-4a86-93df-52516b683324" alt="drawing" width="200"/>      | <img src="https://github.com/user-attachments/assets/a9c5e319-fb8a-4eec-b632-8307a10e9166" alt="drawing" width="200"/> |
