### PR TITLE
ANDROID-16028 Fix new release notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Send Teams notification
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v1.16.4
         with:
           url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
           method: 'POST'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,70 @@ jobs:
           :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
           --max-workers 1 closeAndReleaseStagingRepository"
 
-      - name: Microsoft Teams Notification
-        uses: skitionek/notify-microsoft-teams@v1.0.8
-        if: success()
+      - name: Send Teams notification
+        uses: fjogeleit/http-request-action@v1
         with:
-          webhook_url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
-          needs: ${{ toJson(needs) }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
-          overwrite: "{title: `New Mistica version published ${{ github.event.release.tag_name }}`, text:`Release Notes:\n ${{ github.event.release.html_url }}`}"
+          url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
+          method: 'POST'
+          data: |
+            {
+            "type": "message",
+            "attachments": [
+              {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                  "type": "AdaptiveCard",
+                  "version": "1.5",
+                  "body": [
+                    {
+                      "type": "ColumnSet",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "items": [
+                            {
+                              "type": "Image",
+                              "url": "https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png",
+                              "width": "56px",
+                              "height": "56px",
+                              "style": "RoundedCorners"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "New Mística version published ${{ github.event.release.tag_name }}",
+                              "wrap": true,
+                              "weight": "Bolder",
+                              "style": "heading"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "${{ github.event.release.body }}",
+                      "wrap": true
+                    },
+                    {
+                      "type": "ActionSet",
+                      "actions": [
+                        {
+                          "type": "Action.OpenUrl",
+                          "title": "Open release",
+                          "url": "${{ github.event.release.html_url }}"
+                        }
+                      ]
+                    }
+                  ],
+                  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
+                }
+              }
+            ]
+            }


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix new release notification, instead of using `skitionek/notify-microsoft-teams` GA, I'm making a POST request directly with the adaptive card that we want to show.

### :test_tube: How can I test this?
- I've tested with a manual workflow and the message appears ok in Teams
![image](https://github.com/user-attachments/assets/b33b918a-e967-4cb7-9a4b-85d3c04ce43d)

