### PR TITLE
Fix acceptance errors of v15.0.1

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -191,7 +191,6 @@ class ProgressButton : FrameLayout {
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun setButtonBackground() {
         buttonBackground.apply {
             id = NO_ID
@@ -204,27 +203,36 @@ class ProgressButton : FrameLayout {
             setTextColor(Color.TRANSPARENT)
             visibility = VISIBLE
             setOnTouchListener { view, event ->
+                var eventConsumed = false
                 when (event.action) {
                     MotionEvent.ACTION_DOWN -> {
-                        buttonNormal.isPressed = true
-                        buttonLoading.isPressed = true
+                        setButtonPressed(true)
                     }
 
                     MotionEvent.ACTION_MOVE -> {
                         val outsideBounds =
                             event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
-                        buttonNormal.isPressed = !outsideBounds
-                        buttonLoading.isPressed = !outsideBounds
+                        setButtonPressed(!outsideBounds)
                     }
 
-                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                        buttonNormal.isPressed = false
-                        buttonLoading.isPressed = false
+                    MotionEvent.ACTION_UP -> {
+                        setButtonPressed(false)
+                        view.performClick()
+                        eventConsumed = true
+                    }
+
+                    MotionEvent.ACTION_CANCEL -> {
+                        setButtonPressed(false)
                     }
                 }
-                false
+                eventConsumed
             }
         }
+    }
+
+    private fun setButtonPressed(pressed: Boolean) {
+        buttonNormal.isPressed = pressed
+        buttonLoading.isPressed = pressed
     }
 
     private fun addViews() {

--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -66,94 +66,14 @@ class ProgressButton : FrameLayout {
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    @Suppress("LongMethod")
     private fun init(attrs: AttributeSet? = null, defStyleAttr: Int = 0) {
-        if (attrs != null) {
-            val theme = context.theme
-            val styledAttrs =
-                theme.obtainStyledAttributes(attrs, R.styleable.Button, defStyleAttr, 0)
-            try {
-                isLoading = styledAttrs.getBoolean(R.styleable.Button_isLoading, false)
-            } finally {
-                styledAttrs.recycle()
-            }
-        }
-
-        this.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-        isClickable = false
-        setPadding(0, 0, 0, 0)
-        setBackgroundColor(Color.TRANSPARENT)
-        originalTextColors = buttonNormal.textColors
-
-        buttonNormal.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            showTextOnly()
-        }
-
-        buttonLoading.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            showTextOnly()
-            icon = AppCompatResources.getDrawable(context, R.drawable.empty_material_button_icon)
-            text = ""
-        }
-
-        progressBar.apply {
-            layoutParams = LayoutParams(buttonLoading.iconSize, buttonLoading.iconSize)
-                .apply {
-                    gravity = Gravity.CENTER
-                }
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            isIndeterminate = true
-            indeterminateTintMode = PorterDuff.Mode.SRC_IN
-            visibility = View.INVISIBLE
-        }
-
-        buttonBackground.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            icon = null
-            setTextColor(Color.TRANSPARENT)
-            visibility = View.VISIBLE
-            setOnTouchListener { view, event ->
-                when (event.action) {
-                    MotionEvent.ACTION_DOWN -> {
-                        buttonNormal.isPressed = true
-                        buttonLoading.isPressed = true
-                    }
-                    MotionEvent.ACTION_MOVE -> {
-                        val outsideBounds =
-                            event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
-                        buttonNormal.isPressed = !outsideBounds
-                        buttonLoading.isPressed = !outsideBounds
-                    }
-                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                        buttonNormal.isPressed = false
-                        buttonLoading.isPressed = false
-                    }
-                }
-                false
-            }
-        }
-
-        addView(buttonBackground)
-        addView(buttonNormal)
-        addView(buttonLoading)
-        addView(progressBar)
-
+        setupAttributes(attrs, defStyleAttr)
+        setupViewProperties()
+        setupButtonNormal()
+        setupButtonLoading()
+        setupProgressBar()
+        setButtonBackground()
+        addViews()
         setVisibilityAndColors()
     }
 
@@ -209,6 +129,109 @@ class ProgressButton : FrameLayout {
         if (isLoading) {
             switchState()
         }
+    }
+
+    private fun setupAttributes(attrs: AttributeSet?, defStyleAttr: Int) {
+        if (attrs != null) {
+            val theme = context.theme
+            val styledAttrs =
+                theme.obtainStyledAttributes(attrs, R.styleable.Button, defStyleAttr, 0)
+            try {
+                isLoading = styledAttrs.getBoolean(R.styleable.Button_isLoading, false)
+            } finally {
+                styledAttrs.recycle()
+            }
+        }
+    }
+
+    private fun setupViewProperties() {
+        this.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+        isClickable = false
+        setPadding(0, 0, 0, 0)
+        setBackgroundColor(Color.TRANSPARENT)
+        originalTextColors = buttonNormal.textColors
+    }
+
+    private fun setupButtonNormal() {
+        buttonNormal.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            showTextOnly()
+        }
+    }
+
+    private fun setupButtonLoading() {
+        buttonLoading.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            showTextOnly()
+            icon = AppCompatResources.getDrawable(context, R.drawable.empty_material_button_icon)
+            text = ""
+        }
+    }
+
+    private fun setupProgressBar() {
+        progressBar.apply {
+            layoutParams = LayoutParams(buttonLoading.iconSize, buttonLoading.iconSize)
+                .apply {
+                    gravity = Gravity.CENTER
+                }
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            isIndeterminate = true
+            indeterminateTintMode = PorterDuff.Mode.SRC_IN
+            visibility = INVISIBLE
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setButtonBackground() {
+        buttonBackground.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            icon = null
+            setTextColor(Color.TRANSPARENT)
+            visibility = VISIBLE
+            setOnTouchListener { view, event ->
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        buttonNormal.isPressed = true
+                        buttonLoading.isPressed = true
+                    }
+
+                    MotionEvent.ACTION_MOVE -> {
+                        val outsideBounds =
+                            event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
+                        buttonNormal.isPressed = !outsideBounds
+                        buttonLoading.isPressed = !outsideBounds
+                    }
+
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                        buttonNormal.isPressed = false
+                        buttonLoading.isPressed = false
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    private fun addViews() {
+        addView(buttonBackground)
+        addView(buttonNormal)
+        addView(buttonLoading)
+        addView(progressBar)
     }
 
     private fun switchState() {

--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -66,14 +66,94 @@ class ProgressButton : FrameLayout {
     }
 
     @SuppressLint("ClickableViewAccessibility")
+    @Suppress("LongMethod")
     private fun init(attrs: AttributeSet? = null, defStyleAttr: Int = 0) {
-        setupAttributes(attrs, defStyleAttr)
-        setupViewProperties()
-        setupButtonNormal()
-        setupButtonLoading()
-        setupProgressBar()
-        setButtonBackground()
-        addViews()
+        if (attrs != null) {
+            val theme = context.theme
+            val styledAttrs =
+                theme.obtainStyledAttributes(attrs, R.styleable.Button, defStyleAttr, 0)
+            try {
+                isLoading = styledAttrs.getBoolean(R.styleable.Button_isLoading, false)
+            } finally {
+                styledAttrs.recycle()
+            }
+        }
+
+        this.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+        isClickable = false
+        setPadding(0, 0, 0, 0)
+        setBackgroundColor(Color.TRANSPARENT)
+        originalTextColors = buttonNormal.textColors
+
+        buttonNormal.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            showTextOnly()
+        }
+
+        buttonLoading.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            showTextOnly()
+            icon = AppCompatResources.getDrawable(context, R.drawable.empty_material_button_icon)
+            text = ""
+        }
+
+        progressBar.apply {
+            layoutParams = LayoutParams(buttonLoading.iconSize, buttonLoading.iconSize)
+                .apply {
+                    gravity = Gravity.CENTER
+                }
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            isIndeterminate = true
+            indeterminateTintMode = PorterDuff.Mode.SRC_IN
+            visibility = View.INVISIBLE
+        }
+
+        buttonBackground.apply {
+            id = NO_ID
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            icon = null
+            setTextColor(Color.TRANSPARENT)
+            visibility = View.VISIBLE
+            setOnTouchListener { view, event ->
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        buttonNormal.isPressed = true
+                        buttonLoading.isPressed = true
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        val outsideBounds =
+                            event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
+                        buttonNormal.isPressed = !outsideBounds
+                        buttonLoading.isPressed = !outsideBounds
+                    }
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                        buttonNormal.isPressed = false
+                        buttonLoading.isPressed = false
+                    }
+                }
+                false
+            }
+        }
+
+        addView(buttonBackground)
+        addView(buttonNormal)
+        addView(buttonLoading)
+        addView(progressBar)
+
         setVisibilityAndColors()
     }
 
@@ -129,109 +209,6 @@ class ProgressButton : FrameLayout {
         if (isLoading) {
             switchState()
         }
-    }
-
-    private fun setupAttributes(attrs: AttributeSet?, defStyleAttr: Int) {
-        if (attrs != null) {
-            val theme = context.theme
-            val styledAttrs =
-                theme.obtainStyledAttributes(attrs, R.styleable.Button, defStyleAttr, 0)
-            try {
-                isLoading = styledAttrs.getBoolean(R.styleable.Button_isLoading, false)
-            } finally {
-                styledAttrs.recycle()
-            }
-        }
-    }
-
-    private fun setupViewProperties() {
-        this.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-        isClickable = false
-        setPadding(0, 0, 0, 0)
-        setBackgroundColor(Color.TRANSPARENT)
-        originalTextColors = buttonNormal.textColors
-    }
-
-    private fun setupButtonNormal() {
-        buttonNormal.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            showTextOnly()
-        }
-    }
-
-    private fun setupButtonLoading() {
-        buttonLoading.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            showTextOnly()
-            icon = AppCompatResources.getDrawable(context, R.drawable.empty_material_button_icon)
-            text = ""
-        }
-    }
-
-    private fun setupProgressBar() {
-        progressBar.apply {
-            layoutParams = LayoutParams(buttonLoading.iconSize, buttonLoading.iconSize)
-                .apply {
-                    gravity = Gravity.CENTER
-                }
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-            isIndeterminate = true
-            indeterminateTintMode = PorterDuff.Mode.SRC_IN
-            visibility = INVISIBLE
-        }
-    }
-
-    private fun setButtonBackground() {
-        buttonBackground.apply {
-            id = NO_ID
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
-            layoutParams = LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            icon = null
-            setTextColor(Color.TRANSPARENT)
-            visibility = VISIBLE
-            setOnTouchListener { view, event ->
-                when (event.action) {
-                    MotionEvent.ACTION_DOWN -> {
-                        buttonNormal.isPressed = true
-                        buttonLoading.isPressed = true
-                    }
-
-                    MotionEvent.ACTION_MOVE -> {
-                        val outsideBounds =
-                            event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
-                        buttonNormal.isPressed = !outsideBounds
-                        buttonLoading.isPressed = !outsideBounds
-                    }
-
-                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                        buttonNormal.isPressed = false
-                        buttonLoading.isPressed = false
-                        view.performClick()
-                    }
-                }
-                false
-            }
-        }
-    }
-
-    private fun addViews() {
-        addView(buttonBackground)
-        addView(buttonNormal)
-        addView(buttonLoading)
-        addView(progressBar)
     }
 
     private fun switchState() {

--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -191,6 +191,7 @@ class ProgressButton : FrameLayout {
         }
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun setButtonBackground() {
         buttonBackground.apply {
             id = NO_ID
@@ -203,36 +204,27 @@ class ProgressButton : FrameLayout {
             setTextColor(Color.TRANSPARENT)
             visibility = VISIBLE
             setOnTouchListener { view, event ->
-                var eventConsumed = false
                 when (event.action) {
                     MotionEvent.ACTION_DOWN -> {
-                        setButtonPressed(true)
+                        buttonNormal.isPressed = true
+                        buttonLoading.isPressed = true
                     }
 
                     MotionEvent.ACTION_MOVE -> {
                         val outsideBounds =
                             event.x < 0 || event.y < 0 || event.x > view.measuredWidth || event.y > view.measuredHeight
-                        setButtonPressed(!outsideBounds)
+                        buttonNormal.isPressed = !outsideBounds
+                        buttonLoading.isPressed = !outsideBounds
                     }
 
-                    MotionEvent.ACTION_UP -> {
-                        setButtonPressed(false)
-                        view.performClick()
-                        eventConsumed = true
-                    }
-
-                    MotionEvent.ACTION_CANCEL -> {
-                        setButtonPressed(false)
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                        buttonNormal.isPressed = false
+                        buttonLoading.isPressed = false
                     }
                 }
-                eventConsumed
+                false
             }
         }
-    }
-
-    private fun setButtonPressed(pressed: Boolean) {
-        buttonNormal.isPressed = pressed
-        buttonLoading.isPressed = pressed
     }
 
     private fun addViews() {


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix acceptance errors of v15.0.1. PerformClick call was causing double calls to progressButton. Also if you scroll starting from the button, lifting your finger activates the button.

### :construction: How do we do it?
Deleted performClick call and added SuppressLint annotation

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
Tested [in this PR](https://github.com/Telefonica/android-messenger/actions/runs/11703406958/job/32593677318?pr=2452) with this [snapshot (15.0.1.2-SNAPSHOT)](https://github.com/Telefonica/mistica-android/actions/runs/11702882702/job/32592000326)
