### PR TITLE
ANDROID-15643 Add test tag to Checkbox

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/input/CheckBoxInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/CheckBoxInput.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,6 +36,7 @@ fun CheckBoxInput(
             role = Role.Checkbox
         )) {
             Checkbox(
+                modifier = Modifier.testTag(CheckBoxInputTestTags.CHECKBOX),
                 checked = checked,
                 onCheckedChange = null,
                 enabled = enabled,
@@ -97,4 +99,8 @@ fun PreviewDisabledCheckBoxInput() {
         text = "Disabled checkbox",
         enabled = false,
     )
+}
+
+object CheckBoxInputTestTags {
+    const val CHECKBOX = "checkbox_input_checkbox"
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/input/CheckBoxInput.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/input/CheckBoxInput.kt
@@ -102,5 +102,5 @@ fun PreviewDisabledCheckBoxInput() {
 }
 
 object CheckBoxInputTestTags {
-    const val CHECKBOX = "checkbox_input_checkbox"
+    const val CHECKBOX = "checkbox"
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
`CheckBoxInput` implementation was changed here https://github.com/Telefonica/mistica-android/pull/400 and now the whole `Row` that wraps the `Checkbox` and `TextWithLinks` composables is toggable.

That is more correct in terms of a11y but unexpectedly it has broken some tests in client apps when trying to click on a checkbox with links. The reason is because trying to do some click on a `CheckBoxInput` with a given `testTag` it ends up in a click on the middle of the wrapping `Row` previously mentioned and it may open any link if present.

To prevent that we propose to add some inner testTag to the single Checkbox.

### :construction: How do we do it?
Adding some test tag to the `Checkbox` composable from material user under the hood by `CheckBoxInput`

### ☑️ Checks
- [x] Accessibility considerations.

### :test_tube: How can I test this?
- [x] Mistica App QR or download link
