### PR TITLE
ANDROID-15018 Callout a11y

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
@@ -94,7 +94,7 @@ class CalloutsCatalogFragment : Fragment() {
                 }
             }
             setTitle(view.findViewById<TextInput>(R.id.title_input).text.toString())
-            setTitleAsHeader(true)
+            setTitleAsHeading(true)
             setDescription(view.findViewById<TextInput>(R.id.description_input).text.toString())
             setButtonsConfig(
                 CalloutButtonsConfig.valueOf(view.findViewById<DropDownInput>(R.id.buttons_config_dropdown).dropDown.text.toString()).buttonsConfig

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
@@ -16,8 +16,8 @@ import com.telefonica.mistica.catalog.R
 import com.telefonica.mistica.input.CheckBoxInput
 import com.telefonica.mistica.input.DropDownInput
 import com.telefonica.mistica.input.TextInput
-import com.telefonica.mistica.util.getThemeColor
 import com.telefonica.mistica.util.getMisticaThemeDrawable
+import com.telefonica.mistica.util.getThemeColor
 
 class CalloutsCatalogFragment : Fragment() {
 
@@ -94,6 +94,7 @@ class CalloutsCatalogFragment : Fragment() {
                 }
             }
             setTitle(view.findViewById<TextInput>(R.id.title_input).text.toString())
+            setTitleAsHeader(true)
             setDescription(view.findViewById<TextInput>(R.id.description_input).text.toString())
             setButtonsConfig(
                 CalloutButtonsConfig.valueOf(view.findViewById<DropDownInput>(R.id.buttons_config_dropdown).dropDown.text.toString()).buttonsConfig

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
@@ -148,7 +148,7 @@ fun Callouts() {
                         .fillMaxWidth()
                         .padding(16.dp),
                     title = title.takeIf { it.isNotBlank() },
-                    setTitleAsHeader = true,
+                    setTitleAsHeading = true,
                     description = description.takeIf { it.isNotBlank() },
                     buttonConfig = buttonConfig,
                     imageConfig = iconType,

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
@@ -148,6 +148,7 @@ fun Callouts() {
                         .fillMaxWidth()
                         .padding(16.dp),
                     title = title.takeIf { it.isNotBlank() },
+                    setTitleAsHeader = true,
                     description = description.takeIf { it.isNotBlank() },
                     buttonConfig = buttonConfig,
                     imageConfig = iconType,

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -33,7 +33,7 @@ import com.telefonica.mistica.util.getThemeColor
     BindingMethod(
         type = CalloutView::class,
         attribute = "calloutTitleAsHeader",
-        method = "setTitleAsHeader",
+        method = "setTitleAsHeading",
     ),
     BindingMethod(
         type = CalloutView::class,
@@ -147,14 +147,14 @@ class CalloutView @JvmOverloads constructor(
         @ButtonsConfig
         var buttonsConfig: Int = BUTTONS_CONFIG_PRIMARY
         var dismissable = false
-        var titleAsHeader = true
+        var titleAsHeading = true
         var inverse = false
         assetType = CalloutViewImageConfig.NONE
 
         if (attrs != null) {
             val styledAttrs = context.theme.obtainStyledAttributes(attrs, R.styleable.CalloutView, defStyleAttr, 0)
 
-            titleAsHeader = styledAttrs.getBoolean(R.styleable.CalloutView_calloutTitleAsHeader, true)
+            titleAsHeading = styledAttrs.getBoolean(R.styleable.CalloutView_calloutTitleAsHeader, true)
             styledAttrs.getString(R.styleable.CalloutView_calloutTitle)?.let { setTitle(it) }
             styledAttrs.getString(R.styleable.CalloutView_calloutDescription)?.let { setDescription(it) }
 
@@ -174,7 +174,7 @@ class CalloutView @JvmOverloads constructor(
             styledAttrs.recycle()
         }
 
-        setTitleAsHeader(titleAsHeader)
+        setTitleAsHeading(titleAsHeading)
         setButtonsConfig(buttonsConfig)
         setDismissable(dismissable)
         setInverse(inverse)
@@ -273,7 +273,7 @@ class CalloutView @JvmOverloads constructor(
         }
     }
 
-    fun setTitleAsHeader(value: Boolean) {
+    fun setTitleAsHeading(value: Boolean) {
         ViewCompat.setAccessibilityHeading(title, value)
     }
 

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -16,6 +16,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import com.google.android.material.imageview.ShapeableImageView
@@ -28,6 +29,11 @@ import com.telefonica.mistica.util.getThemeColor
         type = CalloutView::class,
         attribute = "calloutTitle",
         method = "setTitle",
+    ),
+    BindingMethod(
+        type = CalloutView::class,
+        attribute = "calloutTitleAsHeader",
+        method = "setTitleAsHeader",
     ),
     BindingMethod(
         type = CalloutView::class,
@@ -141,12 +147,14 @@ class CalloutView @JvmOverloads constructor(
         @ButtonsConfig
         var buttonsConfig: Int = BUTTONS_CONFIG_PRIMARY
         var dismissable = false
+        var titleAsHeader = true
         var inverse = false
         assetType = CalloutViewImageConfig.NONE
 
         if (attrs != null) {
             val styledAttrs = context.theme.obtainStyledAttributes(attrs, R.styleable.CalloutView, defStyleAttr, 0)
 
+            titleAsHeader = styledAttrs.getBoolean(R.styleable.CalloutView_calloutTitleAsHeader, true)
             styledAttrs.getString(R.styleable.CalloutView_calloutTitle)?.let { setTitle(it) }
             styledAttrs.getString(R.styleable.CalloutView_calloutDescription)?.let { setDescription(it) }
 
@@ -166,6 +174,7 @@ class CalloutView @JvmOverloads constructor(
             styledAttrs.recycle()
         }
 
+        setTitleAsHeader(titleAsHeader)
         setButtonsConfig(buttonsConfig)
         setDismissable(dismissable)
         setInverse(inverse)
@@ -264,6 +273,10 @@ class CalloutView @JvmOverloads constructor(
         }
     }
 
+    fun setTitleAsHeader(value: Boolean) {
+        ViewCompat.setAccessibilityHeading(title, value)
+    }
+
     fun setDescription(text: String) {
         if (text.isNotBlank()) {
             description.text = text
@@ -298,17 +311,19 @@ class CalloutView @JvmOverloads constructor(
     }
 
     fun setButtonsConfig(@ButtonsConfig buttonsConfig: Int) {
-        if (buttonsConfig == BUTTONS_CONFIG_NONE) {
-            buttonsContainer.visibility = GONE
-            return
-        }
         buttonsContainer.visibility = VISIBLE
 
         when (buttonsConfig) {
+            BUTTONS_CONFIG_NONE -> {
+                buttonsContainer.visibility = GONE
+                closeButton.accessibilityTraversalAfter = description.id
+            }
+
             BUTTONS_CONFIG_PRIMARY -> {
                 primaryButton.visibility = VISIBLE
                 secondaryButton.visibility = GONE
                 linkButton.visibility = GONE
+                closeButton.accessibilityTraversalAfter = primaryButton.id
             }
 
             BUTTONS_CONFIG_PRIMARY_LINK -> {
@@ -316,18 +331,21 @@ class CalloutView @JvmOverloads constructor(
                 secondaryButton.visibility = GONE
                 linkButton.visibility = VISIBLE
                 linkButton.layoutParams = marginStart(0f)
+                closeButton.accessibilityTraversalAfter = linkButton.id
             }
 
             BUTTONS_CONFIG_PRIMARY_SECONDARY -> {
                 primaryButton.visibility = VISIBLE
                 secondaryButton.visibility = VISIBLE
                 linkButton.visibility = GONE
+                closeButton.accessibilityTraversalAfter = secondaryButton.id
             }
 
             BUTTONS_CONFIG_SECONDARY -> {
                 primaryButton.visibility = GONE
                 secondaryButton.visibility = VISIBLE
                 linkButton.visibility = GONE
+                closeButton.accessibilityTraversalAfter = secondaryButton.id
             }
 
             BUTTONS_CONFIG_SECONDARY_LINK -> {
@@ -335,6 +353,7 @@ class CalloutView @JvmOverloads constructor(
                 secondaryButton.visibility = VISIBLE
                 linkButton.visibility = VISIBLE
                 linkButton.layoutParams = marginStart(0f)
+                closeButton.accessibilityTraversalAfter = linkButton.id
             }
 
             BUTTONS_CONFIG_LINK -> {
@@ -342,9 +361,8 @@ class CalloutView @JvmOverloads constructor(
                 secondaryButton.visibility = GONE
                 linkButton.visibility = VISIBLE
                 linkButton.layoutParams = marginStart(-8f)
+                closeButton.accessibilityTraversalAfter = linkButton.id
             }
-
-            BUTTONS_CONFIG_NONE -> {}
         }
     }
 

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -32,7 +32,7 @@ import com.telefonica.mistica.util.getThemeColor
     ),
     BindingMethod(
         type = CalloutView::class,
-        attribute = "calloutTitleAsHeader",
+        attribute = "calloutTitleAsHeading",
         method = "setTitleAsHeading",
     ),
     BindingMethod(
@@ -154,7 +154,7 @@ class CalloutView @JvmOverloads constructor(
         if (attrs != null) {
             val styledAttrs = context.theme.obtainStyledAttributes(attrs, R.styleable.CalloutView, defStyleAttr, 0)
 
-            titleAsHeading = styledAttrs.getBoolean(R.styleable.CalloutView_calloutTitleAsHeader, true)
+            titleAsHeading = styledAttrs.getBoolean(R.styleable.CalloutView_calloutTitleAsHeading, true)
             styledAttrs.getString(R.styleable.CalloutView_calloutTitle)?.let { setTitle(it) }
             styledAttrs.getString(R.styleable.CalloutView_calloutDescription)?.let { setDescription(it) }
 

--- a/library/src/main/java/com/telefonica/mistica/callout/README.md
+++ b/library/src/main/java/com/telefonica/mistica/callout/README.md
@@ -12,7 +12,7 @@ configuration and databinding for all properties**.
 ```xml
 <declare-styleable name="CalloutView">
 	<attr name="calloutTitle" format="string"/>
-	<attr name="calloutTitleAsHeader" format="boolean"/>
+	<attr name="calloutTitleAsHeading" format="boolean"/>
 	<attr name="calloutDescription" format="string"/>
 	<attr name="calloutButtonsConfig" format="enum">
 		<enum name="none" value="-1"/>

--- a/library/src/main/java/com/telefonica/mistica/callout/README.md
+++ b/library/src/main/java/com/telefonica/mistica/callout/README.md
@@ -12,9 +12,8 @@ configuration and databinding for all properties**.
 ```xml
 <declare-styleable name="CalloutView">
 	<attr name="calloutTitle" format="string"/>
+	<attr name="calloutTitleAsHeader" format="boolean"/>
 	<attr name="calloutDescription" format="string"/>
-	<attr name="calloutAsset" format="reference"/>
-    <attr name="calloutAssetType" format="enum"/>   
 	<attr name="calloutButtonsConfig" format="enum">
 		<enum name="none" value="-1"/>
 		<enum name="primary" value="0" />
@@ -23,6 +22,13 @@ configuration and databinding for all properties**.
 		<enum name="secondary" value="3" />
 		<enum name="secondary_link" value="4" />
 		<enum name="link" value="5" />
+	</attr>
+	<attr name="calloutAsset" format="reference"/>
+	<attr name="calloutAssetType" format="enum">
+		<enum name="none" value="-1"/>
+		<enum name="icon" value="0"/>
+		<enum name="squareImage" value="1"/>
+		<enum name="circularImage" value="2"/>
 	</attr>
 	<attr name="calloutPrimaryButtonText" format="string" />
 	<attr name="calloutPrimaryButtonOnClick" format="string" />

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -18,6 +18,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
 import com.telefonica.mistica.R
 import com.telefonica.mistica.callout.CalloutViewImageConfig
@@ -32,6 +35,7 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 fun Callout(
     modifier: Modifier = Modifier,
     title: String?,
+    setTitleAsHeader: Boolean = true,
     description: String?,
     buttonConfig: CalloutButtonConfig,
     @DrawableRes iconRes: Int? = null,
@@ -74,7 +78,9 @@ fun Callout(
             ) {
                 title?.let {
                     Text(
-                        modifier = Modifier.testTag(CalloutTestTag.TITLE),
+                        modifier = Modifier
+                            .testTag(CalloutTestTag.TITLE)
+                            .semantics { if (setTitleAsHeader) heading() },
                         text = it,
                         style = MisticaTheme.typography.preset3,
                     )
@@ -163,6 +169,7 @@ fun Callout(
                 Image(
                     modifier = Modifier
                         .clickable { onDismiss?.invoke() }
+                        .semantics { traversalIndex = 1f }
                         .testTag(CalloutTestTag.CLOSE_BUTTON),
                     painter = painterResource(id = R.drawable.icn_cross),
                     contentDescription = stringResource(id = R.string.close_button_content_description)

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -100,7 +100,10 @@ fun Callout(
                         }
 
                         CalloutButtonConfig.PRIMARY -> {
-                            PrimaryButton(text = primaryButtonText, onClick = onPrimaryButtonClick)
+                            PrimaryButton(
+                                text = primaryButtonText,
+                                onClick = onPrimaryButtonClick
+                            )
                         }
 
                         CalloutButtonConfig.PRIMARY_AND_LINK -> {
@@ -109,11 +112,17 @@ fun Callout(
                                 modifier = Modifier.padding(end = 16.dp),
                                 onClick = onPrimaryButtonClick,
                             )
-                            LinkButton(text = linkText, onClick = onLinkClicked)
+                            LinkButton(
+                                text = linkText,
+                                onClick = onLinkClicked
+                            )
                         }
 
                         CalloutButtonConfig.SECONDARY -> {
-                            SecondaryButton(text = secondaryButtonText, onClick = onSecondaryButtonClick)
+                            SecondaryButton(
+                                text = secondaryButtonText,
+                                onClick = onSecondaryButtonClick
+                            )
                         }
 
                         CalloutButtonConfig.PRIMARY_AND_SECONDARY -> {
@@ -122,7 +131,10 @@ fun Callout(
                                 modifier = Modifier.padding(end = 16.dp),
                                 onClick = onPrimaryButtonClick,
                             )
-                            SecondaryButton(text = secondaryButtonText, onClick = onSecondaryButtonClick)
+                            SecondaryButton(
+                                text = secondaryButtonText,
+                                onClick = onSecondaryButtonClick
+                            )
                         }
 
                         CalloutButtonConfig.SECONDARY_AND_LINK -> {
@@ -131,11 +143,17 @@ fun Callout(
                                 modifier = Modifier.padding(end = 16.dp),
                                 onClick = onSecondaryButtonClick,
                             )
-                            LinkButton(text = linkText, onClick = onLinkClicked)
+                            LinkButton(
+                                text = linkText,
+                                onClick = onLinkClicked
+                            )
                         }
 
                         CalloutButtonConfig.LINK -> {
-                            LinkButton(text = linkText, onClick = onLinkClicked)
+                            LinkButton(
+                                text = linkText,
+                                onClick = onLinkClicked
+                            )
                         }
                     }
                 }

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -35,7 +35,7 @@ import com.telefonica.mistica.compose.theme.MisticaTheme
 fun Callout(
     modifier: Modifier = Modifier,
     title: String?,
-    setTitleAsHeader: Boolean = true,
+    setTitleAsHeading: Boolean = true,
     description: String?,
     buttonConfig: CalloutButtonConfig,
     @DrawableRes iconRes: Int? = null,
@@ -80,7 +80,7 @@ fun Callout(
                     Text(
                         modifier = Modifier
                             .testTag(CalloutTestTag.TITLE)
-                            .semantics { if (setTitleAsHeader) heading() },
+                            .semantics { if (setTitleAsHeading) heading() },
                         text = it,
                         style = MisticaTheme.typography.preset3,
                     )

--- a/library/src/main/res/layout/callout_view.xml
+++ b/library/src/main/res/layout/callout_view.xml
@@ -9,15 +9,16 @@
 		android:minHeight="56dp"
 		>
 
-	<ImageView
+	<ImageButton
 			android:id="@+id/callout_close_button"
 			app:layout_constraintTop_toTopOf="parent"
 			app:layout_constraintRight_toRightOf="parent"
-			android:translationX="4dp"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
+			android:background="@android:color/transparent"
+			android:layout_width="40dp"
+			android:layout_height="40dp"
+			android:translationY="-8dp"
 			android:layout_marginStart="8dp"
-			android:layout_marginEnd="16dp"
+			android:layout_marginEnd="4dp"
 			android:src="@drawable/icn_cross"
 			android:contentDescription="@string/close_button_content_description"
 			/>
@@ -76,7 +77,7 @@
 			android:layout_height="wrap_content"
 			android:textAppearance="@style/AppTheme.TextAppearance.Preset3"
 			android:textColor="?colorTextPrimary"
-			tools:text="@tools:sample/lorem/random"
+			tools:text="@tools:sample/lorem"
 			tools:visibility="visible"
 			/>
 
@@ -91,7 +92,7 @@
 			android:layout_marginEnd="16dp"
 			android:textAppearance="@style/AppTheme.TextAppearance.Preset2"
 			android:textColor="?colorTextSecondary"
-			tools:text="@tools:sample/lorem/random"
+			tools:text="@tools:sample/lorem"
 			/>
 
 	<LinearLayout

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -285,6 +285,7 @@
 
     <declare-styleable name="CalloutView">
         <attr name="calloutTitle" format="string"/>
+        <attr name="calloutTitleAsHeader" format="boolean"/>
         <attr name="calloutDescription" format="string"/>
         <attr name="calloutButtonsConfig" format="enum">
             <enum name="none" value="-1"/>

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -285,7 +285,7 @@
 
     <declare-styleable name="CalloutView">
         <attr name="calloutTitle" format="string"/>
-        <attr name="calloutTitleAsHeader" format="boolean"/>
+        <attr name="calloutTitleAsHeading" format="boolean"/>
         <attr name="calloutDescription" format="string"/>
         <attr name="calloutButtonsConfig" format="enum">
             <enum name="none" value="-1"/>


### PR DESCRIPTION
### :goal_net: What's the goal?
- Make the title view configurable so that talkback treats it as a header or not. By default, **it will always** be a header.
- Make the close/dismiss button the last node in the accessibility hierarchy.

### :construction: How do we do it?
* Expose a method to configure "heading"
* Set close/dismiss button to be the last in the hierarchy
* Fixed XML view close/dismiss button touch zone.

### ☑️ Checks
- [X] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [X] Tested with dark mode.
- [X] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.
- [X] Accessibility considerations.

### :test_tube: How can I test this?
- [X] 🖼️ Screenshots/Videos
- [X] Mistica App QR or download link
- [X] Reviewed by Mistica design team

| Focus Before        | Focus After           |
| ------------- |-------------|
| <img src="https://github.com/user-attachments/assets/9029ac74-5757-4cb5-b13e-02da9ff58b01" alt="drawing" width="200"/> | <img src="https://github.com/user-attachments/assets/07b3be78-a84e-4255-b119-a12426fd0312" alt="drawing" width="200"/>      |

| A11y XML        | A11y Compose           |
| ------------- |-------------|
| <video src="https://github.com/user-attachments/assets/e9ce73f0-576c-4558-864c-ae70b0bdf40c" alt="video" width="200"/> | <video src="https://github.com/user-attachments/assets/d3995d9a-d6f9-476b-b26c-a27b02998d30" alt="video" width="200"/>      |







