### PR TITLE
Add HighLightCardButtonSettings.invalidatePaddings ANDROID-16601

### DIFF
--- a/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/card/highlightedcard/HighLightedCard.kt
@@ -219,7 +219,7 @@ private fun HighLightCardButton(
     modifier: Modifier,
     inverseDisplay: Boolean,
     buttonConfig: HighLightCardButtonSettings,
-    onButtonClick: () -> Unit = {}
+    onButtonClick: () -> Unit = {},
 ){
     val buttonStyle = buttonConfig.getButtonStyle(inverseDisplay)
 
@@ -228,6 +228,7 @@ private fun HighLightCardButton(
             modifier = modifier,
             text = buttonConfig.buttonText,
             buttonStyle = buttonStyle,
+            invalidatePaddings = buttonConfig.invalidatePaddings,
             onClickListener = onButtonClick
         )
     }else{
@@ -243,7 +244,8 @@ enum class HighLightCardImageConfig {
 
 data class HighLightCardButtonSettings(
     val buttonText: String = "",
-    val buttonStyle: ButtonStyle? = null
+    val buttonStyle: ButtonStyle? = null,
+    val invalidatePaddings: Boolean = false,
 ){
     fun getButtonStyle(inverse: Boolean): ButtonStyle? {
         return buttonStyle?.let { style ->


### PR DESCRIPTION
### :goal_net: What's the goal?
Add the possibility to invalidate the button paddings on HighlightedCard.

### :construction: How do we do it?
- Add the possibility to invalidate the button paddings on HightlithtedCard

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
- [ ] 🖼️ Screenshots/Videos

Tested by publishing the mistica lib locally:

| Before        | After           |
| ------------- |-------------|
| <img src="https://github.com/user-attachments/assets/0aeb3927-4914-4029-addd-9419acdd9818" alt="Before" width="200"/>      | <img src="https://github.com/user-attachments/assets/8a035ab0-fda1-4bf2-a7ba-1c87ac37e932" alt="After" width="200"/> |

- [x] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
