### PR TITLE
ANDROID-15325 Compose Input test ids

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/CharsCounter.kt
@@ -3,6 +3,7 @@ package com.telefonica.mistica.compose.input
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.telefonica.mistica.compose.theme.MisticaTheme
 
@@ -18,7 +19,7 @@ internal fun CharsCounter(
         color = if (isError) MisticaTheme.colors.error else MisticaTheme.colors.textSecondary,
         textAlign = TextAlign.End,
         style = MisticaTheme.typography.preset1,
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.END_HELPER_TEXT),
     )
 }
 

--- a/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
@@ -2,7 +2,6 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -24,7 +23,8 @@ fun EmailInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.EMAIL_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.EMAIL_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/EmailInput.kt
@@ -2,6 +2,7 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -23,7 +24,7 @@ fun EmailInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.EMAIL_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -2,7 +2,6 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -25,7 +24,8 @@ fun NumberInput(
 ) {
 
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.DECIMAL_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.DECIMAL_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/NumberInput.kt
@@ -2,6 +2,7 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -24,7 +25,7 @@ fun NumberInput(
 ) {
 
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.DECIMAL_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
@@ -36,7 +36,7 @@ fun PasswordInput(
     }
 
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.PASSWORD_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PasswordInput.kt
@@ -36,7 +36,8 @@ fun PasswordInput(
     }
 
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.PASSWORD_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.PASSWORD_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
@@ -2,6 +2,7 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -23,7 +24,7 @@ fun PhoneInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.PHONE_NUMBER_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/PhoneInput.kt
@@ -2,7 +2,6 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -24,7 +23,8 @@ fun PhoneInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.PHONE_NUMBER_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.PHONE_NUMBER_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/SearchInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/SearchInput.kt
@@ -29,7 +29,7 @@ fun SearchInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.SEARCH_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/SearchInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/SearchInput.kt
@@ -29,7 +29,8 @@ fun SearchInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.SEARCH_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.SEARCH_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -34,7 +35,7 @@ fun TextAreaInput(
     }
 
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.TEXT_INPUT),
         value = value,
         onValueChange = { newValue ->
             currentChars = doOnValueChange(maxChars, newValue, onValueChange)

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextAreaInput.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -35,7 +34,8 @@ fun TextAreaInput(
     }
 
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.TEXT_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.TEXT_INPUT,
         value = value,
         onValueChange = { newValue ->
             currentChars = doOnValueChange(maxChars, newValue, onValueChange)

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
@@ -2,7 +2,6 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -24,7 +23,8 @@ fun TextInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     TextInputImpl(
-        modifier = modifier.testTag(TextInputTestTags.TEXT_INPUT),
+        modifier = modifier,
+        testTag = TextInputTestTags.TEXT_INPUT,
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInput.kt
@@ -2,6 +2,7 @@ package com.telefonica.mistica.compose.input
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 
@@ -23,7 +24,7 @@ fun TextInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     TextInputImpl(
-        modifier = modifier,
+        modifier = modifier.testTag(TextInputTestTags.TEXT_INPUT),
         value = value,
         onValueChange = onValueChange,
         label = label,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -39,6 +39,7 @@ internal fun TextInputImpl(
     isInverse: Boolean,
     enabled: Boolean,
     readOnly: Boolean,
+    testTag: String,
     isTextArea: Boolean = false,
     onClick: (() -> Unit)?,
     visualTransformation: VisualTransformation,
@@ -68,7 +69,7 @@ internal fun TextInputImpl(
                     Modifier.height(152.dp)
                 } else {
                     Modifier
-                },
+                }.testTag(testTag),
             ),
         )
         Underline(
@@ -219,6 +220,7 @@ fun PreviewTextInput() {
         isInverse = false,
         enabled = true,
         readOnly = false,
+        testTag = "",
         onClick = { },
         visualTransformation = VisualTransformation.None,
         keyboardOptions = FoundationKeyboardOptions(),
@@ -240,6 +242,7 @@ fun PreviewEmptyTextInput() {
         isInverse = false,
         enabled = true,
         readOnly = false,
+        testTag = "",
         onClick = { },
         visualTransformation = VisualTransformation.None,
         keyboardOptions = FoundationKeyboardOptions(),

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -123,6 +123,7 @@ private fun TextBox(
                     visualTransformation.filter(AnnotatedString(value))
                 }
                 TextInputLabel(
+                    modifier = Modifier.testTag(TextInputTestTags.LABEL),
                     text = it,
                     inputIsNotEmpty = transformedText.text.isNotEmpty(),
                     isFocused = interactionSource.collectIsFocusedAsState().value,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputImpl.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -105,7 +107,6 @@ private fun TextBox(
 
     TextField(
         modifier = modifier
-            .testTag(TextInputTestTags.TEXT_INPUT)
             .fillMaxWidth()
             .border(
                 width = 1.dp,
@@ -132,8 +133,28 @@ private fun TextBox(
         interactionSource = interactionSource,
         keyboardOptions = keyboardOptions,
         isError = isError,
-        leadingIcon = leadingIcon,
-        trailingIcon = trailingIcon,
+        leadingIcon = leadingIcon?.let { icon ->
+            {
+                Box(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .testTag(TextInputTestTags.START_ICON)
+                ) {
+                    icon()
+                }
+            }
+        },
+        trailingIcon = trailingIcon?.let { icon ->
+            {
+                Box(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .testTag(TextInputTestTags.END_ICON)
+                ) {
+                    icon()
+                }
+            }
+        },
         shape = RoundedCornerShape(MisticaTheme.radius.inputBorderRadius),
         colors = TextFieldDefaults.textFieldColors(
             backgroundColor = MisticaTheme.colors.backgroundContainer,

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
@@ -7,6 +7,7 @@ object TextInputTestTags {
     const val PHONE_NUMBER_INPUT = "PhoneNumberField"
     const val EMAIL_INPUT = "EmailField"
     const val DECIMAL_INPUT = "DecimalField"
+    const val LABEL = "label"
     const val HELPER_TEXT = "helperText"
     const val END_HELPER_TEXT = "endHelperText"
     const val ERROR_TEXT = "errorText"

--- a/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/TextInputTestTags.kt
@@ -1,7 +1,18 @@
 package com.telefonica.mistica.compose.input
 
 object TextInputTestTags {
-    const val TEXT_INPUT = "text_input"
+    const val TEXT_INPUT = "TextField"
+    const val PASSWORD_INPUT = "PasswordField"
+    const val SEARCH_INPUT = "SearchField"
+    const val PHONE_NUMBER_INPUT = "PhoneNumberField"
+    const val EMAIL_INPUT = "EmailField"
+    const val DECIMAL_INPUT = "DecimalField"
+    const val HELPER_TEXT = "helperText"
+    const val END_HELPER_TEXT = "endHelperText"
+    const val ERROR_TEXT = "errorText"
+    const val START_ICON = "startIcon"
+    const val END_ICON = "endIcon"
+
     const val PASSWORD_VISIBILITY_TOGGLE = "password_visibility_toggle"
     const val CLEAR_SEARCH_BUTTON = "clear_search_button"
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/Underline.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/Underline.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.compose.theme.MisticaTheme
@@ -43,11 +44,13 @@ internal fun Underline(
         Row(modifier = Modifier.fillMaxWidth()) {
             Box {
                 UnderlineTextAnimatedVisibility(
+                    isError = isError,
                     visible = !isError && helperText != null,
                     text = helperText,
                     color = LocalUnderlineTextColors.current.helperTextColor,
                 )
                 UnderlineTextAnimatedVisibility(
+                    isError = isError,
                     visible = isError && errorText != null,
                     text = errorText,
                     color = LocalUnderlineTextColors.current.errorTextColor,
@@ -65,6 +68,7 @@ internal fun Underline(
 
 @Composable
 private fun UnderlineTextAnimatedVisibility(
+    isError: Boolean,
     visible: Boolean,
     text: String?,
     color: Color,
@@ -75,18 +79,29 @@ private fun UnderlineTextAnimatedVisibility(
         exit = fadeOut(animationSpec = tween(0)),
     ) {
         if (text != null) {
-            UnderlineText(text = text, color = color)
+            UnderlineText(
+                modifier = Modifier.testTag(
+                    if (isError) {
+                        TextInputTestTags.ERROR_TEXT
+                    } else {
+                        TextInputTestTags.HELPER_TEXT
+                    }
+                ),
+                text = text,
+                color = color,
+            )
         }
     }
 }
 
 @Composable
 private fun UnderlineText(
+    modifier: Modifier,
     text: String,
     color: Color,
 ) {
     Text(
-        modifier = Modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp),
+        modifier = modifier.padding(top = 4.dp, start = 14.dp, end = 14.dp),
         text = text,
         style = MisticaTheme.typography.preset1,
         color = color,


### PR DESCRIPTION
### :goal_net: What's the goal?
Test IDs for input component (only compose by now)

### :construction: How do we do it?
I added the following IDs:
- TextField
- PasswordField
- SearchField
- PhoneNumberField
- EmailField
- DecimalField
- label
- helperText
- endHelperText
- errorText
- startIcon
- endIcon

Following IDs weren't added because associated input fields or features are not implemented yet:
- CreditCardexpirationField
- CreditCardNumberField
- CvvField
- DateField
- DateTimeField
- IbanField
- IntegerField
- MonthField
- PinField
- placeholder

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
- [x] Mistica App QR or download link
- [x] Reviewed by Mistica design team
