### PR TITLE
ANDROID-16222 Minor fix on CentralPortal publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
           :catalog:publishCatalogPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-          --max-workers 1 closeAndReleaseStagingRepository"
+          --max-workers 1 closeAndReleaseStagingRepositories"
 
       - name: Prepare release notes
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -30,4 +30,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew :library:publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
           :catalog:publishCatalogPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
-          --max-workers 1 closeAndReleaseStagingRepository"
+          --max-workers 1 closeAndReleaseStagingRepositories"


### PR DESCRIPTION
### :goal_net: What's the goal?
Sometimes CentralPortal publication went wrong

### :construction: How do we do it?
* Use `closeAndReleaseStagingRepositories`
* Using `closeAndReleaseStagingRepository` probably was using `closeAndReleaseOtherNexusStagingRepository` or `closeAndReleaseSonatypeStagingRepository `
* https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#summary-tasks
![Screenshot 2025-05-20 at 16 00 41](https://github.com/user-attachments/assets/9ac02b7a-a17a-490f-8ffc-86979442d573)
