### PR TITLE
ANDROID-16195 Disable Links checker as it is failing due github rate limit issues

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,7 +1,8 @@
 name: Links checker
 
 on:
-  pull_request:
+  # pull_request: # Action fails due rate limit issues -> https://jira.tid.es/browse/ANDROID-16194
+  workflow_dispatch:
 
 jobs:
   linkChecker:
@@ -11,7 +12,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.4.1
+        uses: lycheeverse/lychee-action@v1
         with:
           fail: true
         env:

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@2.4.1
         with:
           fail: true
         env:

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@2.4.1
+        uses: lycheeverse/lychee-action@v2.4.1
         with:
           fail: true
         env:


### PR DESCRIPTION
### :goal_net: What's the goal?

Issue comes from the action to check links. This issue has been reported by more users -> https://github.com/lycheeverse/lychee-action/issues/289

Ticket to update action version when solved -> https://jira.tid.es/browse/ANDROID-16194

### :construction: How do we do it?
* Disable execution on pull requests
* Add worflow_dispatch event to allow launching it manually to test it properly when this issue is fixed.
