### PR TITLE
SMARTWIFI-10829 tags update

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/DataCardFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/DataCardFragment.kt
@@ -21,7 +21,6 @@ import com.telefonica.mistica.tag.TagStyle
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ACTIVE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ERROR
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_INACTIVE
-import com.telefonica.mistica.tag.TagView.Companion.TYPE_INVERSE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_SUCCESS
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_WARNING
@@ -132,7 +131,6 @@ class DataCardFragment : Fragment() {
         SUCCESS(TYPE_SUCCESS),
         WARNING(TYPE_WARNING),
         ERROR(TYPE_ERROR),
-        INVERSE(TYPE_INVERSE),
     }
 
     private enum class IconTypes(@AttrRes val iconType: Int) {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
@@ -29,7 +29,6 @@ import com.telefonica.mistica.list.MisticaRecyclerView
 import com.telefonica.mistica.list.model.ImageDimensions
 import com.telefonica.mistica.tag.TagStyle
 import com.telefonica.mistica.tag.TagView
-import com.telefonica.mistica.tag.TagView.Companion.TYPE_INVERSE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 import com.telefonica.mistica.util.convertDpToPx
 
@@ -194,7 +193,7 @@ class ListsCatalogFragment : Fragment() {
                 val headlineText = "Headline"
                 setHeadlineLayout(layoutRes = R.layout.list_row_tag_headline, contentDescription = headlineText)
                 (getHeadline()!! as TagView).apply {
-                    setTagStyle(if (withInverseBackground) TYPE_INVERSE else withHeadlineStyle)
+                    setTagStyle(withHeadlineStyle)
                     text = headlineText
                 }
             } else {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/TagsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/TagsCatalogFragment.kt
@@ -30,8 +30,6 @@ class TagsCatalogFragment : Fragment() {
         val tagViews = listOf<TagView>(
             view.findViewById(R.id.regular_tag),
             view.findViewById(R.id.regular_with_icon_tag),
-            view.findViewById(R.id.inverse_tag),
-            view.findViewById(R.id.inverse_with_icon_tag),
         )
 
         textInput.addTextChangedListener(object : TextWatcher {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/DataCards.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/DataCards.kt
@@ -148,7 +148,6 @@ private enum class TagColors(@AttrRes val tagStyle: Int) {
     SUCCESS(TagView.TYPE_SUCCESS),
     WARNING(TagView.TYPE_WARNING),
     ERROR(TagView.TYPE_ERROR),
-    INVERSE(TagView.TYPE_INVERSE),
 }
 
 private enum class IconTypes(@AttrRes val iconType: Int) {

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/PosterCards.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/PosterCards.kt
@@ -161,7 +161,6 @@ private enum class TagColorsValues(@AttrRes val tagStyle: Int) {
     SUCCESS(TagView.TYPE_SUCCESS),
     WARNING(TagView.TYPE_WARNING),
     ERROR(TagView.TYPE_ERROR),
-    INVERSE(TagView.TYPE_INVERSE),
 }
 
 private val aspectRatioLabelsMaps = mapOf(

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Tags.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Tags.kt
@@ -4,12 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.Divider
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
@@ -34,19 +32,11 @@ fun Tags() {
     Column(
         modifier = Modifier.padding(vertical = 32.dp, horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+        verticalArrangement = Arrangement.Top,
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Surface(
-                color = MisticaTheme.colors.brand,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-            ) {
-                Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp))
-            }
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
@@ -57,15 +47,6 @@ fun Tags() {
                 item { Tag(text = "Success", style = TagView.TYPE_SUCCESS, modifier = Modifier.padding(4.dp)) }
                 item { Tag(text = "Warning", style = TagView.TYPE_WARNING, modifier = Modifier.padding(4.dp)) }
                 item { Tag(text = "Error", style = TagView.TYPE_ERROR, modifier = Modifier.padding(4.dp)) }
-            }
-            Surface(
-                color = MisticaTheme.colors.brand,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp)
-                    .height(60.dp)
-            ) {
-                Tag(text = "Inverse", style = TagView.TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = R.drawable.icn_cross)
             }
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
@@ -84,22 +65,6 @@ fun Tags() {
 
         Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 16.dp))
         Tag(text = customText.value.text, style = TagView.TYPE_PROMO, modifier = Modifier.padding(top = 8.dp), icon = R.drawable.icn_cross)
-
-        Surface(
-            color = MisticaTheme.colors.brand,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 16.dp)
-                .height(96.dp)
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE)
-                Tag(text = customText.value.text, style = TagView.TYPE_INVERSE, modifier = Modifier.padding(top = 8.dp), icon = R.drawable.icn_cross)
-            }
-        }
 
         TextField(
             value = customText.value,

--- a/catalog/src/main/res/layout/screen_tags_catalog.xml
+++ b/catalog/src/main/res/layout/screen_tags_catalog.xml
@@ -9,27 +9,6 @@
 		android:padding="16dp"
 		>
 
-	<FrameLayout
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:background="?attr/colorBrand"
-			android:layout_marginTop="16dp"
-			android:padding="16dp"
-			android:gravity="center"
-			>
-
-		<com.telefonica.mistica.tag.TagView
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_columnWeight="1"
-				android:layout_gravity="center"
-				android:text="Inverse"
-				app:tagStyle="inverse"
-				tools:text="@tools:sample/full_names"
-				/>
-
-	</FrameLayout>
-
 	<GridLayout
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
@@ -97,28 +76,6 @@
 				tools:text="@tools:sample/full_names"
 				/>
 	</GridLayout>
-
-	<FrameLayout
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:background="?attr/colorBrand"
-			android:layout_marginTop="16dp"
-			android:padding="16dp"
-			android:gravity="center"
-			>
-
-		<com.telefonica.mistica.tag.TagView
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_columnWeight="1"
-				android:layout_gravity="center"
-				android:text="Inverse"
-				app:tagStyle="inverse"
-				app:tagIcon="@drawable/icn_cross"
-				tools:text="@tools:sample/full_names"
-				/>
-
-	</FrameLayout>
 
 	<GridLayout
 			android:layout_width="match_parent"
@@ -221,38 +178,6 @@
 			app:tagIcon="@drawable/icn_cross"
 			tools:text="@tools:sample/full_names"
 			/>
-
-	<LinearLayout
-			android:gravity="center"
-			android:layout_width="match_parent"
-			android:layout_marginTop="16dp"
-			android:layout_height="wrap_content"
-			android:padding="16dp"
-			android:background="?attr/colorBrand"
-			android:orientation="vertical"
-			>
-
-		<com.telefonica.mistica.tag.TagView
-				android:id="@+id/inverse_tag"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:text="Promotion"
-				app:tagStyle="inverse"
-				tools:text="@tools:sample/full_names"
-				/>
-
-		<com.telefonica.mistica.tag.TagView
-				android:id="@+id/inverse_with_icon_tag"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_marginTop="8dp"
-				android:text="Promotion"
-				app:tagStyle="inverse"
-				app:tagIcon="@drawable/icn_cross"
-				tools:text="@tools:sample/full_names"
-				/>
-
-	</LinearLayout>
 
 	<com.telefonica.mistica.input.TextInput
 			android:id="@+id/textInput"

--- a/library/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -148,12 +148,12 @@ internal fun TagPreview() {
 @Composable
 @Suppress("CyclomaticComplexMethod")
 private fun Int.getStyle() = when (this) {
-    TYPE_PROMO -> with(MisticaTheme.colors) { promoLow to promoHigh }
-    TYPE_ACTIVE -> with(MisticaTheme.colors) { brandLow to brand }
-    TYPE_INACTIVE -> with(MisticaTheme.colors) { neutralLow to neutralMedium }
-    TYPE_SUCCESS -> with(MisticaTheme.colors) { successLow to successHigh }
-    TYPE_WARNING -> with(MisticaTheme.colors) { warningLow to warningHigh }
-    TYPE_ERROR -> with(MisticaTheme.colors) { errorLow to errorHigh }
+    TYPE_PROMO -> with(MisticaTheme.colors) { tagBackgroundPromo to tagTextPromo }
+    TYPE_ACTIVE -> with(MisticaTheme.colors) { tagBackgroundActive to tagTextActive }
+    TYPE_INACTIVE -> with(MisticaTheme.colors) { tagBackgroundInactive to tagTextInactive }
+    TYPE_SUCCESS -> with(MisticaTheme.colors) { tagBackgroundSuccess to tagTextSuccess }
+    TYPE_WARNING -> with(MisticaTheme.colors) { tagBackgroundWarning to tagTextWarning }
+    TYPE_ERROR -> with(MisticaTheme.colors) { tagBackgroundError to tagTextError }
     TYPE_INVERSE -> with(MisticaTheme.colors) { inverse to brand }
-    else -> with(MisticaTheme.colors) { promoLow to promoHigh }
+    else -> with(MisticaTheme.colors) { tagBackgroundPromo to tagTextPromo }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/tag/Tag.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -33,7 +32,6 @@ import com.telefonica.mistica.tag.TagStyle
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ACTIVE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ERROR
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_INACTIVE
-import com.telefonica.mistica.tag.TagView.Companion.TYPE_INVERSE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_SUCCESS
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_WARNING
@@ -122,14 +120,6 @@ internal fun TagPreview() {
                 .padding(vertical = 32.dp, horizontal = 16.dp)
                 .background(MisticaTheme.colors.backgroundContainer),
         ) {
-            Surface(
-                color = MisticaTheme.colors.brand,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-            ) {
-                Tag(text = "Inverse", style = TYPE_INVERSE, modifier = Modifier.padding(8.dp), icon = android.R.drawable.ic_lock_power_off)
-            }
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier.padding(16.dp)
@@ -154,6 +144,5 @@ private fun Int.getStyle() = when (this) {
     TYPE_SUCCESS -> with(MisticaTheme.colors) { tagBackgroundSuccess to tagTextSuccess }
     TYPE_WARNING -> with(MisticaTheme.colors) { tagBackgroundWarning to tagTextWarning }
     TYPE_ERROR -> with(MisticaTheme.colors) { tagBackgroundError to tagTextError }
-    TYPE_INVERSE -> with(MisticaTheme.colors) { inverse to brand }
     else -> with(MisticaTheme.colors) { tagBackgroundPromo to tagTextPromo }
 }

--- a/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
+++ b/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
@@ -88,14 +88,14 @@ class TagView @JvmOverloads constructor(
     }
 
     private fun Int.getStyle() = when (this) {
-        TYPE_PROMO -> R.attr.colorPromoLow to R.attr.colorPromoHigh
-        TYPE_ACTIVE -> R.attr.colorBrandLow to R.attr.colorBrand
-        TYPE_INACTIVE -> R.attr.colorNeutralLow to R.attr.colorNeutralMedium
-        TYPE_SUCCESS -> R.attr.colorSuccessLow to R.attr.colorSuccessHigh
-        TYPE_WARNING -> R.attr.colorWarningLow to R.attr.colorWarningHigh
-        TYPE_ERROR -> R.attr.colorErrorLow to R.attr.colorErrorHigh
+        TYPE_PROMO -> R.attr.colorTagBackgroundPromo to R.attr.colorTagTextPromo
+        TYPE_ACTIVE -> R.attr.colorTagBackgroundActive to R.attr.colorTagTextActive
+        TYPE_INACTIVE -> R.attr.colorTagBackgroundInactive to R.attr.colorTagTextInactive
+        TYPE_SUCCESS -> R.attr.colorTagBackgroundSuccess to R.attr.colorTagTextSuccess
+        TYPE_WARNING -> R.attr.colorTagBackgroundWarning to R.attr.colorTagTextWarning
+        TYPE_ERROR -> R.attr.colorTagBackgroundError to R.attr.colorTagTextError
         TYPE_INVERSE -> R.attr.colorInverse to R.attr.colorBrand
-        else -> R.attr.colorPromoLow to R.attr.colorPromoHigh
+        else -> R.attr.colorTagBackgroundPromo to R.attr.colorTagTextPromo
     }
 
     companion object {

--- a/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
+++ b/library/src/main/java/com/telefonica/mistica/tag/TagView.kt
@@ -13,7 +13,6 @@ import com.telefonica.mistica.R
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ACTIVE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_ERROR
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_INACTIVE
-import com.telefonica.mistica.tag.TagView.Companion.TYPE_INVERSE
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_PROMO
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_SUCCESS
 import com.telefonica.mistica.tag.TagView.Companion.TYPE_WARNING
@@ -28,7 +27,6 @@ import com.telefonica.mistica.util.getThemeColor
     TYPE_SUCCESS,
     TYPE_WARNING,
     TYPE_ERROR,
-    TYPE_INVERSE,
 )
 annotation class TagStyle
 
@@ -94,7 +92,6 @@ class TagView @JvmOverloads constructor(
         TYPE_SUCCESS -> R.attr.colorTagBackgroundSuccess to R.attr.colorTagTextSuccess
         TYPE_WARNING -> R.attr.colorTagBackgroundWarning to R.attr.colorTagTextWarning
         TYPE_ERROR -> R.attr.colorTagBackgroundError to R.attr.colorTagTextError
-        TYPE_INVERSE -> R.attr.colorInverse to R.attr.colorBrand
         else -> R.attr.colorTagBackgroundPromo to R.attr.colorTagTextPromo
     }
 
@@ -105,6 +102,5 @@ class TagView @JvmOverloads constructor(
         const val TYPE_SUCCESS = 3
         const val TYPE_WARNING = 4
         const val TYPE_ERROR = 5
-        const val TYPE_INVERSE = 6
     }
 }

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -17,7 +17,6 @@
 		<enum name="success" value="3" />
 		<enum name="warning" value="4" />
 		<enum name="error" value="5" />
-		<enum name="inverse" value="6" />
 	</attr>
 
     <declare-styleable name="FeedbackScreen">


### PR DESCRIPTION
### :goal_net: What's the goal?
Update tag color tokens and remove inverse.
Discussion about the colors and the inverse removal:
https://teams.microsoft.com/l/message/19:9d2d0d5e2fb6472bb80f534bd702cf20@thread.tacv2/1736771738837?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10&groupId=e265fe99-929f-45d1-8154-699649674a40&parentMessageId=1736771738837&teamName=M%C3%ADstica&channelName=design-appscore&createdTime=1736771738837&ngc=true

### :construction: How do we do it?
- Updated tag tokens following the figma design.
- Removed inverse type (breaking change, Active should be used instead)
- [ ] **Once merged**, add the breaking change to the new mistica version 18.0.0

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [x] 🖼️ Screenshots/Videos

| Before        | After           |
| ------------- |-------------|
| <image src="https://github.com/user-attachments/assets/5f2ddd3e-8a36-4a4b-a1b5-840bc945b588" alt="classic views before" width="200" />      | <image src="https://github.com/user-attachments/assets/8e84a311-ec50-44d5-a6aa-4a810d4aced2" alt="Classic views after" width="200"/> |
| <image src="https://github.com/user-attachments/assets/23852c7b-640f-457b-9542-31a480fa3c88" alt="Compose Before" width="200"/>      | <image src="https://github.com/user-attachments/assets/6e178638-c492-457a-8df4-b24666448820" alt="Compose After" width="200"/> |
| <image src="https://github.com/user-attachments/assets/e3e93bf3-bc03-4f61-b7f6-eb6e82556116" alt="classic views before Dark Mode" width="200" />      | <image src="https://github.com/user-attachments/assets/ec3c31c6-b914-45eb-8a56-6c3b01d4e9e6" alt="Classic views after Dark Mode" width="200"/> |
| <image src="https://github.com/user-attachments/assets/d00e6859-8bf7-4b43-8fff-9161fc45b923" alt="Compose Before Dark Mode" width="200"/>      | <image src="https://github.com/user-attachments/assets/dc056222-24e4-4484-9f8d-433ad24079d5" alt="Compose After Dark Mode" width="200"/> |

- [x] Mistica App QR or download link (PR comment)
- [x] Reviewed by Mistica design team (reviewer added)
