### PR TITLE
 Callout custom dismiss content description ANDROID-16865

### DIFF
--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
@@ -18,6 +18,8 @@ import com.telefonica.mistica.input.DropDownInput
 import com.telefonica.mistica.input.TextInput
 import com.telefonica.mistica.util.getMisticaThemeDrawable
 import com.telefonica.mistica.util.getThemeColor
+import com.telefonica.mistica.util.hide
+import com.telefonica.mistica.util.show
 
 class CalloutsCatalogFragment : Fragment() {
 
@@ -86,7 +88,10 @@ class CalloutsCatalogFragment : Fragment() {
                 }
             }
 
-            setDismissable(view.findViewById<CheckBoxInput>(R.id.dismiss_input).isChecked())
+            val dismissInput = view.findViewById<CheckBoxInput>(R.id.dismiss_input)
+            setDismissable(dismissInput.isChecked())
+            setDismissContentDescription(view.findViewById<TextInput>(R.id.dismiss_content_description_input).text.toString())
+
             val inverse = view.findViewById<CheckBoxInput>(R.id.inverse_input).isChecked()
             setInverse(inverse)
             with(view.findViewById<View>(R.id.callout_preview_container)) {
@@ -109,6 +114,14 @@ class CalloutsCatalogFragment : Fragment() {
             setSecondaryButtonOnClick { showToast(context, "Secondary button clicked!") }
             setLinkButtonOnClick { showToast(context, "Link button clicked!") }
             setOnDismiss { showToast(context, "Callout dismissed! Update to show again") }
+            dismissInput.setOnCheckedChangeListener { _, isChecked ->
+                val input = view.findViewById<TextInput>(R.id.dismiss_content_description_input)
+                if (isChecked) {
+                    input.show()
+                } else {
+                    input.hide()
+                }
+            }
         }
     }
 

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/classic/components/CalloutsCatalogFragment.kt
@@ -39,7 +39,7 @@ class CalloutsCatalogFragment : Fragment() {
                 DropDownInput.Adapter(
                     view.context,
                     R.layout.dropdown_menu_popup_item,
-                    CalloutButtonsConfig.values().map { it.name },
+                    CalloutButtonsConfig.entries.map { it.name },
                 )
             )
             setText(CalloutButtonsConfig.PRIMARY.name)
@@ -49,7 +49,7 @@ class CalloutsCatalogFragment : Fragment() {
                 DropDownInput.Adapter(
                     view.context,
                     R.layout.dropdown_menu_popup_item,
-                    CalloutViewImageConfig.values().map { it.name },
+                    CalloutViewImageConfig.entries.map { it.name },
                 )
             )
             setText(CalloutViewImageConfig.ICON.name)

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
@@ -55,9 +55,9 @@ fun Callouts() {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(40.dp, 8.dp),
-            items = CalloutViewImageConfig.values().map { it.name },
-            currentItemIndex = CalloutViewImageConfig.values().indexOf(iconType),
-            onItemSelected = { index -> iconType = CalloutViewImageConfig.values()[index] },
+            items = CalloutViewImageConfig.entries.map { it.name },
+            currentItemIndex = CalloutViewImageConfig.entries.indexOf(iconType),
+            onItemSelected = { index -> iconType = CalloutViewImageConfig.entries.toTypedArray()[index] },
             hint = "Icon type",
         )
 

--- a/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
+++ b/catalog/src/main/java/com/telefonica/mistica/catalog/ui/compose/components/Callouts.kt
@@ -41,6 +41,7 @@ fun Callouts() {
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         var inverse by remember { mutableStateOf(false) }
+        var dismissContentDescription: String by remember { mutableStateOf("") }
         Row(
             modifier = Modifier.padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -67,6 +68,17 @@ fun Callouts() {
         ) {
             Checkbox(checked = dismissable, onCheckedChange = { dismissable = !dismissable })
             Text("Is dismissable")
+        }
+
+        if (dismissable) {
+           OutlinedTextField(
+               modifier = Modifier
+                   .fillMaxWidth()
+                   .padding(horizontal = 16.dp),
+               value = dismissContentDescription,
+               label = {Text("Custom dismiss content description")},
+               onValueChange = { dismissContentDescription = it },
+           )
         }
 
         var title by remember { mutableStateOf("Callout sample title") }
@@ -159,6 +171,7 @@ fun Callouts() {
                         CalloutViewImageConfig.SQUARE_IMAGE -> R.drawable.card_image_sample
                     },
                     dismissable = dismissable,
+                    dismissContentDescription = dismissContentDescription,
                     inverse = inverse,
                     onDismiss = { isShown = false },
                     primaryButtonText = primaryButtonText.takeIf { it.isNotBlank() },

--- a/catalog/src/main/res/layout/screen_callouts_catalog.xml
+++ b/catalog/src/main/res/layout/screen_callouts_catalog.xml
@@ -37,6 +37,16 @@
 				app:inputCheckText="Is Dismissable"
 				/>
 
+		<com.telefonica.mistica.input.TextInput
+				android:id="@+id/dismiss_content_description_input"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_margin="8dp"
+				app:inputHint="Custom dismiss content description"
+				app:inputText=""
+				app:inputType="text"
+				/>
+
 		<com.telefonica.mistica.input.DropDownInput
 				android:id="@+id/image_config_dropdown"
 				android:layout_width="match_parent"

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -169,6 +169,9 @@ class CalloutView @JvmOverloads constructor(
                 ?.let { setAsset(it) }
 
             dismissable = styledAttrs.getBoolean(R.styleable.CalloutView_calloutDismissable, false)
+            styledAttrs.getString(R.styleable.CalloutView_calloutDismissContentDescription)?.let {
+                setDismissContentDescription(it)
+            }
             inverse = styledAttrs.getBoolean(R.styleable.CalloutView_calloutInverse, false)
 
             styledAttrs.recycle()
@@ -183,6 +186,14 @@ class CalloutView @JvmOverloads constructor(
 
     fun setDismissable(dismissable: Boolean) {
         closeButton.visibility = if (dismissable) VISIBLE else GONE
+    }
+
+    fun setDismissContentDescription(contentDescription: String) {
+        if (contentDescription.isEmpty()) {
+            closeButton.contentDescription = context.getString(R.string.close_button_content_description)
+        } else {
+            closeButton.contentDescription = contentDescription
+        }
     }
 
     fun setInverse(inverse: Boolean) {

--- a/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
+++ b/library/src/main/java/com/telefonica/mistica/callout/CalloutView.kt
@@ -409,7 +409,7 @@ enum class CalloutViewImageConfig(val value: Int) {
 
     companion object {
         fun getConfigByValue(item: Int): CalloutViewImageConfig {
-            return values().firstOrNull { it.value == item } ?: NONE
+            return CalloutViewImageConfig.entries.firstOrNull { it.value == item } ?: NONE
         }
     }
 }

--- a/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
+++ b/library/src/main/java/com/telefonica/mistica/compose/callout/Callout.kt
@@ -41,6 +41,7 @@ fun Callout(
     @DrawableRes iconRes: Int? = null,
     imageConfig: CalloutViewImageConfig = CalloutViewImageConfig.NONE,
     dismissable: Boolean,
+    dismissContentDescription: String? = null,
     onDismiss: (() -> Unit)? = null,
     inverse: Boolean,
     primaryButtonText: String? = null,
@@ -172,7 +173,11 @@ fun Callout(
                         .semantics { traversalIndex = 1f }
                         .testTag(CalloutTestTag.CLOSE_BUTTON),
                     painter = painterResource(id = R.drawable.icn_cross),
-                    contentDescription = stringResource(id = R.string.close_button_content_description)
+                    contentDescription = if (dismissContentDescription.isNullOrEmpty()) {
+                        stringResource(id = R.string.close_button_content_description)
+                    } else {
+                        dismissContentDescription
+                    }
                 )
             }
         }

--- a/library/src/main/res/values/attrs_components.xml
+++ b/library/src/main/res/values/attrs_components.xml
@@ -312,6 +312,7 @@
         <attr name="calloutLinkButtonText" format="string" />
         <attr name="calloutLinkButtonOnClick" format="string" />
         <attr name="calloutDismissable" format="boolean"/>
+        <attr name="calloutDismissContentDescription" format="string"/>
         <attr name="calloutInverse" format="boolean"/>
     </declare-styleable>
 


### PR DESCRIPTION
### :goal_net: What's the goal?
The callout content description is fixed and we can't use a custom text for that button in our apps.
This task is in order to provide accessibility texts from the apps instead of relying on a translation in mistica.

### :construction: How do we do it?
_Provide a description of the implementation. A list of steps would be ideal._
* _Step 1_
* _Step 2_
* _Step 3_

### ☑️ Checks
- [x] I updated the documentation, including readmes and wikis. If this is a breaking change, tag the PR with "Breaking Change" label and remember to include breaking change migration guide in release notes where this version is released.
- [x] Tested with dark mode.
- [x] Tested with API 24.
- [x] Sync done with iOS team for this feature to ensure alignment, if applies.
- [x] Accessibility considerations.

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] 🖼️ Screenshots/Videos
- [ ] Mistica App QR or download link
- [ ] Reviewed by Mistica design team
- [ ] ...

### 🤖 Copilot review
@copilot Please review this PR for potential breaking changes in the public API **within the `library` module only**.

Focus on:
- Enum value removals.
- Removed or renamed public classes, interfaces, enums, methods, properties, or constants.
- Changes in method signatures (parameters, return types).
- Visibility changes (e.g., public → protected/private/package-private).
- Removal of public annotations or change of annotation values (e.g., @JvmOverloads, @Deprecated).
- Behavioral changes that keep the signature but alter the contract (e.g., new exceptions thrown, different return values for same input).

Review all modified files in the `library` module and comment on each breaking change.
