### PR TITLE
Explicitly ask for additional context in design token update PRs

### DIFF
--- a/.github/workflows/import-design-tokens.yml
+++ b/.github/workflows/import-design-tokens.yml
@@ -41,7 +41,8 @@ jobs:
           body: |
             This PR was automatically created by the import-design-tokens GitHub Action.
             
-            Please, update this description with additional context for reviewers.
+            ## ⚠️ ACTION REQUIRED
+            > **Please, update this description with additional context for reviewers.**
           branch: 'import-design-tokens'
           assignees: ${{ github.actor }}
           team-reviewers: 'Android,mistica-design'

--- a/.github/workflows/import-design-tokens.yml
+++ b/.github/workflows/import-design-tokens.yml
@@ -42,4 +42,6 @@ jobs:
             This PR was automatically created by the import-design-tokens GitHub Action.
             
             Please, update this description with additional context for reviewers.
-          branch: 'import-design
+          branch: 'import-design-tokens'
+          assignees: ${{ github.actor }}
+          team-reviewers: 'Android,mistica-design'

--- a/.github/workflows/import-design-tokens.yml
+++ b/.github/workflows/import-design-tokens.yml
@@ -38,7 +38,8 @@ jobs:
           token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
           commit-message: 'Update design tokens'
           title: 'Update design tokens'
-          body: 'This PR was automatically created by the import-design-tokens GitHub Action.'
-          branch: 'import-design-tokens'
-          assignees: ${{ github.actor }}
-          team-reviewers: 'Android,mistica-design'
+          body: |
+            This PR was automatically created by the import-design-tokens GitHub Action.
+            
+            Please, update this description with additional context for reviewers.
+          branch: 'import-design


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16193](https://jira.tid.es/browse/ANDROID-16193)

### :goal_net: What's the goal?
Update description for design tokens update PRs that are automatically created so additional context is provided.

The expectation is that whether design token PRs are manually generated from this repo or from mistica-design, they should always have context in the description about the changes requested so reviewers are informed.

### :construction: How do we do it?
Just update the PR body

### :test_tube: How can I test this?
- [x] [PR generated with this changes](https://github.com/Telefonica/mistica-android/pull/422) that will be discarded afterwards