### PR TITLE
ANDROID-15211 Remove unneded ExperimentalMaterialApi annotations

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Badges.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Badges.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BadgedBox
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,7 +22,6 @@ import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.compose.badge.Badge
 import com.telefonica.mistica.compose.button.Button
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun Badges() {
     Column(

--- a/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/ListRowItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,7 +39,6 @@ import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ListRowItem(
     modifier: Modifier = Modifier,
@@ -76,7 +74,6 @@ fun ListRowItem(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 @Deprecated(replaceWith = ReplaceWith("ListRowItem"), message = "Use new ListRowItem with ListRowIcon param instead")
 fun ListRowItem(
@@ -113,7 +110,6 @@ fun ListRowItem(
     )
 }
 
-@ExperimentalMaterialApi
 @Composable
 private fun ListRowItemImp(
     modifier: Modifier = Modifier,
@@ -286,7 +282,6 @@ object ListRowItemTestTags {
     const val LIST_ROW_ITEM_TITLE = "list_row_item_title"
 }
 
-@ExperimentalMaterialApi
 @Preview(showBackground = true)
 @Composable
 fun ListRowItemPreview() {

--- a/library/src/main/java/com/telefonica/mistica/compose/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/compose/list/README.md
@@ -2,8 +2,7 @@
 `ListRowItems` are a continuous group of text or images. They are composed of items containing primary and supplemental actions, which are represented by icons and text.
 This component is designed to be used inside lists, that in Compose are built using `Column` or `LazyColumn`.
 
-```kotlin
-@ExperimentalMaterialApi  
+```kotlin 
 @Composable  
 fun ListRowItem(
     modifier: Modifier = Modifier,


### PR DESCRIPTION
### :goal_net: What's the goal?
Clean unneded ExperimentalMaterialApi annotations.

### :construction: How do we do it?
Removing unneded annotations

### :test_tube: How can I test this?
No changes in code or screens, just removed annotations.
- [x] Mistica [download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/617)