### PR TITLE
ANDROID-15374 divider implemented in informative sheet

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
@@ -24,6 +24,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.telefonica.mistica.R
 import com.telefonica.mistica.button.Button
 import com.telefonica.mistica.list.MisticaRecyclerView
+import com.telefonica.mistica.list.decoration.divider.DividerItemAdapter
+import com.telefonica.mistica.list.decoration.divider.DividerItemDecoration
 import com.telefonica.mistica.list.layout.configureWithFullWidthLayout
 import com.telefonica.mistica.sheet.Children.BottomActions
 import com.telefonica.mistica.sheet.Children.ListActions
@@ -250,6 +252,7 @@ private fun ListInformative.toView(context: Context): View =
     RecyclerView(context).also {
         it.layoutManager = LinearLayoutManager(context)
         it.adapter = InformativeListAdapter(this.elements.mapToInformativeViewData())
+        it.configureWithFullWidthLayout()
     }
 
 private fun BottomActions.toView(onSheetTapped: InternalOnSheetTapped, container: ViewGroup): View {

--- a/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/Sheet.kt
@@ -24,8 +24,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.telefonica.mistica.R
 import com.telefonica.mistica.button.Button
 import com.telefonica.mistica.list.MisticaRecyclerView
-import com.telefonica.mistica.list.decoration.divider.DividerItemAdapter
-import com.telefonica.mistica.list.decoration.divider.DividerItemDecoration
 import com.telefonica.mistica.list.layout.configureWithFullWidthLayout
 import com.telefonica.mistica.sheet.Children.BottomActions
 import com.telefonica.mistica.sheet.Children.ListActions

--- a/library/src/main/java/com/telefonica/mistica/sheet/children/list/adapter/InformativeListAdapter.kt
+++ b/library/src/main/java/com/telefonica/mistica/sheet/children/list/adapter/InformativeListAdapter.kt
@@ -54,11 +54,7 @@ internal class InformativeListAdapter(val items: List<RowInformativeViewData>) :
             }
         }
 
-        if (position == items.size - 1) {
-            holder.bottomExtraSpace.visibility = View.VISIBLE
-        } else {
-            holder.bottomExtraSpace.visibility = View.GONE
-        }
+        holder.bottomExtraSpace.visibility = View.VISIBLE
     }
 
     override fun getItemCount(): Int = items.size

--- a/library/src/main/res/layout/sheet_list_row_informative.xml
+++ b/library/src/main/res/layout/sheet_list_row_informative.xml
@@ -93,7 +93,7 @@
 	<Space
 			android:id="@+id/sheet_row_informative_bottom_extra_space"
 			android:layout_width="match_parent"
-			android:layout_height="8dp"
+			android:layout_height="16dp"
 			android:visibility="visible"
 			app:layout_constraintTop_toBottomOf="@+id/sheet_row_action_text_barrier"
 			/>


### PR DESCRIPTION
### :goal_net: What's the goal?
_We need a divider in the informative sheet recycler view to match [design's specification](https://www.figma.com/design/nxToAYk7FGC86TS0mY61TU/%F0%9F%94%B8-Sheet-Specs?node-id=1960-11572&node-type=frame&t=GY2xRf2pOjf1qSDX-0)._

### :construction: How do we do it?
- Use our existing custom recycler view extension **configureWithFullWidthLayout** when we are configuring the informative sheet recycler.
- Do some modifications within InformativeListAdapter and sheet_list_row_informative.xml to have item spacing exactly as shown in the spec.

Right after invoking **configureWithFullWidthLayout** the UI was like this.
<img src="https://github.com/user-attachments/assets/85c126c5-27e2-41f7-aba4-488dda41a67c" alt="drawing" width="200"/>

After modifying InformativeListAdapter to have below space in all cases, the UI was like this because this below space was 8dp (whereas figma's space is 16dp).
<img src="https://github.com/user-attachments/assets/b73231ee-6572-49d8-86e4-36c668e68a57" alt="drawing" width="200"/>

This is the final result.

| Before        | After           |
| ------------- |-------------|
| <img src="https://github.com/user-attachments/assets/624ed01a-96d6-4e94-bfc9-8beadaeb05be" alt="drawing" width="200"/>      | <img src="https://github.com/user-attachments/assets/2af8114f-6115-41eb-9252-824d8054c48c" alt="drawing" width="200"/> |
| <img src="https://github.com/user-attachments/assets/24b75553-3f83-4ccb-a1b2-c771aedcb313" alt="drawing" width="200"/>      | <img src="https://github.com/user-attachments/assets/8d75885c-4f11-41b0-b52d-b6840d3c1191" alt="drawing" width="200"/> |
| <img src="https://github.com/user-attachments/assets/1b9d6578-b3b9-47b5-8a77-663b504b8e50" alt="drawing" width="200"/>      | <img src="https://github.com/user-attachments/assets/0d830783-e714-4c14-a28b-11cbb7c8af2b" alt="drawing" width="200"/> |

### ☑️ Checks
- No documents needed to be updated.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- No accessibility considerations needed.

### :test_tube: How can I test this?
- Open the mistica's sample app.
- Navigate to Sheet, select **Children type** as **Informative** and put whatever **Icon type** you want.

- [x] 🖼️ Screenshots/Videos
- [x] Mistica App QR or [download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/657)
- [x] Reviewed by Mistica design team
