### PR TITLE
Adding verbosity to the Pull Requests section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,9 @@ Don't hesitate to ask any questions and share your ideas
 
 ## Pull Requests
 
-We would love to accept your Pull Requests but please, before starting your development,
-[create an issue](https://github.com/Telefonica/mistica-android/issues/new/choose).
-
-Include someone from **Telefonica/mistica-design** team as reviewer.
+We would love to accept your Pull Requests but please
+- Before starting your development, [create an issue](https://github.com/Telefonica/mistica-android/issues/new/choose).
+- Once the pull request is created, make sure that you add someone from **Telefonica/mistica-design** team as reviewer to it.
 
 ## Bug reports
 


### PR DESCRIPTION
### :goal_net: What's the goal?
_Updating CONTRIBUTING.md's Pull Requests section._

### :construction: How do we do it?
_Replace_
```
We would love to accept your Pull Requests but please, before starting your development,
[create an issue](https://github.com/Telefonica/mistica-android/issues/new/choose).

Include someone from **Telefonica/mistica-design** team as reviewer.
```
_with_
```
We would love to accept your Pull Requests but please
- Before starting your development, [create an issue](https://github.com/Telefonica/mistica-android/issues/new/choose).
- Once the pull request is created, make sure that you add someone from **Telefonica/mistica-design** team as reviewer to it.
```

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.

### :test_tube: How can I test this?
_Open [CONTRIBUTING.md](https://github.com/Telefonica/mistica-android/blob/jmanriquehiberus-patch-1/CONTRIBUTING.md) and make sure the text is correct._
