### PR TITLE
ANDROID-16024 Let component set its margin

### DIFF
--- a/library/src/main/res/layout/callout_view.xml
+++ b/library/src/main/res/layout/callout_view.xml
@@ -4,7 +4,6 @@
 		xmlns:app="http://schemas.android.com/apk/res-auto"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		android:paddingTop="16dp"
 		android:paddingBottom="16dp"
 		android:minHeight="56dp"
 		>
@@ -16,7 +15,7 @@
 			android:background="@android:color/transparent"
 			android:layout_width="40dp"
 			android:layout_height="40dp"
-			android:translationY="-8dp"
+			android:layout_marginTop="8dp"
 			android:layout_marginStart="8dp"
 			android:layout_marginEnd="4dp"
 			android:src="@drawable/icn_cross"
@@ -27,6 +26,7 @@
 			android:id="@+id/callout_image_layout"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
+			android:layout_marginTop="16dp"
 			app:layout_constraintTop_toTopOf="parent"
 			app:layout_constraintStart_toStartOf="parent"
 			>
@@ -71,6 +71,7 @@
 			app:layout_constraintTop_toTopOf="parent"
 			app:layout_constraintEnd_toStartOf="@id/callout_close_button"
 			app:layout_constraintStart_toEndOf="@id/callout_image_layout"
+			android:layout_marginTop="16dp"
 			android:layout_marginStart="16dp"
 			android:layout_marginEnd="16dp"
 			android:layout_width="0dp"


### PR DESCRIPTION
### :goal_net: What's the goal?
We came from: https://github.com/Telefonica/mistica-android/pull/413
Making XML close button accesible, making it bigger, espresso found a problem due close button container has a padding to  apply a visual margin its children.
The main point is the transalation property with negative value. Visually the button is displayed perfectly, but, espresso have a problem with that, due it thinks that the button is "partly hidden".

### :construction: How do we do it?
* Redistribute margins

### ☑️ Checks
- [ ] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [ ] Tested with dark mode.
- [ ] Tested with API 24.
- [ ] Sync done with iOS team for this feature to ensure alignment, if applies.
- [X] Accessibility considerations.

### :test_tube: How can I test this?
- [X] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [X] Reviewed by Mistica design team

| Before        |  After           |
| ------------- |-------------|
| <img src="https://github.com/user-attachments/assets/33a9e201-88ca-4dee-9fb0-e5238341913e" alt="drawing" width="200"/> | <img src="https://github.com/user-attachments/assets/a23828b2-cd39-42b0-bc7a-61f501fd6695" alt="drawing" width="200"/>      |

