### PR TITLE
ANDROID-15834 Firebase distributions for Mistica

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -28,23 +28,39 @@ jobs:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         run: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'
 
-  firebase-catalog:
+  debug-firebase-catalog:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Telefonica/ios-github-workflows repo
-        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          repository: Telefonica/android-shared-workflows
-          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
-          path: .shared-workflows
-          ref: firebase
+          distribution: 'temurin'
+          java-version: '17'
 
-      - name: Build and Upload to Firebase
-        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build catalog
+        run: 'bash ./gradlew assembleDebug -Dappcenter_notify=false'
+
+      - name: Create firebase service json file
+        run: |
+          echo ${{ secrets.FIREBASE_DIST_CREDENTIALS_NIGHTLY }} | base64 --decode > service-account-file.json
+        shell: bash
+
+      - name: Get Apk path
+        id: get-apk-path
+        run: |
+          apk_path=(**/build/outputs/apk/debug/*.apk)
+          echo "apk_path=${apk_path[0]}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        id: upload-apk
         with:
-          build-tasks: 'assembleDebug'
-          apk-path: '**/build/outputs/apk/debug/*.apk'
-          additional-groups: 'mistica-internal-testers'
-          distribution-track: 'internal'
-          notify-ci-cd-publication: true
-          notify-error-in-publication: true
+          appId: '1:771826505811:android:f64fec267b535d7f974ea6'
+          serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
+          groups: 'mistica-internal-testers'
+          file: ${{ steps.get-apk-path.outputs.apk_path }}

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -29,13 +29,22 @@ jobs:
         run: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'
 
   firebase-catalog:
-    if: github.event.pull_request.merged == true
-    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
-    with:
-      build-tasks: 'assembleDebug'
-      apk-path: '**/build/outputs/apk/debug/*.apk'
-      additional-groups: 'mistica-internal-testers'
-      distribution-track: 'internal'
-      notify-ci-cd-publication: true
-      notify-error-in-publication: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Telefonica/ios-github-workflows repo
+        uses: actions/checkout@v4
+        with:
+          repository: Telefonica/android-shared-workflows
+          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
+          path: .shared-workflows
+          ref: firebase
+
+      - name: Build and Upload to Firebase
+        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+        with:
+          build-tasks: 'assembleDebug'
+          apk-path: '**/build/outputs/apk/debug/*.apk'
+          additional-groups: 'mistica-internal-testers'
+          distribution-track: 'internal'
+          notify-ci-cd-publication: true
+          notify-error-in-publication: true

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -27,3 +27,15 @@ jobs:
         env:
           APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
         run: 'bash ./gradlew clean check appCenterAssembleAndUploadDebug -Dappcenter_app_name=Mistica'
+
+  firebase-catalog:
+    if: github.event.pull_request.merged == true
+    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
+    with:
+      build-tasks: 'assembleDebug'
+      apk-path: '**/build/outputs/apk/debug/*.apk'
+      additional-groups: 'mistica-internal-testers'
+      distribution-track: 'internal'
+      notify-ci-cd-publication: true
+      notify-error-in-publication: true
+    secrets: inherit

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -52,3 +52,12 @@ jobs:
               repo: context.repo.repo,
               body: `📱 New catalog for testing generated: [Download](${{ steps.url-request.outputs.appcenter_url }})`
             })
+
+  debug-firebase-catalog:
+    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
+    with:
+      build-tasks: 'assembleDebug'
+      apk-path: '**/build/outputs/apk/debug/*.apk'
+      additional-groups: 'mistica-internal-testers'
+      notify-publication-as-pr-comment: true
+    secrets: inherit

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -5,6 +5,7 @@ on:
       - '**.md'
       - 'doc/**'
       - 'tokens/**'
+      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get Apk path
         id: get-apk-path
         run: |
-          apk_path=(**/build/outputs/apk/**/debug/*.apk)
+          apk_path=(**/build/outputs/apk/debug/*.apk)
           echo "apk_path=${apk_path[0]}" >> $GITHUB_OUTPUT
         shell: bash
 

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -5,7 +5,6 @@ on:
       - '**.md'
       - 'doc/**'
       - 'tokens/**'
-      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -55,18 +55,47 @@ jobs:
   debug-firebase-catalog:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Telefonica/ios-github-workflows repo
-        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          repository: Telefonica/android-shared-workflows
-          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
-          path: .shared-workflows
-          ref: firebase
+          distribution: 'temurin'
+          java-version: '17'
 
-      - name: Build and Upload to Firebase
-        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build catalog
+        run: 'bash ./gradlew assembleDebug -Dappcenter_notify=false'
+
+      - name: Create firebase service json file
+        run: |
+          echo ${{ secrets.FIREBASE_DIST_CREDENTIALS_ONDEMAND }} | base64 --decode > service-account-file.json
+        shell: bash
+
+      - name: Get Apk path
+        id: get-apk-path
+        run: |
+          apk_path=(**/build/outputs/apk/**/debug/*.apk)
+          echo "apk_path=${apk_path[0]}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        id: upload-apk
         with:
-          build-tasks: 'assembleDebug'
-          apk-path: '**/build/outputs/apk/debug/*.apk'
-          additional-groups: 'mistica-internal-testers'
-          notify-publication-as-pr-comment: true
+          appId: '1:25375145848:android:3d91abf4ac442f4848928d'
+          serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
+          groups: 'mistica-internal-testers'
+          releaseNotes: 'Testing catalog for PR #${{ github.event.number }} ${{ github.sha }}'
+          file: ${{ steps.get-apk-path.outputs.apk_path }}
+
+      - name: Post comment with catalog URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[Firebase] 📱 New catalog for testing generated: [Download](${{ steps.upload-apk.outputs.TESTING_URI }})`
+            })

--- a/.github/workflows/debug_catalog.yml
+++ b/.github/workflows/debug_catalog.yml
@@ -53,10 +53,20 @@ jobs:
             })
 
   debug-firebase-catalog:
-    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
-    with:
-      build-tasks: 'assembleDebug'
-      apk-path: '**/build/outputs/apk/debug/*.apk'
-      additional-groups: 'mistica-internal-testers'
-      notify-publication-as-pr-comment: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Telefonica/ios-github-workflows repo
+        uses: actions/checkout@v4
+        with:
+          repository: Telefonica/android-shared-workflows
+          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
+          path: .shared-workflows
+          ref: firebase
+
+      - name: Build and Upload to Firebase
+        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+        with:
+          build-tasks: 'assembleDebug'
+          apk-path: '**/build/outputs/apk/debug/*.apk'
+          additional-groups: 'mistica-internal-testers'
+          notify-publication-as-pr-comment: true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,23 +6,53 @@ on:
         description: "Snapshot version"
         required: true
 jobs:
-  firebase-catalog:
+  debug-firebase-catalog:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Telefonica/ios-github-workflows repo
-        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          repository: Telefonica/android-shared-workflows
-          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
-          path: .shared-workflows
-          ref: firebase
+          distribution: 'temurin'
+          java-version: '17'
 
-      - name: Build and Upload to Firebase
-        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build catalog
+        run: 'bash ./gradlew assembleDebug -Dappcenter_notify=false'
+
+      - name: Create firebase service json file
+        run: |
+          echo ${{ secrets.FIREBASE_DIST_CREDENTIALS_NIGHTLY }} | base64 --decode > service-account-file.json
+        shell: bash
+
+      - name: Get Apk path
+        id: get-apk-path
+        run: |
+          apk_path=(**/build/outputs/apk/debug/*.apk)
+          echo "apk_path=${apk_path[0]}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        id: upload-apk
         with:
-          build-tasks: 'assembleDebug'
-          apk-path: '**/build/outputs/apk/debug/*.apk'
-          additional-groups: 'mistica-internal-testers'
-          distribution-track: 'internal'
-          notify-ci-cd-publication: true
-          notify-error-in-publication: true
+          appId: '1:413491573542:android:d79e363379e606a7a807e7'
+          serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
+          groups: 'mistica-internal-testers'
+          file: ${{ steps.get-apk-path.outputs.apk_path }}
+
+      - name: Send Notification to Teams about published APK
+        uses: Telefonica/github-actions/microsoft-teams/notify@main
+        with:
+          channel: android_builds
+          template: app_uploaded
+          flow-token: "${{ secrets.NOVUM_FLOW_BEARER }}"
+          template-context: >
+            platform: Android,
+            app_name: Mistica-internal-enterprise,
+            scope: internal,
+            repository: ${{ github.event.repository.name }},
+            changeset: ${{ github.sha }},
+            share_uri: ${{ steps.upload-apk.outputs.TESTING_URI }},
+            temporal_download_uri: ${{ steps.upload-apk.outputs.BINARY_DOWNLOAD_URI }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,7 +6,7 @@ on:
         description: "Snapshot version"
         required: true
 jobs:
-  debug-firebase-catalog:
+  snapshot:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
@@ -16,28 +16,18 @@ jobs:
           java-version: '17'
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
-      - name: Build catalog
-        run: 'bash ./gradlew assembleDebug -Dappcenter_notify=false'
+      - name: Build library
+        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
 
-      - name: Create firebase service json file
-        run: |
-          echo ${{ secrets.FIREBASE_DIST_CREDENTIALS_NIGHTLY }} | base64 --decode > service-account-file.json
-        shell: bash
-
-      - name: Get Apk path
-        id: get-apk-path
-        run: |
-          apk_path=(**/build/outputs/apk/debug/*.apk)
-          echo "apk_path=${apk_path[0]}" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Upload artifact to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        id: upload-apk
-        with:
-          appId: '1:771826505811:android:f64fec267b535d7f974ea6'
-          serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
-          groups: 'mistica-internal-testers'
-          file: ${{ steps.get-apk-path.outputs.apk_path }}
+      - name: Release snapshot
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
+          :catalog:publishCatalogPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
+          --max-workers 1 closeAndReleaseStagingRepository"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,28 +6,22 @@ on:
         description: "Snapshot version"
         required: true
 jobs:
-  snapshot:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+  firebase-catalog:
+    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
+    with:
+      build-tasks: 'assembleDebug'
+      apk-path: '**/build/outputs/apk/debug/*.apk'
+      additional-groups: 'mistica-internal-testers'
+      distribution-track: 'internal'
+      notify-ci-cd-publication: true
+      notify-error-in-publication: true
+    secrets: inherit
 
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Build library
-        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
-
-      - name: Release snapshot
-        env:
-          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
-          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
-          :catalog:publishCatalogPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
-          --max-workers 1 closeAndReleaseStagingRepository"
+  debug-firebase-catalog:
+    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
+    with:
+      build-tasks: 'assembleDebug'
+      apk-path: '**/build/outputs/apk/debug/*.apk'
+      additional-groups: 'mistica-internal-testers'
+      notify-publication-as-pr-comment: true
+    secrets: inherit

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,18 +41,3 @@ jobs:
           serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
           groups: 'mistica-internal-testers'
           file: ${{ steps.get-apk-path.outputs.apk_path }}
-
-      - name: Send Notification to Teams about published APK
-        uses: Telefonica/github-actions/microsoft-teams/notify@main
-        with:
-          channel: android_builds
-          template: app_uploaded
-          flow-token: "${{ secrets.NOVUM_FLOW_BEARER }}"
-          template-context: >
-            platform: Android,
-            app_name: Mistica-internal-enterprise,
-            scope: internal,
-            repository: ${{ github.event.repository.name }},
-            changeset: ${{ github.sha }},
-            share_uri: ${{ steps.upload-apk.outputs.TESTING_URI }},
-            temporal_download_uri: ${{ steps.upload-apk.outputs.BINARY_DOWNLOAD_URI }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,21 +7,22 @@ on:
         required: true
 jobs:
   firebase-catalog:
-    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
-    with:
-      build-tasks: 'assembleDebug'
-      apk-path: '**/build/outputs/apk/debug/*.apk'
-      additional-groups: 'mistica-internal-testers'
-      distribution-track: 'internal'
-      notify-ci-cd-publication: true
-      notify-error-in-publication: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Telefonica/ios-github-workflows repo
+        uses: actions/checkout@v4
+        with:
+          repository: Telefonica/android-shared-workflows
+          token: "${{ secrets.NOVUM_PRIVATE_REPOS }}"
+          path: .shared-workflows
+          ref: firebase
 
-  debug-firebase-catalog:
-    uses: Telefonica/android-shared-workflows/.github/workflows/build-enterprise.yml@firebase
-    with:
-      build-tasks: 'assembleDebug'
-      apk-path: '**/build/outputs/apk/debug/*.apk'
-      additional-groups: 'mistica-internal-testers'
-      notify-publication-as-pr-comment: true
-    secrets: inherit
+      - name: Build and Upload to Firebase
+        uses: ./.shared-workflows/.github/workflows/build-enterprise.yml
+        with:
+          build-tasks: 'assembleDebug'
+          apk-path: '**/build/outputs/apk/debug/*.apk'
+          additional-groups: 'mistica-internal-testers'
+          distribution-track: 'internal'
+          notify-ci-cd-publication: true
+          notify-error-in-publication: true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,7 +37,7 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         id: upload-apk
         with:
-          appId: '1:413491573542:android:d79e363379e606a7a807e7'
+          appId: '1:771826505811:android:f64fec267b535d7f974ea6'
           serviceCredentialsFile: ${{ github.workspace }}/service-account-file.json
           groups: 'mistica-internal-testers'
           file: ${{ steps.get-apk-path.outputs.apk_path }}


### PR DESCRIPTION
### :goal_net: What's the goal?
Add firebase distributions for mistica, without removing appcenter publications. As commented, it's not possible to use private shared workflows from public repositories.

### :construction: How do we do it?
* Just add required steps for existing publications

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
- [x] No need to review by mistica design team
- [x] [Execution to test upload to internal distribution on library publication](https://github.com/Telefonica/mistica-android/actions/runs/13703206735/job/38322014011)
- [x] [Catalog generation in PRs](https://github.com/Telefonica/mistica-android/pull/409#issuecomment-2704330153)
