### PR TITLE
ANDROID-15581 Upgrade material lib & do not expose internal dependencies as api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         constraintComposeVersion = '1.0.1'
         detekt_version = '1.23.7'
         roborazzi_version = "1.26.0"
+        material_version = "1.12.0"
     }
     repositories {
         google()

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -51,6 +51,7 @@ task sourceJar(type: Jar) {
 dependencies {
     implementation project(':library')
 
+    implementation "com.google.android.material:material:1.12.0"
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.constraintlayout:constraintlayout-compose:$constraintComposeVersion"
     implementation 'androidx.activity:activity-compose:1.4.0'

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -51,7 +51,7 @@ task sourceJar(type: Jar) {
 dependencies {
     implementation project(':library')
 
-    implementation "com.google.android.material:material:1.12.0"
+    implementation "com.google.android.material:material:$material_version"
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.constraintlayout:constraintlayout-compose:$constraintComposeVersion"
     implementation 'androidx.activity:activity-compose:1.4.0'

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Tags.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Tags.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.compose.tag.Tag
 import com.telefonica.mistica.compose.theme.MisticaTheme
 import com.telefonica.mistica.compose.theme.brand.MovistarBrand
@@ -64,25 +65,25 @@ fun Tags() {
                     .padding(top = 16.dp)
                     .height(60.dp)
             ) {
-                Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = android.R.drawable.ic_lock_power_off)
+                Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = R.drawable.icn_cross)
             }
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
             ) {
-                item { Tag(text = "Promotion", style = TagView.TYPE_PROMO, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
-                item { Tag(text = "Active", style = TagView.TYPE_ACTIVE, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
-                item { Tag(text = "Inactive", style = TagView.TYPE_INACTIVE, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
-                item { Tag(text = "Success", style = TagView.TYPE_SUCCESS, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
-                item { Tag(text = "Warning", style = TagView.TYPE_WARNING, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
-                item { Tag(text = "Error", style = TagView.TYPE_ERROR, modifier = Modifier.padding(4.dp), icon = android.R.drawable.ic_lock_power_off) }
+                item { Tag(text = "Promotion", style = TagView.TYPE_PROMO, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
+                item { Tag(text = "Active", style = TagView.TYPE_ACTIVE, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
+                item { Tag(text = "Inactive", style = TagView.TYPE_INACTIVE, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
+                item { Tag(text = "Success", style = TagView.TYPE_SUCCESS, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
+                item { Tag(text = "Warning", style = TagView.TYPE_WARNING, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
+                item { Tag(text = "Error", style = TagView.TYPE_ERROR, modifier = Modifier.padding(4.dp), icon = R.drawable.icn_cross) }
             }
         }
 
         Divider(thickness = 2.dp)
 
         Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 16.dp))
-        Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 8.dp), icon = android.R.drawable.ic_lock_power_off)
+        Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 8.dp), icon = R.drawable.icn_cross)
 
         Surface(
             color = MisticaTheme.colors.brand,
@@ -96,8 +97,7 @@ fun Tags() {
                 verticalArrangement = Arrangement.Center,
             ) {
                 Tag(text = customText.value.text, style = TagView.TYPE_INVERSE)
-                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE, modifier = Modifier.padding(top = 8.dp), icon = android.R.drawable
-                    .ic_lock_power_off)
+                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE, modifier = Modifier.padding(top = 8.dp), icon = R.drawable.icn_cross)
             }
         }
 

--- a/library-test-utils/build.gradle
+++ b/library-test-utils/build.gradle
@@ -36,6 +36,7 @@ android {
 
 dependencies {
     implementation project(':library')
+    implementation "androidx.compose.runtime:runtime:$compose_ui_version"
 
     implementation 'androidx.core:core-ktx:1.13.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -72,7 +72,7 @@ task sourceJar(type: Jar) {
 }
 
 dependencies {
-    implementation "com.google.android.material:material:1.12.0"
+    implementation "com.google.android.material:material:$material_version"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -72,11 +72,11 @@ task sourceJar(type: Jar) {
 }
 
 dependencies {
-    api "com.google.android.material:material:1.6.1"
-    api 'androidx.constraintlayout:constraintlayout:2.0.4'
-    api 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
-    api 'androidx.recyclerview:recyclerview:1.1.0'
-    api "androidx.compose.runtime:runtime:$compose_ui_version"
+    implementation "com.google.android.material:material:1.12.0"
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.constraintlayout:constraintlayout-solver:2.0.4'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation "androidx.compose.runtime:runtime:$compose_ui_version"
 
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.activity:activity-compose:1.4.0'


### PR DESCRIPTION
### :goal_net: What's the goal?

Related to https://jira.tid.es/browse/ANDROID-15454. Upgrade material lib in mistica, which is used by android-messenger.

Tagged as breaking change because it does not exposes anymore the internal libraries as api, so apps may need to declare their dependencies explicitly.

### :construction: How do we do it?
* Just raise version & review catalog components are working correctly with new material version.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] No sync with iOS Needed.
- [x] No accessibility changes.

### :test_tube: How can I test this?
- [x] [Mistica App QR or download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/688)
- [x] Reviewed by Mistica design team (Nothing to Review, just need approval to follow the process)
