### PR TITLE
ANDROID-15625 fix two focus points in progress button

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
+++ b/library/src/main/java/com/telefonica/mistica/button/ProgressButton.kt
@@ -145,6 +145,7 @@ class ProgressButton : FrameLayout {
     }
 
     private fun setupViewProperties() {
+        this.descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
         this.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
         isClickable = false
         setPadding(0, 0, 0, 0)


### PR DESCRIPTION
### :goal_net: What's the goal?
- _Prior to these changes, there were two focus points in the ProgressButton when we used a wireless keyboard or had talkback activated._
- _We need to have one single focus point in the progress button, as done with all other buttons._

### :construction: How do we do it?
_As you can see [here](https://developer.android.com/reference/android/view/ViewGroup#attr_android:descendantFocusability), the descendantFocusability attribute value, afterDescendants, forces the element to gain focus only once._
_Modifying the frame layout attribute to afterDescendants fixes the issue._

### ☑️ Checks
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
- Connect a wireless keyboard.
- Navigate to the buttons list.
- Press tab to move the focus among elements.
- See that the "Primary progress" button is only focused once.

- [x] 🖼️ Screenshots/Videos
- [x] Mistica App QR or [download link](https://install.appcenter.ms/orgs/tuenti-organization/apps/mistica-catalog/distribution_groups/public/releases/700)
- [x] Reviewed by Mistica design team

https://github.com/user-attachments/assets/9b37b104-442c-41a9-9432-20140d412337

https://github.com/user-attachments/assets/6c61cb6f-3393-4aef-8aba-caf7a65f9f3a
