### PR TITLE
ANDROID-15258 List accessibility update for XML implementation

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
@@ -102,7 +102,8 @@ class ListsCatalogFragment : Fragment() {
                 withLongTitle: Boolean = false,
                 withTitleMaxLines: Int? = null,
                 withDescriptionMaxLines: Int? = null,
-                withDimensions: ImageDimensions? = null
+                withDimensions: ImageDimensions? = null,
+                withCustomContentDescription: Boolean = false,
             ): (ListRowView) -> Unit = { view ->
                 view.configureView(
                     withAction = withAction,
@@ -120,13 +121,15 @@ class ListsCatalogFragment : Fragment() {
                     withLongTitle = withLongTitle,
                     withTitleMaxLines = withTitleMaxLines,
                     withDescriptionMaxLines = withDescriptionMaxLines,
-                    withDimensions = withDimensions
+                    withDimensions = withDimensions,
+                    withCustomContentDescription = withCustomContentDescription,
                 )
             }
 
             return listOf(
                 configure(withTitleHeading = true),
                 configure(withAction = true),
+                configure(withCustomContentDescription = true),
                 configure(withAction = true, withBadge = true),
                 configure(withAction = true, withBadgeNumeric = 1),
                 configure(withLongDescription = false, withTitleHeading = true),
@@ -163,14 +166,13 @@ class ListsCatalogFragment : Fragment() {
             )
         }
 
-
         @SuppressLint("SetTextI18n")
         @Suppress("CyclomaticComplexMethod")
         private fun ListRowView.configureView(
             withLongTitle: Boolean = false,
             withTitleMaxLines: Int? = null,
-            withTitleHeading: Boolean? = false,
-            withLongDescription: Boolean? = null,
+            withTitleHeading: Boolean = false,
+            withLongDescription: Boolean = true,
             withDescriptionMaxLines: Int? = null,
             withAsset: Boolean = false,
             @AssetType withAssetType: Int = TYPE_SMALL_ICON,
@@ -185,6 +187,7 @@ class ListsCatalogFragment : Fragment() {
             withInverseBackground: Boolean,
             withUrlIcon: String? = null,
             withErrorIcon: Drawable? = null,
+            withCustomContentDescription: Boolean = false,
         ) {
             if (withHeadline) {
                 val headlineText = "Headline"
@@ -210,13 +213,12 @@ class ListsCatalogFragment : Fragment() {
             setSubtitle(if (withSubtitle) "Any Subtitle" else null)
             withDescriptionMaxLines?.let { setDescriptionMaxLines(it) }
             setDescription(
-                withLongDescription?.let { long ->
-                    if (long) {
-                        "Description long enough to need more than 2 lines to show it, just for testing purposes." +
-                                "Description long enough to need more than 2 lines to show it, just for testing purposes."
-                    } else {
-                        "Description"
-                    }
+                when {
+                    withCustomContentDescription -> "Description.\nListRowView with custom content description."
+                    withLongDescription -> "Description long enough to need more than 2 lines to show it, just for testing purposes." +
+                            "Description long enough to need more than 2 lines to show it, just for testing purposes."
+
+                    else -> "Description"
                 }
             )
 
@@ -244,6 +246,8 @@ class ListsCatalogFragment : Fragment() {
                 setActionLayout(ListRowView.ACTION_NONE)
                 isClickable = false
             }
+
+            if (withCustomContentDescription) contentDescription = "Custom content description for ListRowView"
 
             setBadge(withBadge, withBadgeNumeric)
         }

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/ListsCatalogFragment.kt
@@ -92,7 +92,6 @@ class ListsCatalogFragment : Fragment() {
                 withAction: Boolean = false,
                 withBadge: Boolean = false,
                 withBadgeNumeric: Int? = null,
-                withBadgeDescription: String? = null,
                 withAssetType: Int? = null,
                 withHeadline: Boolean = false,
                 withSubtitle: Boolean = false,
@@ -109,7 +108,6 @@ class ListsCatalogFragment : Fragment() {
                     withAction = withAction,
                     withBadge = withBadge,
                     withBadgeNumeric = withBadgeNumeric ?: 0,
-                    withBadgeDescription = withBadgeDescription,
                     withAsset = withAssetType != null,
                     withAssetType = withAssetType ?: TYPE_SMALL_ICON,
                     withInverseBackground = withInverseBackground,
@@ -129,14 +127,14 @@ class ListsCatalogFragment : Fragment() {
             return listOf(
                 configure(withTitleHeading = true),
                 configure(withAction = true),
-                configure(withAction = true, withBadge = true, withBadgeDescription = "You have unread messages"),
+                configure(withAction = true, withBadge = true),
                 configure(withAction = true, withBadgeNumeric = 1),
                 configure(withLongDescription = false, withTitleHeading = true),
                 configure(withLongDescription = false, withAction = true),
                 configure(withAssetType = TYPE_LARGE_ICON),
                 configure(withAssetType = TYPE_LARGE_ICON, withAction = true),
                 configure(withAssetType = TYPE_LARGE_ICON, withAction = true, withBadge = true),
-                configure(withAssetType = TYPE_LARGE_ICON, withAction = true, withBadgeNumeric = 5, withBadgeDescription = "5 new messages"),
+                configure(withAssetType = TYPE_LARGE_ICON, withAction = true, withBadgeNumeric = 5),
                 configure(withLongDescription = false, withAssetType = TYPE_LARGE_ICON),
                 configure(withLongDescription = false, withAssetType = TYPE_LARGE_ICON, withAction = true),
                 configure(withAssetType = TYPE_SMALL_ICON),
@@ -184,7 +182,6 @@ class ListsCatalogFragment : Fragment() {
             @TagStyle withHeadlineStyle: Int = TYPE_PROMO,
             withSubtitle: Boolean = false,
             withSubtitleMaxLines: Int? = null,
-            withBadgeDescription: String? = null,
             withInverseBackground: Boolean,
             withUrlIcon: String? = null,
             withErrorIcon: Drawable? = null,
@@ -248,7 +245,7 @@ class ListsCatalogFragment : Fragment() {
                 isClickable = false
             }
 
-            setBadge(withBadge, withBadgeDescription, withBadgeNumeric)
+            setBadge(withBadge, withBadgeNumeric)
         }
 
         private fun getAssetResource(withAsset: Boolean, @AssetType withAssetType: Int): Int? =
@@ -267,11 +264,11 @@ class ListsCatalogFragment : Fragment() {
                 null
             }
 
-        private fun ListRowView.setBadge(withBadge: Boolean, withBadgeDescription: String?, withBadgeNumeric: Int) {
+        private fun ListRowView.setBadge(withBadge: Boolean, withBadgeNumeric: Int) {
             when {
-                withBadge -> setBadge(true, withBadgeDescription)
-                withBadgeNumeric > 0 -> setNumericBadge(withBadgeNumeric, withBadgeDescription)
-                else -> setBadge(false, withBadgeDescription)
+                withBadge -> setBadge(true)
+                withBadgeNumeric > 0 -> setNumericBadge(withBadgeNumeric)
+                else -> setBadge(false)
             }
         }
     }

--- a/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
+++ b/library/src/main/java/com/telefonica/mistica/list/ListRowView.kt
@@ -180,6 +180,7 @@ open class ListRowView @JvmOverloads constructor(
     private var cachedDefaultBackgroundType: Int = BackgroundType.TYPE_NORMAL
 
     private var isViewInitialized = false
+    private var hasCustomContentDescription = false
 
     // Important! This map builds a sentence for a11y according to Mística order definition. Do not modify the order arbitrarily, check:
     // https://www.figma.com/design/Be8QB9onmHunKCCAkIBAVr/%F0%9F%94%B8-Lists-Specs?node-id=4615-10711&t=rHgrWciayIn0NP4V-4
@@ -315,17 +316,19 @@ open class ListRowView @JvmOverloads constructor(
             // Badge
             setBadgeInitialState(styledAttrs)
 
-            finishInit(styledAttrs)
+            styledAttrs.recycle()
         }
+        finishInit()
     }
 
-    private fun finishInit(styledAttrs: TypedArray) {
-        styledAttrs.recycle()
+    private fun finishInit() {
         isViewInitialized = true
-        if (contentDescription.isNullOrEmpty()) recalculateContentDescription()
+        recalculateContentDescription()
     }
 
     private fun recalculateContentDescription(newContentDescriptionInfo: ContentDescriptionInfo? = null) {
+        if (hasCustomContentDescription) return
+
         newContentDescriptionInfo?.let { newInfo ->
             contentDescriptionValues.find { it.key == newInfo.key }?.description = newInfo.description
         }
@@ -338,12 +341,23 @@ open class ListRowView @JvmOverloads constructor(
                 contentDescriptionBuilder.append("${it.description}. ")
             }
 
-            this@ListRowView.contentDescription = contentDescriptionBuilder
+            // Call super to update the content description without affecting the hasCustomContentDescription flag
+            super.setContentDescription(contentDescriptionBuilder)
         }
     }
 
     fun setAssetResource(@DrawableRes resource: Int? = null) {
         setAssetDrawable(resource?.let { AppCompatResources.getDrawable(context, it) })
+    }
+
+    override fun setContentDescription(contentDescription: CharSequence?) {
+        hasCustomContentDescription = true
+        super.setContentDescription(contentDescription)
+    }
+
+    fun resetContentDescription() {
+        hasCustomContentDescription = false
+        recalculateContentDescription()
     }
 
     fun setAssetUrl(

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -52,7 +52,6 @@ Implemented as a custom view, `com.telefonica.mistica.ListRowView` can be used i
 		<enum name="gone" value="0" />
 	</attr>
 	<attr name="listRowBadgeVisible" format="boolean" />
-	<attr name="listRowBadgeDescription" format="string" />
 	<attr name="onClick" format="string" />
 </declare-styleable>
 ```
@@ -123,3 +122,26 @@ configuration. It will thrown an IllegalStateException if you try to access this
 // Do not invoke this method
 listRowViewWithSwitch.getActionView()
 ```
+
+## Custom Content Description
+This component now supports configuring a **custom `contentDescription`**, which will override the internally managed default value. By default, the component automatically assigns and manages an accessible `contentDescription`.
+
+If you need to set a custom `contentDescription`, you can do so using the corresponding method. 
+To revert to the default behavior, you can use the new public method `resetContentDescription()`, which will remove the custom value and restore the component-managed `contentDescription`.
+
+> [!WARNING]
+> If the component uses a badge and you need to provide accessibility support for it, you must use a custom contentDescription as the component's default
+> behavior will ignore the badge.
+
+### Usage Example
+
+```kotlin
+// Set a custom contentDescription
+listRowViewWithSwitch.contentDescription = "Custom description for accessibility"
+
+// Restore the component's default managed contentDescription
+listRowViewWithSwitch.resetDescription()
+```
+
+> [!TIP]
+> Using a custom contentDescription can be useful for specific accessibility cases, but it's recommended to use the default value whenever possible to ensure the best user experience.

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -124,6 +124,9 @@ listRowViewWithSwitch.getActionView()
 ```
 
 ## Custom Content Description
+> [!NOTE]
+> Using a custom contentDescription can be useful for specific accessibility cases, but it's recommended to use the default value whenever possible to ensure the best user experience.
+
 This component now supports configuring a **custom `contentDescription`**, which will override the internally managed default value. By default, the component automatically assigns and manages an accessible `contentDescription`.
 
 If you need to set a custom `contentDescription`, you can do so by simply setting the view's standard `contentDescription` property, either in code or via XML.
@@ -143,6 +146,3 @@ listRowViewWithSwitch.contentDescription = "Custom description for accessibility
 // Restore the component's default managed contentDescription
 listRowViewWithSwitch.resetDescription()
 ```
-
-> [!NOTE]
-> Using a custom contentDescription can be useful for specific accessibility cases, but it's recommended to use the default value whenever possible to ensure the best user experience.

--- a/library/src/main/java/com/telefonica/mistica/list/README.md
+++ b/library/src/main/java/com/telefonica/mistica/list/README.md
@@ -126,10 +126,11 @@ listRowViewWithSwitch.getActionView()
 ## Custom Content Description
 This component now supports configuring a **custom `contentDescription`**, which will override the internally managed default value. By default, the component automatically assigns and manages an accessible `contentDescription`.
 
-If you need to set a custom `contentDescription`, you can do so using the corresponding method. 
-To revert to the default behavior, you can use the new public method `resetContentDescription()`, which will remove the custom value and restore the component-managed `contentDescription`.
+If you need to set a custom `contentDescription`, you can do so by simply setting the view's standard `contentDescription` property, either in code or via XML.
 
-> [!WARNING]
+To revert to the default behavior, you can use the new method `resetContentDescription()`, which will remove the custom value and restore the component-managed `contentDescription`.
+
+> [!CAUTION]
 > If the component uses a badge and you need to provide accessibility support for it, you must use a custom contentDescription as the component's default
 > behavior will ignore the badge.
 
@@ -143,5 +144,5 @@ listRowViewWithSwitch.contentDescription = "Custom description for accessibility
 listRowViewWithSwitch.resetDescription()
 ```
 
-> [!TIP]
+> [!NOTE]
 > Using a custom contentDescription can be useful for specific accessibility cases, but it's recommended to use the default value whenever possible to ensure the best user experience.

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -93,7 +93,6 @@
             <enum name="gone" value="0" />
         </attr>
         <attr name="listRowBadgeVisible" format="boolean" />
-        <attr name="listRowBadgeDescription" format="string" />
         <attr name="onClick" format="string" />
     </declare-styleable>
 

--- a/library/src/test/java/com/telefonica/mistica/list/ListRowViewTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/list/ListRowViewTest.kt
@@ -11,7 +11,6 @@ import com.telefonica.mistica.testutils.ScreenshotsTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test

--- a/library/src/test/java/com/telefonica/mistica/list/ListRowViewTest.kt
+++ b/library/src/test/java/com/telefonica/mistica/list/ListRowViewTest.kt
@@ -10,6 +10,8 @@ import com.telefonica.mistica.R
 import com.telefonica.mistica.testutils.ScreenshotsTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -71,5 +73,45 @@ internal class ListRowViewTest : ScreenshotsTest() {
         }
     }
 
+    @Test
+    fun `check ListRowView custom contentDescription overrides default contentDescription behavior`() {
+        rule.scenario.onActivity { activity ->
+            val listRowView = givenAnyListRowView(activity)
+            val defaultDescription = listRowView.contentDescription
+
+            listRowView.contentDescription = ANY_CUSTOM_DESCRIPTION
+
+            assertEquals(ANY_CUSTOM_DESCRIPTION, listRowView.contentDescription)
+            assertNotEquals(defaultDescription, listRowView.contentDescription)
+        }
+    }
+
+    @Test
+    fun `check ListRowView resetContentDescription reverts to default contentDescription behavior`() {
+        rule.scenario.onActivity { activity ->
+            val listRowView = givenAnyListRowView(activity)
+            val defaultDescription = listRowView.contentDescription?.toString()
+
+            listRowView.contentDescription = ANY_CUSTOM_DESCRIPTION
+            assertEquals(ANY_CUSTOM_DESCRIPTION, listRowView.contentDescription)
+
+            listRowView.resetContentDescription()
+
+            val actualDescriptionAfterReset = listRowView.contentDescription?.toString()
+
+            assertEquals(defaultDescription, actualDescriptionAfterReset)
+            assertNotEquals(ANY_CUSTOM_DESCRIPTION, actualDescriptionAfterReset)
+        }
+    }
+
+    private fun givenAnyListRowView(activity: DummyActivity) = ListRowView(activity).apply {
+        setTitle("Some title")
+        setSubtitle("Some subtitle")
+    }
+
     private fun ListRowView.hasTitleHeading() = this.findViewById<TextView>(R.id.row_title_text).isAccessibilityHeading
+
+    private companion object {
+        const val ANY_CUSTOM_DESCRIPTION = "Any custom description"
+    }
 }


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-15258](https://jira.tid.es/browse/ANDROID-15258)

### :goal_net: What's the goal?
ℹ️ **Only for XML implementation**. The Compose implementation will be added in this other task: https://jira.tid.es/browse/ANDROID-15075

- Allow to provide a custom label in informative rows to be read by screen readers in a single focus, instead reading all elements one by one.
- Hide always badges to Screen readers no matter if the list is informative or interactive

For more info, check out this Figma documentation: https://www.figma.com/design/Be8QB9onmHunKCCAkIBAVr/%F0%9F%94%B8-Lists-Specs?node-id=4615-10678&t=eRMRYwPaobn7VxjU-4

### :construction: How do we do it?
* Remove badgeDescription implementation.
* Managing the coexistence both contentDescription:
   * Default: handled by the component itself
   * Custom: managed by the implementation
* Create unitTests for ensure the proper behavior with the new contentDescription logic.
* Add readme to explain the users how to handle the new custom contentDescription

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
  ℹ️ Since iOS isn't currently handling this task, I'll add a comment to the iOS task to inform them about the Android implementation.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
https://github.com/user-attachments/assets/194cb411-d749-4dba-9db1-c939fd0a8853