### PR TITLE
ANDROID-16118 Escape release notes to avoid problems with multiline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
                 "contentType": "application/vnd.microsoft.card.adaptive",
                 "content": {
                   "type": "AdaptiveCard",
-                  "version": "1.4",
+                  "version": "1.5",
                   "body": [
                     {
                       "type": "ColumnSet",
@@ -78,13 +78,7 @@ jobs:
                     },
                     {
                       "type": "TextBlock",
-                      "text": "## What's Changed
-                      * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
-                      * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
-                      * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
-                      
-                      
-                      **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0",
+                      "text": "## What's Changed",
                       "wrap": true
                     },
                     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,15 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_NOTES: |
+          ## What's Changed
+          * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
+          * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
+          * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
+
+
+          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0
     steps:
 #      - name: Set up JDK 17
 #        uses: actions/setup-java@v2
@@ -29,6 +38,11 @@ jobs:
 #        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
 #          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
 #          --max-workers 1 closeAndReleaseStagingRepository"
+
+      - name: Prepare release notes
+        run: |
+          RELEASE_BODY=$(echo '${RELEASE_NOTES}' | jq -Rs .)
+          echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
       - name: Send Teams notification
         uses: fjogeleit/http-request-action@v1.16.4
@@ -78,7 +92,7 @@ jobs:
                     },
                     {
                       "type": "TextBlock",
-                      "text": "## What's Changed",
+                      "text": ${{ env.FORMATTED_BODY }},
                       "wrap": true
                     },
                     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
 
       - name: Prepare release notes
         run: |
-          RELEASE_BODY=$(echo '${{ env.RELEASE_NOTES }}' | jq -Rs .)
+          RELEASE_BODY=$(jq -Rs . <<'EOF'
+          ${{ env.RELEASE_NOTES }}
+          EOF
+          )
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
       - name: Print formatted release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Prepare release notes
         run: |
-          RELEASE_BODY=$(echo ${{ env.RELEASE_NOTES }} | jq -Rs .)
+          RELEASE_BODY=$(echo '${{ env.RELEASE_NOTES }}' | jq -Rs .)
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
       - name: Print formatted release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,34 @@
 name: "Upload release to MavenCentral"
 on:
-  release:
-    types: [published]
+  push:
+#  release:
+#    types: [published]
 jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Build library
-        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
-
-      - name: Release library
-        env:
-          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
-          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-          --max-workers 1 closeAndReleaseStagingRepository"
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v2
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#
+#      - name: Checkout repo
+#        uses: actions/checkout@v2
+#
+#      - name: Build library
+#        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
+#
+#      - name: Release library
+#        env:
+#          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+#          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+#          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+#          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+#          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+#        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+#          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+#          --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Send Teams notification
         uses: fjogeleit/http-request-action@v1.16.4
@@ -77,7 +78,13 @@ jobs:
                     },
                     {
                       "type": "TextBlock",
-                      "text": "${{ github.event.release.body }}",
+                      "text": "## What's Changed
+                      * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
+                      * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
+                      * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
+                      
+                      
+                      **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0",
                       "wrap": true
                     },
                     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 #          --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Print release notes
-        run: echo ${{ env.RELEASE_NOTES }}
+        run: echo "${{ env.RELEASE_NOTES }}"
 
       - name: Prepare release notes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Prepare release notes
         run: |
-          RELEASE_BODY=$(echo '${{ env.RELEASE_NOTES }}' | jq -Rs .)
+          RELEASE_BODY=$(echo ${{ env.RELEASE_NOTES }} | jq -Rs .)
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
       - name: Print formatted release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: "Upload release to MavenCentral"
 on:
   release:
-    types: [ published ]
+    types: [published]
 jobs:
   promote:
     runs-on: ubuntu-latest
@@ -26,8 +26,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-         :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-         --max-workers 1 closeAndReleaseStagingRepository"
+           :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+           --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Prepare release notes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: |
-          "## What's Changed
+          ## What's Changed
           * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
           * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
           * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
 
 
-          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0"
+          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0
     steps:
 #      - name: Set up JDK 17
 #        uses: actions/setup-java@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
                 "contentType": "application/vnd.microsoft.card.adaptive",
                 "content": {
                   "type": "AdaptiveCard",
-                  "version": "1.5",
+                  "version": "1.4",
                   "body": [
                     {
                       "type": "ColumnSet",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-           :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-           --max-workers 1 closeAndReleaseStagingRepository"
+          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+          --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Prepare release notes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,15 @@ jobs:
 #          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
 #          --max-workers 1 closeAndReleaseStagingRepository"
 
+      - name: Print release notes
+        run: echo ${{ env.RELEASE_NOTES }}
+
       - name: Prepare release notes
         run: |
-          RELEASE_BODY=$(echo '$RELEASE_NOTES' | jq -Rs .)
+          RELEASE_BODY=$(echo '${{ env.RELEASE_NOTES }}' | jq -Rs .)
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
-      - name: Print release notes
+      - name: Print formatted release notes
         run: echo ${{ env.FORMATTED_BODY }}
 
 #      - name: Send Teams notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,38 @@
 name: "Upload release to MavenCentral"
 on:
-  push:
-#  release:
-#    types: [published]
+  release:
+    types: [ published ]
 jobs:
   promote:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_NOTES: |
-          ## What's Changed
-          * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
-          * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
-          * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
-
-
-          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0
     steps:
-#      - name: Set up JDK 17
-#        uses: actions/setup-java@v2
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#
-#      - name: Checkout repo
-#        uses: actions/checkout@v2
-#
-#      - name: Build library
-#        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
-#
-#      - name: Release library
-#        env:
-#          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
-#          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
-#          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-#          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-#          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-#        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-#          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-#          --max-workers 1 closeAndReleaseStagingRepository"
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Build library
+        run: 'bash ./gradlew clean :library:assembleRelease :catalog:assembleRelease'
+
+      - name: Release library
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+        run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+         :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
+         --max-workers 1 closeAndReleaseStagingRepository"
 
       - name: Prepare release notes
         run: |
           RELEASE_BODY=$(jq -Rs . <<'EOF'
-          ${{ env.RELEASE_NOTES }}
+          ${{ github.event.release.body }}
           EOF
           )
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,73 +41,76 @@ jobs:
 
       - name: Prepare release notes
         run: |
-          RELEASE_BODY=$(echo '${RELEASE_NOTES}' | jq -Rs .)
+          RELEASE_BODY=$(echo '$RELEASE_NOTES' | jq -Rs .)
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
-      - name: Send Teams notification
-        uses: fjogeleit/http-request-action@v1.16.4
-        with:
-          url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
-          method: 'POST'
-          data: |
-            {
-            "type": "message",
-            "attachments": [
-              {
-                "contentType": "application/vnd.microsoft.card.adaptive",
-                "content": {
-                  "type": "AdaptiveCard",
-                  "version": "1.5",
-                  "body": [
-                    {
-                      "type": "ColumnSet",
-                      "columns": [
-                        {
-                          "type": "Column",
-                          "width": "auto",
-                          "items": [
-                            {
-                              "type": "Image",
-                              "url": "https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png",
-                              "width": "56px",
-                              "height": "56px",
-                              "style": "RoundedCorners"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "Column",
-                          "width": "stretch",
-                          "items": [
-                            {
-                              "type": "TextBlock",
-                              "text": "New Mística version published ${{ github.event.release.tag_name }}",
-                              "wrap": true,
-                              "weight": "Bolder",
-                              "style": "heading"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "TextBlock",
-                      "text": ${{ env.FORMATTED_BODY }},
-                      "wrap": true
-                    },
-                    {
-                      "type": "ActionSet",
-                      "actions": [
-                        {
-                          "type": "Action.OpenUrl",
-                          "title": "Open release",
-                          "url": "${{ github.event.release.html_url }}"
-                        }
-                      ]
-                    }
-                  ],
-                  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
-                }
-              }
-            ]
-            }
+      - name: Print release notes
+        run: echo ${{ env.FORMATTED_BODY }}
+
+#      - name: Send Teams notification
+#        uses: fjogeleit/http-request-action@v1.16.4
+#        with:
+#          url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
+#          method: 'POST'
+#          data: |
+#            {
+#            "type": "message",
+#            "attachments": [
+#              {
+#                "contentType": "application/vnd.microsoft.card.adaptive",
+#                "content": {
+#                  "type": "AdaptiveCard",
+#                  "version": "1.5",
+#                  "body": [
+#                    {
+#                      "type": "ColumnSet",
+#                      "columns": [
+#                        {
+#                          "type": "Column",
+#                          "width": "auto",
+#                          "items": [
+#                            {
+#                              "type": "Image",
+#                              "url": "https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png",
+#                              "width": "56px",
+#                              "height": "56px",
+#                              "style": "RoundedCorners"
+#                            }
+#                          ]
+#                        },
+#                        {
+#                          "type": "Column",
+#                          "width": "stretch",
+#                          "items": [
+#                            {
+#                              "type": "TextBlock",
+#                              "text": "New Mística version published ${{ github.event.release.tag_name }}",
+#                              "wrap": true,
+#                              "weight": "Bolder",
+#                              "style": "heading"
+#                            }
+#                          ]
+#                        }
+#                      ]
+#                    },
+#                    {
+#                      "type": "TextBlock",
+#                      "text": ${{ env.FORMATTED_BODY }},
+#                      "wrap": true
+#                    },
+#                    {
+#                      "type": "ActionSet",
+#                      "actions": [
+#                        {
+#                          "type": "Action.OpenUrl",
+#                          "title": "Open release",
+#                          "url": "${{ github.event.release.html_url }}"
+#                        }
+#                      ]
+#                    }
+#                  ],
+#                  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
+#                }
+#              }
+#            ]
+#            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: |
-          ## What's Changed
+          "## What's Changed
           * ANDROID-16028 Fix new release notification by @jeslat in https://github.com/Telefonica/mistica-android/pull/418
           * ANDROID-15952 Input border contrast improvements by @yceballost in https://github.com/Telefonica/mistica-android/pull/415
           * ANDROID-15772 Text link component by @haynlo in https://github.com/Telefonica/mistica-android/pull/416
 
 
-          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0
+          **Full Changelog**: https://github.com/Telefonica/mistica-android/compare/18.1.4...18.2.0"
     steps:
 #      - name: Set up JDK 17
 #        uses: actions/setup-java@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
 #          :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
 #          --max-workers 1 closeAndReleaseStagingRepository"
 
-      - name: Print release notes
-        run: echo "${{ env.RELEASE_NOTES }}"
-
       - name: Prepare release notes
         run: |
           RELEASE_BODY=$(jq -Rs . <<'EOF'
@@ -50,73 +47,70 @@ jobs:
           )
           echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
 
-      - name: Print formatted release notes
-        run: echo ${{ env.FORMATTED_BODY }}
-
-#      - name: Send Teams notification
-#        uses: fjogeleit/http-request-action@v1.16.4
-#        with:
-#          url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
-#          method: 'POST'
-#          data: |
-#            {
-#            "type": "message",
-#            "attachments": [
-#              {
-#                "contentType": "application/vnd.microsoft.card.adaptive",
-#                "content": {
-#                  "type": "AdaptiveCard",
-#                  "version": "1.5",
-#                  "body": [
-#                    {
-#                      "type": "ColumnSet",
-#                      "columns": [
-#                        {
-#                          "type": "Column",
-#                          "width": "auto",
-#                          "items": [
-#                            {
-#                              "type": "Image",
-#                              "url": "https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png",
-#                              "width": "56px",
-#                              "height": "56px",
-#                              "style": "RoundedCorners"
-#                            }
-#                          ]
-#                        },
-#                        {
-#                          "type": "Column",
-#                          "width": "stretch",
-#                          "items": [
-#                            {
-#                              "type": "TextBlock",
-#                              "text": "New Mística version published ${{ github.event.release.tag_name }}",
-#                              "wrap": true,
-#                              "weight": "Bolder",
-#                              "style": "heading"
-#                            }
-#                          ]
-#                        }
-#                      ]
-#                    },
-#                    {
-#                      "type": "TextBlock",
-#                      "text": ${{ env.FORMATTED_BODY }},
-#                      "wrap": true
-#                    },
-#                    {
-#                      "type": "ActionSet",
-#                      "actions": [
-#                        {
-#                          "type": "Action.OpenUrl",
-#                          "title": "Open release",
-#                          "url": "${{ github.event.release.html_url }}"
-#                        }
-#                      ]
-#                    }
-#                  ],
-#                  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
-#                }
-#              }
-#            ]
-#            }
+      - name: Send Teams notification
+        uses: fjogeleit/http-request-action@v1.16.4
+        with:
+          url: ${{ secrets.ANDROID_LIBRARIES_TEAMS_WEBHOOK }}
+          method: 'POST'
+          data: |
+            {
+            "type": "message",
+            "attachments": [
+              {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                  "type": "AdaptiveCard",
+                  "version": "1.5",
+                  "body": [
+                    {
+                      "type": "ColumnSet",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "items": [
+                            {
+                              "type": "Image",
+                              "url": "https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png",
+                              "width": "56px",
+                              "height": "56px",
+                              "style": "RoundedCorners"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "New Mística version published ${{ github.event.release.tag_name }}",
+                              "wrap": true,
+                              "weight": "Bolder",
+                              "style": "heading"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": ${{ env.FORMATTED_BODY }},
+                      "wrap": true
+                    },
+                    {
+                      "type": "ActionSet",
+                      "actions": [
+                        {
+                          "type": "Action.OpenUrl",
+                          "title": "Open release",
+                          "url": "${{ github.event.release.html_url }}"
+                        }
+                      ]
+                    }
+                  ],
+                  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
+                }
+              }
+            ]
+            }


### PR DESCRIPTION
### :goal_net: What's the goal?
Escape release notes to avoid problems with multiline.

### :construction: How do we do it?
* Add a new step to escape the release notes using `jq` (thanks copilot) to avoid problems when they are multiline and are added to the JSON.

### :test_tube: How can I test this?
I've done some tests setting the release notes text as an environment variable and worked ok:

![image](https://github.com/user-attachments/assets/97b4fab3-8334-4f72-9d3d-03d28eb31eab)
