### PR TITLE
ANDROID-15982 Fix feedback Accessibility

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
+++ b/library/src/main/java/com/telefonica/mistica/feedback/screen/view/FeedbackScreenView.kt
@@ -25,6 +25,7 @@ import androidx.annotation.RawRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.ViewCompat
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.model.KeyPath
@@ -107,6 +108,7 @@ class FeedbackScreenView : ConstraintLayout {
     fun setFeedbackTitle(text: CharSequence) {
         titleText = text
         title.text = text
+        ViewCompat.setAccessibilityHeading(title, true)
     }
 
     fun setFeedbackSubtitle(text: CharSequence) {

--- a/library/src/main/res/layout/screen_feedback.xml
+++ b/library/src/main/res/layout/screen_feedback.xml
@@ -12,7 +12,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusable="true"
             android:orientation="vertical"
             android:paddingTop="64dp"
             android:layout_marginStart="16dp"


### PR DESCRIPTION
### :goal_net: What's the goal?
In the feedback component in mística the image, title, subtitle are read grouped by talkback.
Also the title should be set as a heading.
This PR is in order to fix that.

### :construction: How do we do it?
- Removed focusable on the LinearLayout that made the elements be grouped.
- Set the title as heading.

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies. <-- iOS has already these elements separate
- [x] Accessibility considerations.

### :test_tube: How can I test this?
**_Turn up the volume on the videos_**

| Before        | After           |
| ------------- |-------------|
| <video src="https://github.com/user-attachments/assets/eb9127f0-94c8-412f-a117-74d69252566c" alt="Before" width="200"/>      | <video src="https://github.com/user-attachments/assets/4ae8c36a-aadc-43f2-823a-5bbbab50e148" alt="After" width="200"/> |

